### PR TITLE
레디스 모니터링 환경 구축

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,16 @@ services:
     ports:
       - "6379:6379"
 
+  redis-exporter:
+    image: oliver006/redis_exporter
+    container_name: redis-exporter
+    ports:
+      - "9121:9121"
+    environment:
+      REDIS_ADDR: "redis:6379"
+    depends_on:
+      - redis
+
   solid-connect-server:
     build:
       context: .


### PR DESCRIPTION
## 관련 이슈

- resolves: [모니터링 환경 구축 #63](https://github.com/solid-connection/solid-connect-server/issues/63)

## 작업 내용

- redis-exporter 추가하였습니다.

해당 exporter를 활용하여 redis metric을 prometheus에서 받아와서 grafana로 시각화 할 예정입니다.

<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

## 특이 사항

docker compose가 실행되는 서버에서 9121 포트를 열어줘야합니다.