### PR TITLE
feat: 단위 테스트 코드 추가

### DIFF
--- a/src/test/java/com/example/solidconnection/unit/application/service/ApplicationServiceTest.java
+++ b/src/test/java/com/example/solidconnection/unit/application/service/ApplicationServiceTest.java
@@ -1,4 +1,4 @@
-package com.example.solidconnection.unit.service;
+package com.example.solidconnection.unit.application.service;
 
 import com.example.solidconnection.application.domain.Application;
 import com.example.solidconnection.application.domain.Gpa;

--- a/src/test/java/com/example/solidconnection/unit/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/example/solidconnection/unit/auth/service/AuthServiceTest.java
@@ -1,0 +1,164 @@
+package com.example.solidconnection.unit.auth.service;
+
+import com.example.solidconnection.auth.dto.ReissueResponse;
+import com.example.solidconnection.auth.service.AuthService;
+import com.example.solidconnection.config.token.TokenService;
+import com.example.solidconnection.config.token.TokenType;
+import com.example.solidconnection.custom.exception.CustomException;
+import com.example.solidconnection.custom.exception.ErrorCode;
+import com.example.solidconnection.siteuser.domain.SiteUser;
+import com.example.solidconnection.siteuser.repository.SiteUserRepository;
+import com.example.solidconnection.type.Gender;
+import com.example.solidconnection.type.PreparationStatus;
+import com.example.solidconnection.type.Role;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.time.LocalDate;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("인증 서비스 테스트")
+class AuthServiceTest {
+
+    @InjectMocks
+    private AuthService authService;
+
+    @Mock
+    private TokenService tokenService;
+
+    @Mock
+    private SiteUserRepository siteUserRepository;
+
+    @Mock
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    private static final String TEST_ACCESS_TOKEN = "testAccessToken";
+    private static final String TEST_REFRESH_TOKEN = "testRefreshToken";
+    private static final String SIGN_OUT_VALUE = "signOut";
+
+    private SiteUser testUser;
+
+    @BeforeEach
+    void setUp() {
+        testUser = createTestUser();
+    }
+
+    @Test
+    @DisplayName("로그아웃_요청시_리프레시_토큰을_무효화한다()")
+    void shouldInvalidateRefreshTokenWhenSignOut() {
+        // given
+        String refreshTokenKey = TokenType.REFRESH.addTokenPrefixToSubject(testUser.getEmail());
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+
+        // when
+        authService.signOut(testUser.getEmail());
+
+        // then & verify
+        verify(valueOperations).set(
+                eq(refreshTokenKey),
+                eq(SIGN_OUT_VALUE),
+                eq(604800000L),
+                eq(TimeUnit.MILLISECONDS)
+        );
+    }
+
+
+    @Test
+    @DisplayName("회원탈퇴_요청시_탈퇴일자를_설정한다()")
+    void shouldSetQuitedAtWhenUserQuits() {
+        // given
+        when(siteUserRepository.getByEmail(testUser.getEmail())).thenReturn(testUser);
+
+        // when
+        authService.quit(testUser.getEmail());
+
+        // then
+        assertThat(testUser.getQuitedAt()).isNotNull();
+        assertThat(testUser.getQuitedAt()).isEqualTo(LocalDate.now().plusDays(1));
+
+        // verify
+        verify(siteUserRepository).getByEmail(testUser.getEmail());
+    }
+
+    @Test
+    @DisplayName("존재하지_않는_이메일로_회원탈퇴_요청시_예외를_반환한다()")
+    void shouldThrowExceptionWhenQuitWithNonExistentEmail() {
+        // given
+        when(siteUserRepository.getByEmail(testUser.getEmail()))
+                .thenThrow(new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> authService.quit(testUser.getEmail()));
+        assertThat(exception.getCode()).isEqualTo(ErrorCode.USER_NOT_FOUND.getCode());
+
+        // verify
+        verify(siteUserRepository).getByEmail(testUser.getEmail());
+    }
+
+    @Test
+    @DisplayName("유효한_리프레시_토큰으로_재발급_요청시_새로운_액세스_토큰을_반환한다()")
+    void shouldReturnNewAccessTokenWhenRefreshTokenValid() {
+        // given
+        String refreshTokenKey = TokenType.REFRESH.addTokenPrefixToSubject(testUser.getEmail());
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(valueOperations.get(refreshTokenKey)).thenReturn(TEST_REFRESH_TOKEN);
+        when(tokenService.generateToken(testUser.getEmail(), TokenType.ACCESS)).thenReturn(TEST_ACCESS_TOKEN);
+
+        // when
+        ReissueResponse response = authService.reissue(testUser.getEmail());
+
+        // then
+        assertThat(response.accessToken()).isEqualTo(TEST_ACCESS_TOKEN);
+
+        // verify
+        verify(valueOperations).get(refreshTokenKey);
+        verify(tokenService).generateToken(testUser.getEmail(), TokenType.ACCESS);
+        verify(tokenService).saveToken(TEST_ACCESS_TOKEN, TokenType.ACCESS);
+    }
+
+    @Test
+    @DisplayName("만료된_리프레시_토큰으로_재발급_요청시_예외를_반환한다()")
+    void shouldThrowExceptionWhenRefreshTokenExpired() {
+        // given
+        String refreshTokenKey = TokenType.REFRESH.addTokenPrefixToSubject(testUser.getEmail());
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(valueOperations.get(refreshTokenKey)).thenReturn(null);
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> authService.reissue(testUser.getEmail()));
+        assertThat(exception.getCode()).isEqualTo(ErrorCode.REFRESH_TOKEN_EXPIRED.getCode());
+
+        // verify
+        verify(valueOperations).get(refreshTokenKey);
+        verify(tokenService, never()).generateToken(any(), any());
+    }
+
+    private SiteUser createTestUser() {
+        return new SiteUser(
+                "test@example.com",
+                "nickname",
+                "profileImageUrl",
+                "1999-10-21",
+                PreparationStatus.CONSIDERING,
+                Role.MENTEE,
+                Gender.MALE
+        );
+    }
+}

