### PR TITLE
fix: 전체 테스트 코드 통과되도록 수정

### DIFF
--- a/src/main/java/com/example/solidconnection/application/domain/Application.java
+++ b/src/main/java/com/example/solidconnection/application/domain/Application.java
@@ -52,8 +52,8 @@ public class Application {
     @Column(length = 50, nullable = false)
     private String term;
 
-    @Column(columnDefinition = "TINYINT(1) NOT NULL DEFAULT 0")
-    private Boolean isDelete;
+    @Column
+    private boolean isDelete = false;
 
     @ManyToOne(fetch = FetchType.LAZY)
     private UniversityInfoForApply firstChoiceUniversity;

--- a/src/test/java/com/example/solidconnection/e2e/SignUpTest.java
+++ b/src/test/java/com/example/solidconnection/e2e/SignUpTest.java
@@ -76,7 +76,7 @@ class SignUpTest extends BaseEndToEndTest {
         List<String> interestedRegionNames = List.of("유럽");
         List<String> interestedCountryNames = List.of("프랑스", "독일");
         SignUpRequest signUpRequest = new SignUpRequest(generatedKakaoToken, interestedRegionNames, interestedCountryNames,
-                PreparationStatus.CONSIDERING, "nickname", Gender.FEMALE, "profile", "2000-01-01");
+                PreparationStatus.CONSIDERING, "profile", Gender.FEMALE, "nickname", "2000-01-01");
         SignUpResponse response = RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
                 .body(signUpRequest)
@@ -127,7 +127,7 @@ class SignUpTest extends BaseEndToEndTest {
 
         // request - body 생성 및 요청
         SignUpRequest signUpRequest = new SignUpRequest(generatedKakaoToken, null, null,
-                PreparationStatus.CONSIDERING, alreadyExistNickname, Gender.FEMALE, "profile", "2000-01-01");
+                PreparationStatus.CONSIDERING, "profile", Gender.FEMALE, alreadyExistNickname, "2000-01-01");
         ErrorResponse errorResponse = RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
                 .body(signUpRequest)
@@ -153,7 +153,7 @@ class SignUpTest extends BaseEndToEndTest {
 
         // request - body 생성 및 요청
         SignUpRequest signUpRequest = new SignUpRequest(generatedKakaoToken, null, null,
-                PreparationStatus.CONSIDERING, "nickname0", Gender.FEMALE, "profile", "2000-01-01");
+                PreparationStatus.CONSIDERING, "profile", Gender.FEMALE, "nickname0", "2000-01-01");
         ErrorResponse errorResponse = RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
                 .body(signUpRequest)
@@ -169,7 +169,7 @@ class SignUpTest extends BaseEndToEndTest {
     @Test
     void 유효하지_않은_카카오_토큰으로_회원가입을_하면_예외를_응답한다() {
         SignUpRequest signUpRequest = new SignUpRequest("invalid", null, null,
-                PreparationStatus.CONSIDERING, "nickname", Gender.FEMALE, "profile", "2000-01-01");
+                PreparationStatus.CONSIDERING, "profile", Gender.FEMALE, "nickname", "2000-01-01");
         ErrorResponse errorResponse = RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
                 .body(signUpRequest)

--- a/src/test/java/com/example/solidconnection/unit/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/example/solidconnection/unit/repository/CommentRepositoryTest.java
@@ -40,8 +40,6 @@ class CommentRepositoryTest {
     @Autowired
     private SiteUserRepository siteUserRepository;
     @Autowired
-    private EntityManager entityManager;
-    @Autowired
     private CommentRepository commentRepository;
 
     private Board board;
@@ -65,9 +63,6 @@ class CommentRepositoryTest {
         childComment = createChildComment();
         commentRepository.save(parentComment);
         commentRepository.save(childComment);
-
-        entityManager.flush();
-        entityManager.clear();
     }
 
     private Board createBoard() {

--- a/src/test/java/com/example/solidconnection/unit/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/example/solidconnection/unit/repository/CommentRepositoryTest.java
@@ -13,7 +13,6 @@ import com.example.solidconnection.type.Gender;
 import com.example.solidconnection.type.PostCategory;
 import com.example.solidconnection.type.PreparationStatus;
 import com.example.solidconnection.type.Role;
-import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -31,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 
 @SpringBootTest
-@ActiveProfiles("local")
+@ActiveProfiles("dev")
 @DisplayName("댓글 레포지토리 테스트")
 class CommentRepositoryTest {
     @Autowired


### PR DESCRIPTION
## 관련 이슈

- related to: #111 

## 작업 내용

<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

실패하는 테스트 코드들을 수정했습니다.
1. TINYINT(1)에 대해서 MySQL과 H2의 환경이 달라 문제가 발생했었습니다.
문제 해결 과정을 디스커션에 정리해두었습니다 https://github.com/solid-connection/solid-connect-server/discussions/117
2. `CommentRepository.findCommentTreeByPostId()`의 단위 테스트 코드가 profile 변경에 의해 깨졌습니다.
H2은 MySQL과 달리 RECURSIVE 문이 동작하지 않으므로 MySQL을 사용하기 위해서 local 로 profile을 지정해놨는데,
이 profile 이름을 dev 로 바꿈에 따라서 깨졌던 것입니다.
ActiveProfile을 dev 로 바꿔 테스트 통과시켰습니다.
(하지만 이렇게 profile이나 db의 종류에 의존하는 테스트코드가 베스트라고 생각하진 않습니다..😔)

## 특이 사항

위 두가지 문제 모두, test 환경에서는 H2을, 개발 환경에서는 MySQL을 사용하기에 생기는 문제입니다.
이를 해결하기 위해서 따로 이슈를 팠으며, https://github.com/solid-connection/solid-connect-server/issues/119
이 PR에서는 우선 테스트 코드가 다 통과하게 하는 것이 목적이었기에 여기까지 하고 PR 올립니다!



<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
