### PR TITLE
조회수 갱신 시점마다 updated_at 필드가 수정되는 오류 해결

### DIFF
--- a/src/main/java/com/example/solidconnection/post/domain/Post.java
+++ b/src/main/java/com/example/solidconnection/post/domain/Post.java
@@ -97,9 +97,4 @@ public class Post extends BaseEntity {
         this.content = postUpdateRequest.content();
         this.category = PostCategory.valueOf(postUpdateRequest.postCategory());
     }
-
-    public void increaseViewCount(Long updateViewCount) {
-        this.viewCount += updateViewCount;
-    }
-
 }

--- a/src/main/java/com/example/solidconnection/post/repository/PostRepository.java
+++ b/src/main/java/com/example/solidconnection/post/repository/PostRepository.java
@@ -38,4 +38,9 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     @Query("UPDATE Post p SET p.likeCount = p.likeCount + 1 " +
             "WHERE p.id = :postId")
     void increaseLikeCount(@Param("postId") Long postId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE Post p SET p.viewCount = p.viewCount + :count " +
+            "WHERE p.id = :postId")
+    void increaseViewCount(@Param("postId") Long postId, @Param("count") Long count);
 }

--- a/src/main/java/com/example/solidconnection/service/UpdateViewCountService.java
+++ b/src/main/java/com/example/solidconnection/service/UpdateViewCountService.java
@@ -26,7 +26,7 @@ public class UpdateViewCountService {
         log.info("updateViewCount Processing key: {} in thread: {}", key, Thread.currentThread().getName());
         Long postId = redisUtils.getPostIdFromPostViewCountRedisKey(key);
         Post post = postRepository.getById(postId);
-        post.increaseViewCount(redisService.getAndDelete(key));
+        postRepository.increaseViewCount(postId, redisService.getAndDelete(key));
         log.info("updateViewCount Updated post id: {} with view count from key: {}", postId, key);
     }
 }


### PR DESCRIPTION
## 관련 이슈

- resolves: [조회수 갱신 시점마다 updated_at 필드가 수정되는 오류 해결 #90](https://github.com/solid-connection/solid-connect-server/issues/90)

## 작업 내용

기존에는 jpa 변경감지를 통해서 조회수가 갱신되어 조회수 갱신 시점마다 updated_at 필드가 수정되었습니다.
해당 부분을 직접 update query를 수행하도록 하여 updated_at 필드가 수정되지 않도록 변경하였습니다.

<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