--- a/src/test/java/com/example/solidconnection/unit/auth/service/SignInServiceTest.java
+++ b/src/test/java/com/example/solidconnection/unit/auth/service/SignInServiceTest.java
@@ -1,0 +1,211 @@
+package com.example.solidconnection.unit.auth.service;
+
+import com.example.solidconnection.auth.client.KakaoOAuthClient;
+import com.example.solidconnection.auth.dto.SignInResponse;
+import com.example.solidconnection.auth.dto.kakao.FirstAccessResponse;
+import com.example.solidconnection.auth.dto.kakao.KakaoCodeRequest;
+import com.example.solidconnection.auth.dto.kakao.KakaoOauthResponse;
+import com.example.solidconnection.auth.dto.kakao.KakaoUserInfoDto;
+import com.example.solidconnection.auth.service.SignInService;
+import com.example.solidconnection.config.token.TokenService;
+import com.example.solidconnection.config.token.TokenType;
+import com.example.solidconnection.custom.exception.CustomException;
+import com.example.solidconnection.custom.exception.ErrorCode;
+import com.example.solidconnection.siteuser.domain.SiteUser;
+import com.example.solidconnection.siteuser.repository.SiteUserRepository;
+import com.example.solidconnection.type.Gender;
+import com.example.solidconnection.type.PreparationStatus;
+import com.example.solidconnection.type.Role;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("카카오 로그인 서비스 테스트")
+class SignInServiceTest {
+
+    @InjectMocks
+    private SignInService signInService;
+
+    @Mock
+    private SiteUserRepository siteUserRepository;
+
+    @Mock
+    private TokenService tokenService;
+
+    @Mock
+    private KakaoOAuthClient kakaoOAuthClient;
+
+    private static final String TEST_ACCESS_TOKEN = "testAccessToken";
+    private static final String TEST_REFRESH_TOKEN = "testRefreshToken";
+    private static final String TEST_KAKAO_OAUTH_TOKEN = "testKakaoOauthToken";
+    private static final String VALID_CODE = "validCode";
+    private static final String INVALID_CODE = "invalidCode";
+
+    private SiteUser testUser;
+    private KakaoUserInfoDto testKakaoUserInfo;
+    private KakaoCodeRequest validKakaoCodeRequest;
+
+    @BeforeEach
+    void setUp() {
+        testUser = createTestUser();
+        testKakaoUserInfo = createTestKakaoUserInfoDto();
+        validKakaoCodeRequest = new KakaoCodeRequest(VALID_CODE);
+    }
+
+    @Test
+    @DisplayName("기존_회원이_로그인하면_로그인_정보를_반환한다()")
+    void shouldReturnSignInInfoWhenUserAlreadyRegistered() {
+        // given
+        when(kakaoOAuthClient.processOauth(VALID_CODE)).thenReturn(testKakaoUserInfo);
+        when(siteUserRepository.existsByEmail(testUser.getEmail())).thenReturn(true);
+        when(siteUserRepository.getByEmail(testUser.getEmail())).thenReturn(testUser);
+        when(tokenService.generateToken(testUser.getEmail(), TokenType.ACCESS)).thenReturn(TEST_ACCESS_TOKEN);
+        when(tokenService.generateToken(testUser.getEmail(), TokenType.REFRESH)).thenReturn(TEST_REFRESH_TOKEN);
+
+        // when
+        KakaoOauthResponse response = signInService.signIn(validKakaoCodeRequest);
+
+        // then
+        assertThat(response).isInstanceOf(SignInResponse.class);
+        SignInResponse signInResponse = (SignInResponse) response;
+        assertThat(signInResponse.accessToken()).isEqualTo(TEST_ACCESS_TOKEN);
+        assertThat(signInResponse.refreshToken()).isEqualTo(TEST_REFRESH_TOKEN);
+        assertThat(signInResponse.isRegistered()).isTrue();
+
+        // verify
+        verify(kakaoOAuthClient).processOauth(VALID_CODE);
+        verify(siteUserRepository).existsByEmail(testUser.getEmail());
+        verify(siteUserRepository).getByEmail(testUser.getEmail());
+        verify(tokenService).generateToken(testUser.getEmail(), TokenType.ACCESS);
+        verify(tokenService).generateToken(testUser.getEmail(), TokenType.REFRESH);
+        verify(tokenService).saveToken(TEST_REFRESH_TOKEN, TokenType.REFRESH);
+    }
+
+    @Test
+    @DisplayName("탈퇴한_회원이_로그인하면_탈퇴일자를_초기화하고_로그인_정보를_반환한다()")
+    void shouldResetQuitedAtAndReturnSignInInfoWhenQuitedUserSignsIn() {
+        // given
+        testUser.setQuitedAt(LocalDate.now().minusDays(1));
+
+        when(kakaoOAuthClient.processOauth(VALID_CODE)).thenReturn(testKakaoUserInfo);
+        when(siteUserRepository.existsByEmail(testUser.getEmail())).thenReturn(true);
+        when(siteUserRepository.getByEmail(testUser.getEmail())).thenReturn(testUser);
+        when(tokenService.generateToken(testUser.getEmail(), TokenType.ACCESS)).thenReturn(TEST_ACCESS_TOKEN);
+        when(tokenService.generateToken(testUser.getEmail(), TokenType.REFRESH)).thenReturn(TEST_REFRESH_TOKEN);
+
+        // when
+        KakaoOauthResponse response = signInService.signIn(validKakaoCodeRequest);
+
+        // then
+        assertThat(response).isInstanceOf(SignInResponse.class);
+        assertThat(testUser.getQuitedAt()).isNull();
+
+        // verify
+        verify(siteUserRepository).getByEmail(testUser.getEmail());
+    }
+
+    @Test
+    @DisplayName("신규_회원이_로그인하면_회원가입_정보를_반환한다()")
+    void shouldReturnSignUpInfoWhenUserNotRegistered() {
+        // given
+        when(kakaoOAuthClient.processOauth(VALID_CODE)).thenReturn(testKakaoUserInfo);
+        when(siteUserRepository.existsByEmail(testUser.getEmail())).thenReturn(false);
+        when(tokenService.generateToken(testUser.getEmail(), TokenType.KAKAO_OAUTH)).thenReturn(TEST_KAKAO_OAUTH_TOKEN);
+
+        // when
+        KakaoOauthResponse response = signInService.signIn(validKakaoCodeRequest);
+
+        // then
+        assertThat(response).isInstanceOf(FirstAccessResponse.class);
+        FirstAccessResponse firstAccessResponse = (FirstAccessResponse) response;
+        assertThat(firstAccessResponse.kakaoOauthToken()).isEqualTo(TEST_KAKAO_OAUTH_TOKEN);
+        assertThat(firstAccessResponse.isRegistered()).isFalse();
+        assertThat(firstAccessResponse.email()).isEqualTo(testUser.getEmail());
+        assertThat(firstAccessResponse.nickname()).isEqualTo("testNickname");
+        assertThat(firstAccessResponse.profileImageUrl()).isEqualTo("testProfileImageUrl");
+
+        // verify
+        verify(siteUserRepository).existsByEmail(testUser.getEmail());
+        verify(tokenService).generateToken(testUser.getEmail(), TokenType.KAKAO_OAUTH);
+        verify(tokenService).saveToken(TEST_KAKAO_OAUTH_TOKEN, TokenType.KAKAO_OAUTH);
+    }
+
+    @Test
+    @DisplayName("유효하지_않은_인증_코드로_로그인_시도하면_예외를_반환한다()")
+    void shouldThrowExceptionWhenInvalidAuthCodeProvided() {
+        // given
+        KakaoCodeRequest invalidRequest = new KakaoCodeRequest(INVALID_CODE);
+        when(kakaoOAuthClient.processOauth(INVALID_CODE))
+                .thenThrow(new CustomException(ErrorCode.INVALID_OR_EXPIRED_KAKAO_AUTH_CODE));
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> signInService.signIn(invalidRequest));
+        assertThat(exception.getCode()).isEqualTo(ErrorCode.INVALID_OR_EXPIRED_KAKAO_AUTH_CODE.getCode());
+
+        // verify
+        verify(kakaoOAuthClient).processOauth(INVALID_CODE);
+    }
+
+    @Test
+    @DisplayName("카카오_리다이렉트_URI가_일치하지_않으면_예외를_반환한다()")
+    void shouldThrowExceptionWhenKakaoRedirectUriMismatch() {
+        // given
+        when(kakaoOAuthClient.processOauth(VALID_CODE))
+                .thenThrow(new CustomException(ErrorCode.KAKAO_REDIRECT_URI_MISMATCH));
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> signInService.signIn(validKakaoCodeRequest));
+        assertThat(exception.getCode()).isEqualTo(ErrorCode.KAKAO_REDIRECT_URI_MISMATCH.getCode());
+
+        // verify
+        verify(kakaoOAuthClient).processOauth(VALID_CODE);
+    }
+
+    @Test
+    @DisplayName("카카오_사용자_정보_조회에_실패하면_예외를_반환한다()")
+    void shouldThrowExceptionWhenKakaoUserInfoFetchFails() {
+        // given
+        when(kakaoOAuthClient.processOauth(VALID_CODE))
+                .thenThrow(new CustomException(ErrorCode.KAKAO_USER_INFO_FAIL));
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> signInService.signIn(validKakaoCodeRequest));
+        assertThat(exception.getCode()).isEqualTo(ErrorCode.KAKAO_USER_INFO_FAIL.getCode());
+
+        // verify
+        verify(kakaoOAuthClient).processOauth(VALID_CODE);
+    }
+
+    private SiteUser createTestUser() {
+        return new SiteUser(
+                "test@example.com",
+                "nickname",
+                "profileImageUrl",
+                "1999-10-21",
+                PreparationStatus.CONSIDERING,
+                Role.MENTEE,
+                Gender.MALE
+        );
+    }
+
+    private KakaoUserInfoDto createTestKakaoUserInfoDto() {
+        KakaoUserInfoDto.KakaoAccountDto kakaoAccountDto = new KakaoUserInfoDto.KakaoAccountDto(
+                new KakaoUserInfoDto.KakaoAccountDto.KakaoProfileDto("testProfileImageUrl", "testNickname"),
+                testUser.getEmail());
+        return new KakaoUserInfoDto(kakaoAccountDto);
+    }
+}

