### PR TITLE
feat: 내 정보 조회 API에 email 필드 추가

### DIFF
--- a/src/main/java/com/example/solidconnection/auth/controller/AuthController.java
+++ b/src/main/java/com/example/solidconnection/auth/controller/AuthController.java
@@ -31,15 +31,13 @@ public class AuthController implements AuthControllerSwagger {
     @PostMapping("/kakao")
     public ResponseEntity<KakaoOauthResponse> processKakaoOauth(@RequestBody KakaoCodeRequest kakaoCodeRequest) {
         KakaoOauthResponse kakaoOauthResponse = signInService.signIn(kakaoCodeRequest);
-        return ResponseEntity
-                .ok(kakaoOauthResponse);
+        return ResponseEntity.ok(kakaoOauthResponse);
     }
 
     @PostMapping("/sign-up")
     public ResponseEntity<SignUpResponse> signUp(@Valid @RequestBody SignUpRequest signUpRequest) {
         SignUpResponse signUpResponseDto = signUpService.signUp(signUpRequest);
-        return ResponseEntity
-                .ok(signUpResponseDto);
+        return ResponseEntity.ok(signUpResponseDto);
     }
 
     @PostMapping("/sign-out")
@@ -57,7 +55,6 @@ public class AuthController implements AuthControllerSwagger {
     @PostMapping("/reissue")
     public ResponseEntity<ReissueResponse> reissueToken(Principal principal) {
         ReissueResponse reissueResponse = authService.reissue(principal.getName());
-        return ResponseEntity
-                .ok(reissueResponse);
+        return ResponseEntity.ok(reissueResponse);
     }
 }

--- a/src/main/java/com/example/solidconnection/siteuser/dto/MyPageResponse.java
+++ b/src/main/java/com/example/solidconnection/siteuser/dto/MyPageResponse.java
@@ -19,6 +19,9 @@ public record MyPageResponse(
         @Schema(description = "생년월일", example = "1990-01-01")
         String birth,
 
+        @Schema(description = "이메일", example = "example@solid-conenct.net")
+        String email,
+
         @Schema(description = "좋아요 누른 게시물 수", example = "0")
         int likedPostCount,
 
@@ -34,6 +37,7 @@ public record MyPageResponse(
                 siteUser.getProfileImageUrl(),
                 siteUser.getRole(),
                 siteUser.getBirth(),
+                siteUser.getEmail(),
                 0, // TODO: 커뮤니티 기능 생기면 업데이트 필요
                 0, // TODO: 멘토 기능 생기면 업데이트 필요
                 likedUniversityCount

--- a/src/test/java/com/example/solidconnection/e2e/MyPageTest.java
+++ b/src/test/java/com/example/solidconnection/e2e/MyPageTest.java
@@ -52,6 +52,7 @@ class MyPageTest extends BaseEndToEndTest {
         assertAll("불러온 마이 페이지 정보가 DB의 정보와 일치한다.",
                 () -> assertThat(myPageResponse.nickname()).isEqualTo(savedSiteUser.getNickname()),
                 () -> assertThat(myPageResponse.birth()).isEqualTo(savedSiteUser.getBirth()),
-                () -> assertThat(myPageResponse.profileImageUrl()).isEqualTo(savedSiteUser.getProfileImageUrl()));
+                () -> assertThat(myPageResponse.profileImageUrl()).isEqualTo(savedSiteUser.getProfileImageUrl()),
+                () -> assertThat(myPageResponse.email()).isEqualTo(savedSiteUser.getEmail()));
     }
 }


### PR DESCRIPTION
## 관련 이슈

- resolves: #100 

## 작업 내용

내 정보 API에서 email 정보를 확인할 수 있게 email 필드를 추가했습니다.

## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->

혹시 개발 진행하실때 auth 필요한 부분은 어떻게 진행하시나요? Kakao OAuth를 기반으로 하니 로컬 개발 환경에서는 토큰 얻어서 postman으로 테스트해보기는 어려워서 결국 test case만으로 검증하게 되네요...

개인적으로는 아래 글과 같이 테이블 구성해서 리팩토링 하고, 일반 email&PW 로그인과 다른 OAuth 로그인들도 구현해보고 싶네요!
https://rastalion.dev/%ED%9A%8C%EC%9B%90-%EA%B0%80%EC%9E%85-%EB%B0%8F-%EB%A1%9C%EA%B7%B8%EC%9D%B8%EC%9D%84-%EC%9C%84%ED%95%9C-%ED%85%8C%EC%9D%B4%EB%B8%94-%EC%84%A4%EA%B3%84/