--- a/src/test/java/com/example/solidconnection/unit/auth/service/SignUpServiceTest.java
+++ b/src/test/java/com/example/solidconnection/unit/auth/service/SignUpServiceTest.java
@@ -1,0 +1,213 @@
+package com.example.solidconnection.unit.auth.service;
+
+import com.example.solidconnection.auth.dto.SignUpRequest;
+import com.example.solidconnection.auth.dto.SignUpResponse;
+import com.example.solidconnection.auth.service.SignUpService;
+import com.example.solidconnection.config.token.TokenService;
+import com.example.solidconnection.config.token.TokenType;
+import com.example.solidconnection.config.token.TokenValidator;
+import com.example.solidconnection.custom.exception.CustomException;
+import com.example.solidconnection.custom.exception.ErrorCode;
+import com.example.solidconnection.entity.Country;
+import com.example.solidconnection.entity.Region;
+import com.example.solidconnection.repositories.CountryRepository;
+import com.example.solidconnection.repositories.InterestedCountyRepository;
+import com.example.solidconnection.repositories.InterestedRegionRepository;
+import com.example.solidconnection.repositories.RegionRepository;
+import com.example.solidconnection.siteuser.domain.SiteUser;
+import com.example.solidconnection.siteuser.repository.SiteUserRepository;
+import com.example.solidconnection.type.Gender;
+import com.example.solidconnection.type.PreparationStatus;
+import com.example.solidconnection.type.Role;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("회원가입 서비스 테스트")
+class SignUpServiceTest {
+
+    @InjectMocks
+    private SignUpService signUpService;
+
+    @Mock
+    private SiteUserRepository siteUserRepository;
+
+    @Mock
+    private TokenService tokenService;
+
+    @Mock
+    private TokenValidator tokenValidator;
+
+    @Mock
+    private RegionRepository regionRepository;
+
+    @Mock
+    private CountryRepository countryRepository;
+
+    @Mock
+    private InterestedRegionRepository interestedRegionRepository;
+
+    @Mock
+    private InterestedCountyRepository interestedCountryRepository;
+
+    private static final String TEST_KAKAO_TOKEN = "testKakaoToken";
+    private static final String TEST_ACCESS_TOKEN = "testAccessToken";
+    private static final String TEST_REFRESH_TOKEN = "testRefreshToken";
+    private static final String TEST_NICKNAME = "testNickname";
+
+    private SignUpRequest validSignUpRequest;
+    private SiteUser testUser;
+    private Region testRegion;
+    private Country testCountry;
+
+    @BeforeEach
+    void setUp() {
+        validSignUpRequest = createValidSignUpRequest();
+        testUser = createTestUser();
+        testRegion = createTestRegion();
+        testCountry = createTestCountry();
+    }
+
+    @Test
+    @DisplayName("올바른_회원가입_요청시_회원가입에_성공하고_토큰을_반환한다()")
+    void shouldSuccessfullySignUpAndReturnTokens() {
+        // given
+        when(tokenService.getEmail(TEST_KAKAO_TOKEN)).thenReturn(testUser.getEmail());
+        when(siteUserRepository.existsByEmail(testUser.getEmail())).thenReturn(false);
+        when(siteUserRepository.existsByNickname(TEST_NICKNAME)).thenReturn(false);
+        when(siteUserRepository.save(any(SiteUser.class))).thenReturn(testUser);
+        when(regionRepository.findByKoreanNames(any())).thenReturn(List.of(testRegion));
+        when(countryRepository.findByKoreanNames(any())).thenReturn(List.of(testCountry));
+        when(tokenService.generateToken(testUser.getEmail(), TokenType.ACCESS)).thenReturn(TEST_ACCESS_TOKEN);
+        when(tokenService.generateToken(testUser.getEmail(), TokenType.REFRESH)).thenReturn(TEST_REFRESH_TOKEN);
+
+        // when
+        SignUpResponse response = signUpService.signUp(validSignUpRequest);
+
+        // then
+        assertThat(response.accessToken()).isEqualTo(TEST_ACCESS_TOKEN);
+        assertThat(response.refreshToken()).isEqualTo(TEST_REFRESH_TOKEN);
+
+        // verify
+        verify(tokenValidator).validateKakaoToken(TEST_KAKAO_TOKEN);
+        verify(siteUserRepository).save(any(SiteUser.class));
+        verify(interestedRegionRepository).saveAll(any());
+        verify(interestedCountryRepository).saveAll(any());
+        verify(tokenService).saveToken(TEST_REFRESH_TOKEN, TokenType.REFRESH);
+    }
+
+    @Test
+    @DisplayName("이미_사용중인_닉네임으로_회원가입_시도시_예외를_반환한다()")
+    void shouldThrowExceptionWhenNicknameAlreadyExists() {
+        // given
+        when(tokenService.getEmail(TEST_KAKAO_TOKEN)).thenReturn(testUser.getEmail());
+        when(siteUserRepository.existsByNickname(TEST_NICKNAME)).thenReturn(true);
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> signUpService.signUp(validSignUpRequest));
+        assertThat(exception.getCode()).isEqualTo(ErrorCode.NICKNAME_ALREADY_EXISTED.getCode());
+
+        // verify
+        verify(tokenValidator).validateKakaoToken(TEST_KAKAO_TOKEN);
+        verify(siteUserRepository).existsByNickname(TEST_NICKNAME);
+        verify(siteUserRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("이미_가입된_이메일로_회원가입_시도시_예외를_반환한다()")
+    void shouldThrowExceptionWhenEmailAlreadyExists() {
+        // given
+        when(tokenService.getEmail(TEST_KAKAO_TOKEN)).thenReturn(testUser.getEmail());
+        when(siteUserRepository.existsByNickname(TEST_NICKNAME)).thenReturn(false);
+        when(siteUserRepository.existsByEmail(testUser.getEmail())).thenReturn(true);
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> signUpService.signUp(validSignUpRequest));
+        assertThat(exception.getCode()).isEqualTo(ErrorCode.USER_ALREADY_EXISTED.getCode());
+
+        // verify
+        verify(siteUserRepository).existsByEmail(testUser.getEmail());
+        verify(siteUserRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("만료된_카카오_토큰으로_회원가입_시도시_예외를_반환한다()")
+    void shouldThrowExceptionWhenKakaoTokenExpired() {
+        // given
+        doThrow(new CustomException(ErrorCode.INVALID_SERVICE_PUBLISHED_KAKAO_TOKEN))
+                .when(tokenValidator).validateKakaoToken(TEST_KAKAO_TOKEN);
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> signUpService.signUp(validSignUpRequest));
+        assertThat(exception.getCode()).isEqualTo(ErrorCode.INVALID_SERVICE_PUBLISHED_KAKAO_TOKEN.getCode());
+
+        // verify
+        verify(tokenValidator).validateKakaoToken(TEST_KAKAO_TOKEN);
+        verify(siteUserRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("이미_사용된_카카오_토큰으로_회원가입_시도시_예외를_반환한다()")
+    void shouldThrowExceptionWhenKakaoTokenAlreadyUsed() {
+        // given
+        doThrow(new CustomException(ErrorCode.INVALID_SERVICE_PUBLISHED_KAKAO_TOKEN))
+                .when(tokenValidator).validateKakaoToken(TEST_KAKAO_TOKEN);
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> signUpService.signUp(validSignUpRequest));
+        assertThat(exception.getCode()).isEqualTo(ErrorCode.INVALID_SERVICE_PUBLISHED_KAKAO_TOKEN.getCode());
+
+        // verify
+        verify(tokenValidator).validateKakaoToken(TEST_KAKAO_TOKEN);
+        verify(siteUserRepository, never()).save(any());
+    }
+
+    private SignUpRequest createValidSignUpRequest() {
+        return new SignUpRequest(
+                TEST_KAKAO_TOKEN,
+                List.of("미주권"),
+                List.of("브라질"),
+                PreparationStatus.CONSIDERING,
+                "https://example.com/profile.jpg",
+                Gender.PREFER_NOT_TO_SAY,
+                TEST_NICKNAME,
+                "1999-10-21"
+        );
+    }
+
+    private SiteUser createTestUser() {
+        return new SiteUser(
+                "test@example.com",
+                TEST_NICKNAME,
+                "https://example.com/profile.jpg",
+                "1999-10-21",
+                PreparationStatus.CONSIDERING,
+                Role.MENTEE,
+                Gender.PREFER_NOT_TO_SAY
+        );
+    }
+
+    private Region createTestRegion() {
+        return new Region("AMERICAS", "미주권");
+    }
+
+    private Country createTestCountry() {
+        return new Country("BR", "브라질", testRegion);
+    }
+}

--- a/src/test/java/com/example/solidconnection/unit/board/service/BoardServiceTest.java
+++ b/src/test/java/com/example/solidconnection/unit/board/service/BoardServiceTest.java
@@ -1,4 +1,4 @@
-package com.example.solidconnection.unit.service;
+package com.example.solidconnection.unit.board.service;
 
 import com.example.solidconnection.board.domain.Board;
 import com.example.solidconnection.board.repository.BoardRepository;

--- a/src/test/java/com/example/solidconnection/unit/comment/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/example/solidconnection/unit/comment/repository/CommentRepositoryTest.java
@@ -1,7 +1,9 @@
-package com.example.solidconnection.unit.repository;
+package com.example.solidconnection.unit.comment.repository;
 
 import com.example.solidconnection.board.domain.Board;
 import com.example.solidconnection.board.repository.BoardRepository;
+import com.example.solidconnection.comment.domain.Comment;
+import com.example.solidconnection.comment.repository.CommentRepository;
 import com.example.solidconnection.custom.exception.CustomException;
 import com.example.solidconnection.post.domain.Post;
 import com.example.solidconnection.post.repository.PostRepository;
@@ -11,23 +13,26 @@ import com.example.solidconnection.type.Gender;
 import com.example.solidconnection.type.PostCategory;
 import com.example.solidconnection.type.PreparationStatus;
 import com.example.solidconnection.type.Role;
-import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
-import static com.example.solidconnection.custom.exception.ErrorCode.INVALID_BOARD_CODE;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import java.util.List;
 
-@DataJpaTest
-@ActiveProfiles("test")
-@DisplayName("게시판 레포지토리 테스트")
-class BoardRepositoryTest {
+import static com.example.solidconnection.custom.exception.ErrorCode.INVALID_COMMENT_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+
+@SpringBootTest
+@ActiveProfiles("dev")
+@DisplayName("댓글 레포지토리 테스트")
+class CommentRepositoryTest {
     @Autowired
     private PostRepository postRepository;
     @Autowired
@@ -35,11 +40,13 @@ class BoardRepositoryTest {
     @Autowired
     private SiteUserRepository siteUserRepository;
     @Autowired
-    private EntityManager entityManager;
+    private CommentRepository commentRepository;
 
     private Board board;
     private SiteUser siteUser;
     private Post post;
+    private Comment parentComment;
+    private Comment childComment;
 
     @BeforeEach
     public void setUp() {
@@ -52,8 +59,10 @@ class BoardRepositoryTest {
         post = createPost(board, siteUser);
         post = postRepository.save(post);
 
-        entityManager.flush();
-        entityManager.clear();
+        parentComment = createParentComment();
+        childComment = createChildComment();
+        commentRepository.save(parentComment);
+        commentRepository.save(childComment);
     }
 
     private Board createBoard() {
@@ -86,56 +95,56 @@ class BoardRepositoryTest {
         return post;
     }
 
-    @Test
-    @Transactional
-    public void 게시판을_조회할_때_게시글은_즉시_로딩한다() {
-        // when
-        Board foundBoard = boardRepository.getByCodeUsingEntityGraph(board.getCode());
-        foundBoard.getPostList().size(); // 추가쿼리 발생하지 않는다.
+    private Comment createParentComment() {
+        Comment comment = new Comment(
+                "parent"
+        );
+        comment.setPostAndSiteUser(post, siteUser);
+        return comment;
+    }
 
-        // then
-        assertThat(foundBoard.getCode()).isEqualTo(board.getCode());
+    private Comment createChildComment() {
+        Comment comment = new Comment(
+                "child"
+        );
+        comment.setParentCommentAndPostAndSiteUser(parentComment, post, siteUser);
+        return comment;
     }
 
     @Test
     @Transactional
-    public void 게시판을_조회할_때_게시글은_즉시_로딩한다_유효한_게시판이_아니라면_예외_응답을_반환한다() {
+    public void 재귀쿼리로_댓글트리를_조회한다() {
+        // when
+        List<Comment> commentTreeByPostId = commentRepository.findCommentTreeByPostId(post.getId());
+
+        // then
+        List<Comment> expectedResponse = List.of(parentComment, childComment);
+        assertEquals(commentTreeByPostId, expectedResponse);
+    }
+
+    @Test
+    @Transactional
+    public void 댓글을_조회한다() {
+        // when
+        Comment foundComment = commentRepository.getById(parentComment.getId());
+
+        // then
+        assertEquals(parentComment, foundComment);
+    }
+
+    @Test
+    @Transactional
+    public void 댓글을_조회할_때_유효한_댓글이_아니라면_예외_응답을_반환한다() {
         // given
-        String invalidCode = "INVALID_CODE";
+        Long invalidId = -1L;
 
         // when, then
         CustomException exception = assertThrows(CustomException.class, () -> {
-            boardRepository.getByCodeUsingEntityGraph(invalidCode);
+            commentRepository.getById(invalidId);
         });
         assertThat(exception.getMessage())
-                .isEqualTo(INVALID_BOARD_CODE.getMessage());
+                .isEqualTo(INVALID_COMMENT_ID.getMessage());
         assertThat(exception.getCode())
-                .isEqualTo(INVALID_BOARD_CODE.getCode());
-    }
-
-    @Test
-    @Transactional
-    public void 게시판을_조회한다() {
-        // when
-        Board foundBoard = boardRepository.getByCode(board.getCode());
-
-        // then
-        assertEquals(board.getCode(), foundBoard.getCode());
-    }
-
-    @Test
-    @Transactional
-    public void 게시판을_조회할_때_유효한_게시판이_아니라면_예외_응답을_반환한다() {
-        // given
-        String invalidCode = "INVALID_CODE";
-
-        // when, then
-        CustomException exception = assertThrows(CustomException.class, () -> {
-            boardRepository.getByCode(invalidCode);
-        });
-        assertThat(exception.getMessage())
-                .isEqualTo(INVALID_BOARD_CODE.getMessage());
-        assertThat(exception.getCode())
-                .isEqualTo(INVALID_BOARD_CODE.getCode());
+                .isEqualTo(INVALID_COMMENT_ID.getCode());
     }
 }

--- a/src/test/java/com/example/solidconnection/unit/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/example/solidconnection/unit/comment/service/CommentServiceTest.java
@@ -1,4 +1,4 @@
-package com.example.solidconnection.unit.service;
+package com.example.solidconnection.unit.comment.service;
 
 import com.example.solidconnection.board.domain.Board;
 import com.example.solidconnection.comment.domain.Comment;

--- a/src/test/java/com/example/solidconnection/unit/post/repository/PostLikeRepositoryTest.java
+++ b/src/test/java/com/example/solidconnection/unit/post/repository/PostLikeRepositoryTest.java
@@ -1,10 +1,10 @@
-package com.example.solidconnection.unit.repository;
+package com.example.solidconnection.unit.post.repository;
 
 import com.example.solidconnection.board.domain.Board;
 import com.example.solidconnection.board.repository.BoardRepository;
-import com.example.solidconnection.comment.domain.Comment;
-import com.example.solidconnection.comment.repository.CommentRepository;
 import com.example.solidconnection.custom.exception.CustomException;
+import com.example.solidconnection.post.domain.PostLike;
+import com.example.solidconnection.post.repository.PostLikeRepository;
 import com.example.solidconnection.post.domain.Post;
 import com.example.solidconnection.post.repository.PostRepository;
 import com.example.solidconnection.siteuser.domain.SiteUser;
@@ -17,22 +17,19 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-
-import static com.example.solidconnection.custom.exception.ErrorCode.INVALID_COMMENT_ID;
+import static com.example.solidconnection.custom.exception.ErrorCode.INVALID_POST_LIKE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-
-@SpringBootTest
-@ActiveProfiles("dev")
-@DisplayName("댓글 레포지토리 테스트")
-class CommentRepositoryTest {
+@DataJpaTest
+@ActiveProfiles("test")
+@DisplayName("게시글 좋아요 레포지토리 테스트")
+class PostLikeRepositoryTest {
     @Autowired
     private PostRepository postRepository;
     @Autowired
@@ -40,34 +37,24 @@ class CommentRepositoryTest {
     @Autowired
     private SiteUserRepository siteUserRepository;
     @Autowired
-    private CommentRepository commentRepository;
+    private PostLikeRepository postLikeRepository;
 
+    private Post post;
     private Board board;
     private SiteUser siteUser;
-    private Post post;
-    private Comment parentComment;
-    private Comment childComment;
+    private PostLike postLike;
+
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         board = createBoard();
         boardRepository.save(board);
-
         siteUser = createSiteUser();
         siteUserRepository.save(siteUser);
-
         post = createPost(board, siteUser);
         post = postRepository.save(post);
-
-        parentComment = createParentComment();
-        childComment = createChildComment();
-        commentRepository.save(parentComment);
-        commentRepository.save(childComment);
-    }
-
-    private Board createBoard() {
-        return new Board(
-                "FREE", "자유게시판");
+        postLike = createPostLike(post, siteUser);
+        postLikeRepository.save(postLike);
     }
 
     private SiteUser createSiteUser() {
@@ -80,6 +67,11 @@ class CommentRepositoryTest {
                 Role.MENTEE,
                 Gender.MALE
         );
+    }
+
+    private Board createBoard() {
+        return new Board(
+                "FREE", "자유게시판");
     }
 
     private Post createPost(Board board, SiteUser siteUser) {
@@ -95,56 +87,36 @@ class CommentRepositoryTest {
         return post;
     }
 
-    private Comment createParentComment() {
-        Comment comment = new Comment(
-                "parent"
-        );
-        comment.setPostAndSiteUser(post, siteUser);
-        return comment;
-    }
-
-    private Comment createChildComment() {
-        Comment comment = new Comment(
-                "child"
-        );
-        comment.setParentCommentAndPostAndSiteUser(parentComment, post, siteUser);
-        return comment;
+    private PostLike createPostLike(Post post, SiteUser siteUser) {
+        PostLike postLike = new PostLike();
+        postLike.setPostAndSiteUser(post, siteUser);
+        return postLike;
     }
 
     @Test
     @Transactional
-    public void 재귀쿼리로_댓글트리를_조회한다() {
+    void 게시글_좋아요를_조회한다() {
         // when
-        List<Comment> commentTreeByPostId = commentRepository.findCommentTreeByPostId(post.getId());
+        PostLike foundPostLike = postLikeRepository.getByPostAndSiteUser(post, siteUser);
 
         // then
-        List<Comment> expectedResponse = List.of(parentComment, childComment);
-        assertEquals(commentTreeByPostId, expectedResponse);
+        assertEquals(foundPostLike, postLike);
     }
 
     @Test
     @Transactional
-    public void 댓글을_조회한다() {
-        // when
-        Comment foundComment = commentRepository.getById(parentComment.getId());
-
-        // then
-        assertEquals(parentComment, foundComment);
-    }
-
-    @Test
-    @Transactional
-    public void 댓글을_조회할_때_유효한_댓글이_아니라면_예외_응답을_반환한다() {
+    void 게시글_좋아요를_조회할_때_유효한_좋아요가_아니라면_예외_응답을_반환한다() {
         // given
-        Long invalidId = -1L;
+        postLike.resetPostAndSiteUser();
+        postLikeRepository.delete(postLike);
 
         // when, then
         CustomException exception = assertThrows(CustomException.class, () -> {
-            commentRepository.getById(invalidId);
+            postLikeRepository.getByPostAndSiteUser(post, siteUser);
         });
         assertThat(exception.getMessage())
-                .isEqualTo(INVALID_COMMENT_ID.getMessage());
+                .isEqualTo(INVALID_POST_LIKE.getMessage());
         assertThat(exception.getCode())
-                .isEqualTo(INVALID_COMMENT_ID.getCode());
+                .isEqualTo(INVALID_POST_LIKE.getCode());
     }
 }

--- a/src/test/java/com/example/solidconnection/unit/post/repository/PostRepositoryTest.java
+++ b/src/test/java/com/example/solidconnection/unit/post/repository/PostRepositoryTest.java
@@ -1,4 +1,4 @@
-package com.example.solidconnection.unit.repository;
+package com.example.solidconnection.unit.post.repository;
 
 import com.example.solidconnection.board.domain.Board;
 import com.example.solidconnection.board.repository.BoardRepository;

--- a/src/test/java/com/example/solidconnection/unit/post/service/PostServiceTest.java
+++ b/src/test/java/com/example/solidconnection/unit/post/service/PostServiceTest.java
@@ -1,4 +1,4 @@
-package com.example.solidconnection.unit.service;
+package com.example.solidconnection.unit.post.service;
 
 import com.example.solidconnection.board.domain.Board;
 import com.example.solidconnection.board.dto.PostFindBoardResponse;

--- a/src/test/java/com/example/solidconnection/unit/score/repository/GpaScoreRepositoryTest.java
+++ b/src/test/java/com/example/solidconnection/unit/score/repository/GpaScoreRepositoryTest.java
@@ -1,4 +1,4 @@
-package com.example.solidconnection.unit.repository;
+package com.example.solidconnection.unit.score.repository;
 
 import com.example.solidconnection.application.domain.Gpa;
 import com.example.solidconnection.score.domain.GpaScore;

--- a/src/test/java/com/example/solidconnection/unit/score/repository/LanguageTestScoreRepositoryTest.java
+++ b/src/test/java/com/example/solidconnection/unit/score/repository/LanguageTestScoreRepositoryTest.java
@@ -1,4 +1,4 @@
-package com.example.solidconnection.unit.repository;
+package com.example.solidconnection.unit.score.repository;
 
 import com.example.solidconnection.application.domain.LanguageTest;
 import com.example.solidconnection.score.domain.LanguageTestScore;

--- a/src/test/java/com/example/solidconnection/unit/score/service/ScoreServiceTest.java
+++ b/src/test/java/com/example/solidconnection/unit/score/service/ScoreServiceTest.java
@@ -1,4 +1,4 @@
-package com.example.solidconnection.unit.service;
+package com.example.solidconnection.unit.score.service;
 
 import com.example.solidconnection.application.domain.Gpa;
 import com.example.solidconnection.application.domain.LanguageTest;

--- a/src/test/java/com/example/solidconnection/unit/siteuser/service/SiteUserServiceTest.java
+++ b/src/test/java/com/example/solidconnection/unit/siteuser/service/SiteUserServiceTest.java
@@ -1,4 +1,4 @@
-package com.example.solidconnection.unit.service;
+package com.example.solidconnection.unit.siteuser.service;
 
 import com.example.solidconnection.custom.exception.CustomException;
 import com.example.solidconnection.s3.S3Service;

--- a/src/test/java/com/example/solidconnection/unit/university/service/UniversityLikeServiceTest.java
+++ b/src/test/java/com/example/solidconnection/unit/university/service/UniversityLikeServiceTest.java
@@ -56,7 +56,7 @@ class UniversityLikeServiceTest {
     }
 
     @Test
-    @DisplayName("사용자가 특정 대학을 좋아요 상태인지 확인하면 True를 반환한다")
+    @DisplayName("사용자가_특정_대학을_좋아요_상태인지_확인하면_True를_반환한다()")
     void shouldReturnTrueWhenUserLikedTheUniversity() {
         // given
         String email = testUser.getEmail();
@@ -81,7 +81,7 @@ class UniversityLikeServiceTest {
     }
 
     @Test
-    @DisplayName("사용자가 특정 대학을 좋아요 상태인지 확인하면 False를 반환한다")
+    @DisplayName("사용자가_특정_대학을_좋아요_상태인지_확인하면_False를_반환한다()")
     void shouldReturnFalseWhenUserNotLikedTheUniversity() {
         // given
         String email = testUser.getEmail();
@@ -106,7 +106,7 @@ class UniversityLikeServiceTest {
     }
 
     @Test
-    @DisplayName("사용자가 대학 좋아요를 추가하면 성공 메시지를 반환한다")
+    @DisplayName("사용자가_대학_좋아요를_추가하면_성공_메시지를_반환한다()")
     void shouldAddLikeWhenUserNotLikedTheUniversity() {
         // given
         String email = testUser.getEmail();
@@ -129,7 +129,7 @@ class UniversityLikeServiceTest {
     }
 
     @Test
-    @DisplayName("사용자가 대학 좋아요를 취소하면 취소 메시지를 반환한다")
+    @DisplayName("사용자가_대학_좋아요를_취소하면_취소_메시지를_반환한다()")
     void shouldRemoveLikeWhenUserAlreadyLikedTheUniversity() {
         // given
         String email = testUser.getEmail();
@@ -152,7 +152,7 @@ class UniversityLikeServiceTest {
     }
 
     @Test
-    @DisplayName("존재하지 않는 대학 ID로 좋아요 요청 시 예외를 반환한다")
+    @DisplayName("존재하지_않는_대학_ID로_좋아요_요청_시_예외를_반환한다()")
     void shouldThrowExceptionWhenUniversityNotFound() {
         // given
         String email = testUser.getEmail();

--- a/src/test/java/com/example/solidconnection/unit/university/service/UniversityLikeServiceTest.java
+++ b/src/test/java/com/example/solidconnection/unit/university/service/UniversityLikeServiceTest.java
@@ -1,0 +1,209 @@
+package com.example.solidconnection.unit.university.service;
+
+import com.example.solidconnection.custom.exception.CustomException;
+import com.example.solidconnection.custom.exception.ErrorCode;
+import com.example.solidconnection.siteuser.domain.SiteUser;
+import com.example.solidconnection.siteuser.repository.LikedUniversityRepository;
+import com.example.solidconnection.siteuser.repository.SiteUserRepository;
+import com.example.solidconnection.type.Gender;
+import com.example.solidconnection.type.PreparationStatus;
+import com.example.solidconnection.type.Role;
+import com.example.solidconnection.university.domain.LikedUniversity;
+import com.example.solidconnection.university.domain.UniversityInfoForApply;
+import com.example.solidconnection.university.dto.IsLikeResponse;
+import com.example.solidconnection.university.dto.LikeResultResponse;
+import com.example.solidconnection.university.repository.UniversityInfoForApplyRepository;
+import com.example.solidconnection.university.service.UniversityService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static com.example.solidconnection.university.service.UniversityService.LIKE_CANCELED_MESSAGE;
+import static com.example.solidconnection.university.service.UniversityService.LIKE_SUCCESS_MESSAGE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("대학교 좋아요 서비스 테스트")
+class UniversityLikeServiceTest {
+
+    @InjectMocks
+    private UniversityService universityService;
+
+    @Mock
+    private UniversityInfoForApplyRepository universityInfoForApplyRepository;
+
+    @Mock
+    private SiteUserRepository siteUserRepository;
+
+    @Mock
+    private LikedUniversityRepository likedUniversityRepository;
+
+    private SiteUser testUser;
+    private UniversityInfoForApply testUniversity;
+
+    @BeforeEach
+    void setUp() {
+        testUser = createTestUser();
+        testUniversity = createTestUniversity();
+    }
+
+    @Test
+    @DisplayName("사용자가 특정 대학을 좋아요 상태인지 확인하면 True를 반환한다")
+    void shouldReturnTrueWhenUserLikedTheUniversity() {
+        // given
+        String email = testUser.getEmail();
+        Long universityId = testUniversity.getId();
+
+        when(siteUserRepository.getByEmail(email)).thenReturn(testUser);
+        when(universityInfoForApplyRepository.getUniversityInfoForApplyById(universityId)).thenReturn(testUniversity);
+        when(likedUniversityRepository.findBySiteUserAndUniversityInfoForApply(testUser, testUniversity))
+                .thenReturn(Optional.of(new LikedUniversity()));
+
+        // when
+        IsLikeResponse response = universityService.getIsLiked(email, universityId);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.isLike()).isTrue();
+
+        // verify
+        verify(siteUserRepository).getByEmail(email);
+        verify(universityInfoForApplyRepository).getUniversityInfoForApplyById(universityId);
+        verify(likedUniversityRepository).findBySiteUserAndUniversityInfoForApply(testUser, testUniversity);
+    }
+
+    @Test
+    @DisplayName("사용자가 특정 대학을 좋아요 상태인지 확인하면 False를 반환한다")
+    void shouldReturnFalseWhenUserNotLikedTheUniversity() {
+        // given
+        String email = testUser.getEmail();
+        Long universityId = testUniversity.getId();
+
+        when(siteUserRepository.getByEmail(email)).thenReturn(testUser);
+        when(universityInfoForApplyRepository.getUniversityInfoForApplyById(universityId)).thenReturn(testUniversity);
+        when(likedUniversityRepository.findBySiteUserAndUniversityInfoForApply(testUser, testUniversity))
+                .thenReturn(Optional.empty());
+
+        // when
+        IsLikeResponse response = universityService.getIsLiked(email, universityId);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.isLike()).isFalse();
+
+        // verify
+        verify(siteUserRepository).getByEmail(email);
+        verify(universityInfoForApplyRepository).getUniversityInfoForApplyById(universityId);
+        verify(likedUniversityRepository).findBySiteUserAndUniversityInfoForApply(testUser, testUniversity);
+    }
+
+    @Test
+    @DisplayName("사용자가 대학 좋아요를 추가하면 성공 메시지를 반환한다")
+    void shouldAddLikeWhenUserNotLikedTheUniversity() {
+        // given
+        String email = testUser.getEmail();
+        Long universityId = testUniversity.getId();
+
+        when(siteUserRepository.getByEmail(email)).thenReturn(testUser);
+        when(universityInfoForApplyRepository.getUniversityInfoForApplyById(universityId)).thenReturn(testUniversity);
+        when(likedUniversityRepository.findBySiteUserAndUniversityInfoForApply(testUser, testUniversity))
+                .thenReturn(Optional.empty());
+
+        // when
+        LikeResultResponse response = universityService.likeUniversity(email, universityId);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.result()).isEqualTo(LIKE_SUCCESS_MESSAGE);
+
+        // verify
+        verify(likedUniversityRepository).save(any(LikedUniversity.class));
+    }
+
+    @Test
+    @DisplayName("사용자가 대학 좋아요를 취소하면 취소 메시지를 반환한다")
+    void shouldRemoveLikeWhenUserAlreadyLikedTheUniversity() {
+        // given
+        String email = testUser.getEmail();
+        Long universityId = testUniversity.getId();
+
+        when(siteUserRepository.getByEmail(email)).thenReturn(testUser);
+        when(universityInfoForApplyRepository.getUniversityInfoForApplyById(universityId)).thenReturn(testUniversity);
+        when(likedUniversityRepository.findBySiteUserAndUniversityInfoForApply(testUser, testUniversity))
+                .thenReturn(Optional.of(new LikedUniversity(1L, testUniversity, testUser)));
+
+        // when
+        LikeResultResponse response = universityService.likeUniversity(email, universityId);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.result()).isEqualTo(LIKE_CANCELED_MESSAGE);
+
+        // verify
+        verify(likedUniversityRepository).delete(any(LikedUniversity.class));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 대학 ID로 좋아요 요청 시 예외를 반환한다")
+    void shouldThrowExceptionWhenUniversityNotFound() {
+        // given
+        String email = testUser.getEmail();
+        Long invalidUniversityId = 999L;
+
+        when(siteUserRepository.getByEmail(email)).thenReturn(testUser);
+        when(universityInfoForApplyRepository.getUniversityInfoForApplyById(invalidUniversityId))
+                .thenThrow(new CustomException(ErrorCode.UNIVERSITY_NOT_FOUND));
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> universityService.likeUniversity(email, invalidUniversityId));
+
+        assertThat(exception.getCode()).isEqualTo(ErrorCode.UNIVERSITY_NOT_FOUND.getCode());
+
+        // verify
+        verify(siteUserRepository).getByEmail(email);
+        verify(universityInfoForApplyRepository).getUniversityInfoForApplyById(invalidUniversityId);
+    }
+
+    private SiteUser createTestUser() {
+        return new SiteUser(
+                "test@example.com",
+                "nickname",
+                "profileImageUrl",
+                "1999-10-21",
+                PreparationStatus.CONSIDERING,
+                Role.MENTEE,
+                Gender.MALE
+        );
+    }
+
+    private UniversityInfoForApply createTestUniversity() {
+        return new UniversityInfoForApply(
+                1L,
+                "2025-1-a",
+                "Test University",
+                3,
+                null,
+                null,
+                "4학기",
+                "어학 요구사항",
+                "3.0/4.5",
+                "4.5",
+                "지원 상세",
+                "전공 상세",
+                "기숙사 상세",
+                "영어 강좌 상세",
+                "기타 상세",
+                null,
+                null
+        );
+    }
+}

--- a/src/test/java/com/example/solidconnection/unit/university/service/UniversityLikeServiceTest.java
+++ b/src/test/java/com/example/solidconnection/unit/university/service/UniversityLikeServiceTest.java
@@ -160,13 +160,13 @@ class UniversityLikeServiceTest {
 
         when(siteUserRepository.getByEmail(email)).thenReturn(testUser);
         when(universityInfoForApplyRepository.getUniversityInfoForApplyById(invalidUniversityId))
-                .thenThrow(new CustomException(ErrorCode.UNIVERSITY_NOT_FOUND));
+                .thenThrow(new CustomException(ErrorCode.UNIVERSITY_INFO_FOR_APPLY_NOT_FOUND));
 
         // when & then
         CustomException exception = assertThrows(CustomException.class,
                 () -> universityService.likeUniversity(email, invalidUniversityId));
 
-        assertThat(exception.getCode()).isEqualTo(ErrorCode.UNIVERSITY_NOT_FOUND.getCode());
+        assertThat(exception.getCode()).isEqualTo(ErrorCode.UNIVERSITY_INFO_FOR_APPLY_NOT_FOUND.getCode());
 
         // verify
         verify(siteUserRepository).getByEmail(email);

--- a/src/test/java/com/example/solidconnection/unit/university/service/UniversityQueryServiceTest.java
+++ b/src/test/java/com/example/solidconnection/unit/university/service/UniversityQueryServiceTest.java
@@ -1,0 +1,262 @@
+package com.example.solidconnection.unit.university.service;
+
+import com.example.solidconnection.custom.exception.CustomException;
+import com.example.solidconnection.custom.exception.ErrorCode;
+import com.example.solidconnection.entity.Country;
+import com.example.solidconnection.entity.Region;
+import com.example.solidconnection.siteuser.repository.LikedUniversityRepository;
+import com.example.solidconnection.siteuser.repository.SiteUserRepository;
+import com.example.solidconnection.type.LanguageTestType;
+import com.example.solidconnection.type.SemesterAvailableForDispatch;
+import com.example.solidconnection.type.TuitionFeeType;
+import com.example.solidconnection.university.domain.LanguageRequirement;
+import com.example.solidconnection.university.domain.University;
+import com.example.solidconnection.university.domain.UniversityInfoForApply;
+import com.example.solidconnection.university.dto.UniversityDetailResponse;
+import com.example.solidconnection.university.dto.UniversityInfoForApplyPreviewResponse;
+import com.example.solidconnection.university.repository.UniversityInfoForApplyRepository;
+import com.example.solidconnection.university.repository.custom.UniversityFilterRepositoryImpl;
+import com.example.solidconnection.university.service.UniversityService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.HashSet;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("대학교 조회 서비스 테스트")
+class UniversityQueryServiceTest {
+
+    @InjectMocks
+    private UniversityService universityService;
+
+    @Mock
+    private UniversityFilterRepositoryImpl universityFilterRepository;
+
+    @Mock
+    private UniversityInfoForApplyRepository universityInfoForApplyRepository;
+
+    @Mock
+    private LikedUniversityRepository likedUniversityRepository;
+
+    @Mock
+    private SiteUserRepository siteUserRepository;
+
+    private UniversityInfoForApply testUniversityInfoForApply;
+    @BeforeEach
+    void setUp() {
+        universityService = new UniversityService(
+                universityInfoForApplyRepository,
+                likedUniversityRepository,
+                universityFilterRepository,
+                siteUserRepository
+        );
+        ReflectionTestUtils.setField(universityService, "term", "2025-1-a");
+        University testUniversity = createTestUniversity();
+        testUniversityInfoForApply = createTestUniversityInfoForApply(testUniversity);
+    }
+
+
+    @Test
+    @DisplayName("유효한 ID로 상세 조회하면 대학 정보를 반환한다")
+    void shouldReturnUniversityDetailsWhenValidIdProvided() {
+        // given
+        Long universityInfoForApplyId = testUniversityInfoForApply.getId();
+        when(universityInfoForApplyRepository.getUniversityInfoForApplyById(universityInfoForApplyId))
+                .thenReturn(testUniversityInfoForApply);
+
+        // when
+        UniversityDetailResponse response = universityService.getUniversityDetail(universityInfoForApplyId);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.id()).isEqualTo(universityInfoForApplyId);
+        assertThat(response.koreanName()).isEqualTo(testUniversityInfoForApply.getKoreanName());
+
+        // verify
+        verify(universityInfoForApplyRepository).getUniversityInfoForApplyById(universityInfoForApplyId);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 ID로 조회하면 예외를 반환한다")
+    void shouldThrowExceptionWhenInvalidIdProvided() {
+        // given
+        Long invalidId = 999L;
+        when(universityInfoForApplyRepository.getUniversityInfoForApplyById(invalidId))
+                .thenThrow(new CustomException(ErrorCode.UNIVERSITY_INFO_FOR_APPLY_NOT_FOUND));
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> universityService.getUniversityDetail(invalidId));
+
+        assertThat(exception.getCode()).isEqualTo(ErrorCode.UNIVERSITY_INFO_FOR_APPLY_NOT_FOUND.getCode());
+
+        // verify
+        verify(universityInfoForApplyRepository).getUniversityInfoForApplyById(invalidId);
+    }
+
+    @Test
+    @DisplayName("검색 조건이 없는 경우 전체 대학 목록을 반환한다")
+    void shouldReturnAllUniversitiesWhenNoSearchConditionProvided() {
+        // given
+        List<UniversityInfoForApply> universityList = List.of(testUniversityInfoForApply);
+        when(universityFilterRepository.findByRegionCodeAndKeywordsAndLanguageTestTypeAndTestScoreAndTerm(
+                "", List.of(), null, "", "2025-1-a"))
+                .thenReturn(universityList);
+
+        // when
+        List<UniversityInfoForApplyPreviewResponse> response = universityService
+                .searchUniversity("", List.of(), null, "")
+                .universityInfoForApplyPreviewResponses();
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response).hasSize(1);
+        assertThat(response.get(0).id()).isEqualTo(testUniversityInfoForApply.getId());
+
+        // verify
+        verify(universityFilterRepository).findByRegionCodeAndKeywordsAndLanguageTestTypeAndTestScoreAndTerm(
+                "", List.of(), null, "", "2025-1-a");
+    }
+
+    @Test
+    @DisplayName("검색 조건(region, keyword)을 만족하는 대학 목록을 반환한다")
+    void shouldReturnFilteredUniversitiesWhenSearchConditionProvided() {
+        // given
+        String region = "ASIA";
+        List<String> keywords = List.of("서울", "대학");
+        List<UniversityInfoForApply> universityList = List.of(testUniversityInfoForApply);
+
+        when(universityFilterRepository.findByRegionCodeAndKeywordsAndLanguageTestTypeAndTestScoreAndTerm(
+                region, keywords, null, "", "2025-1-a"))
+                .thenReturn(universityList);
+
+        // when
+        List<UniversityInfoForApplyPreviewResponse> response = universityService
+                .searchUniversity(region, keywords, null, "")
+                .universityInfoForApplyPreviewResponses();
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response).hasSize(1);
+        assertThat(response.get(0).koreanName()).isEqualTo(testUniversityInfoForApply.getKoreanName());
+
+        // verify
+        verify(universityFilterRepository).findByRegionCodeAndKeywordsAndLanguageTestTypeAndTestScoreAndTerm(
+                region, keywords, null, "", "2025-1-a");
+    }
+
+
+    @Test
+    @DisplayName("검색 조건(region, keyword, testType, testScore)을 만족하는 대학 목록을 반환한다")
+    void shouldReturnFilteredUniversitiesWhenFullSearchConditionProvided() {
+        // given
+        String region = "ASIA";
+        List<String> keywords = List.of("서울", "대학");
+        LanguageTestType testType = LanguageTestType.TOEFL_IBT;
+        String testScore = "90";
+        List<UniversityInfoForApply> universityList = List.of(testUniversityInfoForApply);
+
+        when(universityFilterRepository.findByRegionCodeAndKeywordsAndLanguageTestTypeAndTestScoreAndTerm(
+                region, keywords, testType, testScore, "2025-1-a"))
+                .thenReturn(universityList);
+
+        // when
+        List<UniversityInfoForApplyPreviewResponse> response = universityService
+                .searchUniversity(region, keywords, testType, testScore)
+                .universityInfoForApplyPreviewResponses();
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response).hasSize(1);
+        assertThat(response.get(0).languageRequirements()).isNotEmpty();
+
+        // verify
+        verify(universityFilterRepository).findByRegionCodeAndKeywordsAndLanguageTestTypeAndTestScoreAndTerm(
+                region, keywords, testType, testScore, "2025-1-a");
+    }
+
+    @Test
+    @DisplayName("검색 조건을 만족하지 않을 경우 결과가 비어 있다")
+    void shouldReturnEmptyListWhenSearchConditionNotMet() {
+        // given
+        String region = "EUROPE";
+        List<String> keywords = List.of("비현실적인 대학명");
+        LanguageTestType testType = LanguageTestType.TOEFL_IBT;
+        String testScore = "150";
+
+        when(universityFilterRepository.findByRegionCodeAndKeywordsAndLanguageTestTypeAndTestScoreAndTerm(
+                region, keywords, testType, testScore, "2025-1-a"))
+                .thenReturn(List.of());
+
+        // when
+        List<UniversityInfoForApplyPreviewResponse> response = universityService
+                .searchUniversity(region, keywords, testType, testScore)
+                .universityInfoForApplyPreviewResponses();
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response).isEmpty();
+
+        // verify
+        verify(universityFilterRepository).findByRegionCodeAndKeywordsAndLanguageTestTypeAndTestScoreAndTerm(
+                region, keywords, testType, testScore, "2025-1-a");
+    }
+    private University createTestUniversity() {
+        Region region = new Region("ASIA", "아시아권");
+        Country country = new Country("KR", "대한민국", region);
+        return new University(
+                1L,
+                "서울대학교",
+                "Seoul National University",
+                "SNU",
+                "https://www.snu.ac.kr",
+                "https://english.snu.ac.kr",
+                "https://accommodation.snu.ac.kr",
+                "https://logo.snu.ac.kr",
+                "https://background.snu.ac.kr",
+                "서울에 위치한 최고의 대학",
+                country,
+                region
+        );
+    }
+
+    private UniversityInfoForApply createTestUniversityInfoForApply(University university) {
+        LanguageRequirement languageRequirement = new LanguageRequirement(
+                1L,
+                LanguageTestType.TOEFL_IBT,
+                "90",
+                null
+        );
+        return new UniversityInfoForApply(
+                1L,
+                "2025-1-a",
+                "서울대학교",
+                100,
+                TuitionFeeType.HOME_UNIVERSITY_PAYMENT,
+                SemesterAvailableForDispatch.IRRELEVANT,
+                "4학기 이상",
+                "TOEFL iBT 90 이상",
+                "3.0/4.5",
+                "4.5",
+                "지원 상세 정보",
+                "전공 상세 정보",
+                "기숙사 상세 정보",
+                "영어 강좌 상세 정보",
+                "기타 상세 정보",
+                new HashSet<>(List.of(languageRequirement)),
+                university
+        );
+    }
+}

--- a/src/test/java/com/example/solidconnection/unit/university/service/UniversityQueryServiceTest.java
+++ b/src/test/java/com/example/solidconnection/unit/university/service/UniversityQueryServiceTest.java
@@ -69,7 +69,7 @@ class UniversityQueryServiceTest {
 
 
     @Test
-    @DisplayName("유효한 ID로 상세 조회하면 대학 정보를 반환한다")
+    @DisplayName("유효한_ID로_상세_조회하면_대학_정보를_반환한다()")
     void shouldReturnUniversityDetailsWhenValidIdProvided() {
         // given
         Long universityInfoForApplyId = testUniversityInfoForApply.getId();
@@ -89,7 +89,7 @@ class UniversityQueryServiceTest {
     }
 
     @Test
-    @DisplayName("존재하지 않는 ID로 조회하면 예외를 반환한다")
+    @DisplayName("존재하지_않는_ID로_조회하면_예외를_반환한다()")
     void shouldThrowExceptionWhenInvalidIdProvided() {
         // given
         Long invalidId = 999L;
@@ -107,7 +107,7 @@ class UniversityQueryServiceTest {
     }
 
     @Test
-    @DisplayName("검색 조건이 없는 경우 전체 대학 목록을 반환한다")
+    @DisplayName("검색_조건이_없는_경우_전체_대학_목록을_반환한다()")
     void shouldReturnAllUniversitiesWhenNoSearchConditionProvided() {
         // given
         List<UniversityInfoForApply> universityList = List.of(testUniversityInfoForApply);
@@ -131,7 +131,7 @@ class UniversityQueryServiceTest {
     }
 
     @Test
-    @DisplayName("검색 조건(region, keyword)을 만족하는 대학 목록을 반환한다")
+    @DisplayName("검색_조건(region,_keyword)을_만족하는_대학_목록을_반환한다()")
     void shouldReturnFilteredUniversitiesWhenSearchConditionProvided() {
         // given
         String region = "ASIA";
@@ -159,7 +159,7 @@ class UniversityQueryServiceTest {
 
 
     @Test
-    @DisplayName("검색 조건(region, keyword, testType, testScore)을 만족하는 대학 목록을 반환한다")
+    @DisplayName("검색_조건(region,_keyword,_testType,_testScore)을_만족하는_대학_목록을_반환한다()")
     void shouldReturnFilteredUniversitiesWhenFullSearchConditionProvided() {
         // given
         String region = "ASIA";
@@ -188,7 +188,7 @@ class UniversityQueryServiceTest {
     }
 
     @Test
-    @DisplayName("검색 조건을 만족하지 않을 경우 결과가 비어 있다")
+    @DisplayName("검색_조건을_만족하지_않을_경우_결과가_비어_있다()")
     void shouldReturnEmptyListWhenSearchConditionNotMet() {
         // given
         String region = "EUROPE";

--- a/src/test/java/com/example/solidconnection/unit/university/service/UniversityRecommendServiceTest.java
+++ b/src/test/java/com/example/solidconnection/unit/university/service/UniversityRecommendServiceTest.java
@@ -1,0 +1,270 @@
+package com.example.solidconnection.unit.university.service;
+
+import com.example.solidconnection.custom.exception.CustomException;
+import com.example.solidconnection.custom.exception.ErrorCode;
+import com.example.solidconnection.entity.Country;
+import com.example.solidconnection.entity.Region;
+import com.example.solidconnection.siteuser.domain.SiteUser;
+import com.example.solidconnection.siteuser.repository.SiteUserRepository;
+import com.example.solidconnection.type.*;
+import com.example.solidconnection.university.domain.*;
+import com.example.solidconnection.university.dto.UniversityInfoForApplyPreviewResponse;
+import com.example.solidconnection.university.dto.UniversityRecommendsResponse;
+import com.example.solidconnection.university.repository.UniversityInfoForApplyRepository;
+import com.example.solidconnection.university.service.GeneralRecommendUniversities;
+import com.example.solidconnection.university.service.UniversityRecommendService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.*;
+
+import static java.util.stream.IntStream.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("대학교 추천 서비스 테스트")
+class UniversityRecommendServiceTest {
+
+    @InjectMocks
+    private UniversityRecommendService universityRecommendService;
+
+    @Mock
+    private UniversityInfoForApplyRepository universityInfoForApplyRepository;
+
+    @Mock
+    private GeneralRecommendUniversities generalRecommendUniversities;
+
+    @Mock
+    private SiteUserRepository siteUserRepository;
+
+    private SiteUser testUser;
+    private List<UniversityInfoForApply> testUniversities;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(universityRecommendService, "term", "2025-1-a");
+        testUser = createTestUser();
+        testUniversities = createTestUniversities();
+    }
+
+    @Test
+    @DisplayName("일반 추천 목록을 정상적으로 반환한다")
+    void getGeneralRecommends_ShouldReturnShuffledAndConvertedList() {
+        // given
+        List<UniversityInfoForApply> generalUniversities =
+                range(0, UniversityRecommendService.RECOMMEND_UNIVERSITY_NUM)
+                        .mapToObj(this::createUniversityInfo)
+                        .toList();
+        when(generalRecommendUniversities.getRecommendUniversities())
+                .thenReturn(generalUniversities);
+
+        // when
+        UniversityRecommendsResponse response = universityRecommendService.getGeneralRecommends();
+
+        // then
+        assertThat(response.recommendedUniversities()).isNotNull();
+        assertThat(response.recommendedUniversities())
+                .hasSize(UniversityRecommendService.RECOMMEND_UNIVERSITY_NUM);
+        response.recommendedUniversities().forEach(preview -> {
+            assertThat(preview).isInstanceOf(UniversityInfoForApplyPreviewResponse.class);
+            assertThat(preview.studentCapacity()).isEqualTo(3);
+            assertThat(preview.region()).isEqualTo("유럽권");
+            assertThat(preview.country()).isEqualTo("프랑스");
+        });
+        assertThat(response.recommendedUniversities())
+                .extracting("koreanName")
+                .isNotEqualTo(generalUniversities.stream()
+                        .map(UniversityInfoForApply::getKoreanName)
+                        .toList());
+        // verify
+        verify(generalRecommendUniversities).getRecommendUniversities();
+    }
+
+    @Test
+    @DisplayName("개인화 추천 목록을 정상적으로 반환한다")
+    void getPersonalRecommends_ShouldReturnPersonalizedAndShuffledList() {
+
+        // given
+        String email = "test@example.com";
+        List<UniversityInfoForApply> personalRecommends = new ArrayList<>(
+                range(0, UniversityRecommendService.RECOMMEND_UNIVERSITY_NUM)
+                        .mapToObj(this::createUniversityInfo)
+                        .toList()
+        );
+
+
+        when(siteUserRepository.getByEmail(email)).thenReturn(testUser);
+        when(universityInfoForApplyRepository
+                .findUniversityInfoForAppliesBySiteUsersInterestedCountryOrRegionAndTerm(any(), anyString()))
+                .thenReturn(personalRecommends);
+
+        // when
+        List<UniversityInfoForApply> originalList = new ArrayList<>(personalRecommends);
+        UniversityRecommendsResponse response = universityRecommendService.getPersonalRecommends(email);
+
+        // then
+        assertThat(response.recommendedUniversities()).isNotNull();
+        assertThat(response.recommendedUniversities())
+                .hasSize(UniversityRecommendService.RECOMMEND_UNIVERSITY_NUM);
+        assertThat(response.recommendedUniversities())
+                .extracting("koreanName")
+                .containsExactlyInAnyOrderElementsOf(originalList.stream()
+                        .map(UniversityInfoForApply::getKoreanName)
+                        .toList());
+        List<String> shuffledOrder = response.recommendedUniversities().stream()
+                .map(UniversityInfoForApplyPreviewResponse::koreanName)
+                .toList();
+        assertThat(shuffledOrder)
+                .isNotEqualTo(originalList.stream()
+                        .map(UniversityInfoForApply::getKoreanName)
+                        .toList());
+
+        // verify
+        verify(siteUserRepository).getByEmail(email);
+        verify(universityInfoForApplyRepository)
+                .findUniversityInfoForAppliesBySiteUsersInterestedCountryOrRegionAndTerm(any(), anyString());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자의 경우 예외를 반환한다")
+    void getPersonalRecommends_WithInvalidUser_ShouldThrowException() {
+        // given
+        String email = "invalid@example.com";
+        when(siteUserRepository.getByEmail(email))
+                .thenThrow(new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> universityRecommendService.getPersonalRecommends(email));
+        assertThat(exception.getCode()).isEqualTo(ErrorCode.USER_NOT_FOUND.getCode());
+
+        // verify
+        verify(siteUserRepository).getByEmail(email);
+    }
+
+    @Test
+    @DisplayName("개인화 추천이 부족할 경우 일반 추천으로 보충한다")
+    void getPersonalRecommends_WithInsufficientRecommends_ShouldSupplementWithGeneral() {
+        // given
+        String email = "test@example.com";
+        List<UniversityInfoForApply> personalRecommends = new ArrayList<>();
+        personalRecommends.add(testUniversities.get(0));
+        List<UniversityInfoForApply> generalRecommends = createAdditionalUniversities();
+        when(siteUserRepository.getByEmail(email)).thenReturn(testUser);
+        when(universityInfoForApplyRepository
+                .findUniversityInfoForAppliesBySiteUsersInterestedCountryOrRegionAndTerm(any(), anyString()))
+                .thenReturn(personalRecommends);
+        when(generalRecommendUniversities.getRecommendUniversities())
+                .thenReturn(generalRecommends);
+
+        // when
+        UniversityRecommendsResponse response = universityRecommendService.getPersonalRecommends(email);
+
+        // then
+        assertThat(response.recommendedUniversities()).isNotNull();
+        assertThat(response.recommendedUniversities())
+                .hasSize(UniversityRecommendService.RECOMMEND_UNIVERSITY_NUM);
+        List<String> allKoreanNames = response.recommendedUniversities().stream()
+                .map(UniversityInfoForApplyPreviewResponse::koreanName)
+                .toList();
+        assertThat(allKoreanNames).doesNotHaveDuplicates();
+        response.recommendedUniversities().forEach(preview -> {
+            assertThat(preview).isInstanceOf(UniversityInfoForApplyPreviewResponse.class);
+            assertThat(preview.studentCapacity()).isEqualTo(3);
+            assertThat(preview.region()).isEqualTo("유럽권");
+            assertThat(preview.country()).isEqualTo("프랑스");
+        });
+
+        // verify
+        verify(siteUserRepository).getByEmail(email);
+        verify(universityInfoForApplyRepository)
+                .findUniversityInfoForAppliesBySiteUsersInterestedCountryOrRegionAndTerm(any(), anyString());
+        verify(generalRecommendUniversities).getRecommendUniversities();
+    }
+
+    private SiteUser createTestUser() {
+        return new SiteUser(
+                "test@example.com",
+                "nickname",
+                "profileImageUrl",
+                "1999-01-01",
+                PreparationStatus.CONSIDERING,
+                Role.MENTEE,
+                Gender.MALE
+        );
+    }
+
+    private List<UniversityInfoForApply> createTestUniversities() {
+        List<UniversityInfoForApply> universities = new ArrayList<>();
+        for(int i = 0; i < UniversityRecommendService.RECOMMEND_UNIVERSITY_NUM + 2; i++) {
+            universities.add(createUniversityInfo(i));
+        }
+        return universities;
+    }
+
+    private List<UniversityInfoForApply> createAdditionalUniversities() {
+        List<UniversityInfoForApply> universities = new ArrayList<>();
+        for(int i = UniversityRecommendService.RECOMMEND_UNIVERSITY_NUM; i < UniversityRecommendService.RECOMMEND_UNIVERSITY_NUM * 2; i++) {
+            universities.add(createUniversityInfo(i));
+        }
+        return universities;
+    }
+
+    private UniversityInfoForApply createUniversityInfo(int index) {
+        Region region = new Region("EUROPE", "유럽권");
+        Country country = new Country("FR", "프랑스", region);
+
+        University university = new University(
+                (long) index,
+                "University" + index,
+                "University" + index,
+                "univ" + index,
+                "https://example.com/life" + index,
+                "https://example.com/courses" + index,
+                "https://example.com/accommodation" + index,
+                "https://example.com/logo" + index,
+                "https://example.com/background" + index,
+                "details" + index,
+                country,
+                region
+        );
+
+        Set<LanguageRequirement> requirements = new HashSet<>();
+        requirements.add(new LanguageRequirement(
+                (long) index,
+                LanguageTestType.TOEFL_IBT,
+                "90",
+                null
+        ));
+
+        return new UniversityInfoForApply(
+                (long) index,
+                "2025-1-a",
+                "University" + index,
+                3,
+                TuitionFeeType.HOME_UNIVERSITY_PAYMENT,
+                SemesterAvailableForDispatch.IRRELEVANT,
+                "4학기",
+                "어학 요구사항" + index,
+                "3.0/4.5",
+                "4.5",
+                "지원 상세" + index,
+                "전공 상세" + index,
+                "기숙사 상세" + index,
+                "영어 강좌 상세" + index,
+                "기타 상세" + index,
+                requirements,
+                university
+        );
+    }
+}

--- a/src/test/java/com/example/solidconnection/unit/university/service/UniversityRecommendServiceTest.java
+++ b/src/test/java/com/example/solidconnection/unit/university/service/UniversityRecommendServiceTest.java
@@ -58,7 +58,7 @@ class UniversityRecommendServiceTest {
     }
 
     @Test
-    @DisplayName("일반 추천 목록을 정상적으로 반환한다")
+    @DisplayName("일반_추천_목록을_정상적으로_반환한다()")
     void getGeneralRecommendsShouldReturnShuffledAndConvertedList() {
         // given
         List<UniversityInfoForApply> generalUniversities =
@@ -91,7 +91,7 @@ class UniversityRecommendServiceTest {
     }
 
     @Test
-    @DisplayName("개인화 추천 목록을 정상적으로 반환한다")
+    @DisplayName("개인화_추천_목록을_정상적으로_반환한다()")
     void getPersonalRecommendsShouldReturnPersonalizedAndShuffledList() {
 
         // given
@@ -136,7 +136,7 @@ class UniversityRecommendServiceTest {
     }
 
     @Test
-    @DisplayName("존재하지 않는 사용자의 경우 예외를 반환한다")
+    @DisplayName("존재하지_않는_사용자의_경우_예외를_반환한다()")
     void getPersonalRecommendsWithInvalidUserShouldThrowException() {
         // given
         String email = "invalid@example.com";
@@ -153,7 +153,7 @@ class UniversityRecommendServiceTest {
     }
 
     @Test
-    @DisplayName("개인화 추천이 부족할 경우 일반 추천으로 보충한다")
+    @DisplayName("개인화_추천이_부족할_경우_일반_추천으로_보충한다()")
     void getPersonalRecommendsWithInsufficientRecommendsShouldSupplementWithGeneral() {
         // given
         String email = "test@example.com";

--- a/src/test/java/com/example/solidconnection/unit/university/service/UniversityRecommendServiceTest.java
+++ b/src/test/java/com/example/solidconnection/unit/university/service/UniversityRecommendServiceTest.java
@@ -59,7 +59,7 @@ class UniversityRecommendServiceTest {
 
     @Test
     @DisplayName("일반 추천 목록을 정상적으로 반환한다")
-    void getGeneralRecommends_ShouldReturnShuffledAndConvertedList() {
+    void getGeneralRecommendsShouldReturnShuffledAndConvertedList() {
         // given
         List<UniversityInfoForApply> generalUniversities =
                 range(0, UniversityRecommendService.RECOMMEND_UNIVERSITY_NUM)
@@ -92,7 +92,7 @@ class UniversityRecommendServiceTest {
 
     @Test
     @DisplayName("개인화 추천 목록을 정상적으로 반환한다")
-    void getPersonalRecommends_ShouldReturnPersonalizedAndShuffledList() {
+    void getPersonalRecommendsShouldReturnPersonalizedAndShuffledList() {
 
         // given
         String email = "test@example.com";
@@ -137,7 +137,7 @@ class UniversityRecommendServiceTest {
 
     @Test
     @DisplayName("존재하지 않는 사용자의 경우 예외를 반환한다")
-    void getPersonalRecommends_WithInvalidUser_ShouldThrowException() {
+    void getPersonalRecommendsWithInvalidUserShouldThrowException() {
         // given
         String email = "invalid@example.com";
         when(siteUserRepository.getByEmail(email))
@@ -154,7 +154,7 @@ class UniversityRecommendServiceTest {
 
     @Test
     @DisplayName("개인화 추천이 부족할 경우 일반 추천으로 보충한다")
-    void getPersonalRecommends_WithInsufficientRecommends_ShouldSupplementWithGeneral() {
+    void getPersonalRecommendsWithInsufficientRecommendsShouldSupplementWithGeneral() {
         // given
         String email = "test@example.com";
         List<UniversityInfoForApply> personalRecommends = new ArrayList<>();
@@ -197,7 +197,7 @@ class UniversityRecommendServiceTest {
                 "test@example.com",
                 "nickname",
                 "profileImageUrl",
-                "1999-01-01",
+                "1999-10-21",
                 PreparationStatus.CONSIDERING,
                 Role.MENTEE,
                 Gender.MALE


### PR DESCRIPTION
## 관련 이슈

- resolves: #131 

## 작업 내용

<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<img width="519" alt="테스트코드" src="https://github.com/user-attachments/assets/4c499d4b-797f-4e97-b9d4-fe39bf6219dd" />

단위 테스트 코드 추가
- 대학 추천 서비스
1. 일반 추천 목록 반환 테스트
2. 개인화 추천 목록 반환 테스트
3. 개인화 추천이 섞이는지 검증
4. 사용자 존재하지 않을 시 예외 처리 테스트
5. 개인화 추천이 부족할 경우 일반 추천으로 보충하는 로직 검증

- 대학 좋아요 서비스
1. 특정 대학에 대해 사용자가 좋아요 상태인지 확인하는 테스트
2. 좋아요 상태일 경우 True 반환, 좋아요 상태가 아닐 경우 False 반환 테스트
3. 사용자가 대학 좋아요를 추가/취소하는 로직 검증
4. 좋아요 추가 시 성공 메시지 반환, 좋아요 취소 시 취소 메시지 반환 테스트
5. 존재하지 않는 대학 ID로 요청 시 예외 처리 테스트

- 대학 조회 및 검색
1. 대학 상세 조회 테스트
2. 대학 검색 조건 테스트

- 카카오 로그인 서비스
1. 기존 회원 로그인 시 로그인 정보 반환 테스트
2. 신규 회원 로그인 시 회원가입 정보 반환 테스트
3. 탈퇴한 회원 로그인 시 탈퇴일 초기화 및 로그인 정보 반환 테스트
4. 인증 코드 만료 시, 리다이렉트 URI 불일치 시, 카카오 사용자 정보 조회 실패 시 예외 반환 테스트 

- 회원가입 서비스
1. 정상 회원가입 시 회원가입 성공 후 토큰 반환 테스트
2. 중복된 닉네임/이메일로 회원가입 시 예외 반환 테스트
3. 만료되거나 이미 사용된 카카오 토큰으로 회원가입 시 예외 반환 테스트

- 인증 서비스
1. 로그아웃 요청 시 리프레시 토큰 무효화 테스트
2. 회원탈퇴 요청 시 탈퇴일자 설정 테스트
3. 존재하지 않는 이메일로 회원탈퇴 시 예외 반환 테스트
4. 유효한 리프레시 토큰으로 재발급 요청 시 새 엑세스 토큰 반환 테스트
5. 만료된 리프레시 토큰으로 재발급 요청 시 예외 반환 테스트


- 리팩토링
1 .기존에는 service와 repository 폴더에 모든 테스트 코드가 혼재되어 있었으나, 이를 도메인별로 정리
<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->
1. 대학 추천 서비스에서 개인화 추천 검증 로직이 셔플된 결과로 인해 간헐적으로 테스트가 실패할 수 있는 이슈가 있습니다.(셔플 후에도 순서가 동일한 경우)


## 리뷰 요구사항 (선택)
1. 리팩토링된 테스트 코드 구조에 대한 개선 사항이 있다면 제안 부탁드립니다.
2. 작성된 단위 테스트가 서비스 로직을 충분히 검증하고 있는지 확인 부탁드립니다.
3. 단위 테스트 작성 방식에서 보완해야 할 점이 있다면 피드백 부탁드립니다.
4. 현재 서비스 로직 관련 단위테스트만 작성했으며, Controller 및 Repository 레이어의 단위 테스트가 필요한지 궁금합니다.
5. InterestedCountyRepository의 스펠링 오타를 발견하였는데 아직 수정하지 않았습니다.
 <img width="755" alt="사진" src="https://github.com/user-attachments/assets/23cbb7de-06ca-4ce5-b46f-7bc0106c8e0a" /> 


<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
