### PR TITLE
refactor: 테스트 컨테이너 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,17 +37,25 @@ dependencies {//todo: 안쓰는 의존성이나 deprecated된 의존성 제거
     implementation 'org.hibernate.validator:hibernate-validator:8.0.1.Final'
     implementation 'jakarta.annotation:jakarta.annotation-api:2.1.1'
     implementation 'org.apache.commons:commons-lang3:3.12.0'
-    testImplementation 'org.mockito:mockito-core:3.3.3'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
 
+    // Lombok
     compileOnly 'org.projectlombok:lombok:1.18.26'
     annotationProcessor 'org.projectlombok:lombok'
+
+    // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'com.h2database:h2:2.2.224'
+    testImplementation 'org.mockito:mockito-core:3.3.3'
     testImplementation 'io.rest-assured:rest-assured:5.4.0'
 
-    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    // Testcontainers
+    testImplementation 'org.testcontainers:testcontainers'
+    testImplementation 'org.testcontainers:junit-jupiter'
+    testImplementation 'org.testcontainers:mysql'
+    testImplementation 'com.redis:testcontainers-redis'
+
     annotationProcessor(
             'com.querydsl:querydsl-apt:5.0.0:jakarta',
             'jakarta.persistence:jakarta.persistence-api:3.1.0',

--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,6 @@ dependencies {//todo: 안쓰는 의존성이나 deprecated된 의존성 제거
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.testcontainers:mysql'
-    testImplementation 'com.redis:testcontainers-redis'
 
     annotationProcessor(
             'com.querydsl:querydsl-apt:5.0.0:jakarta',

--- a/src/test/java/com/example/solidconnection/concurrency/PostLikeCountConcurrencyTest.java
+++ b/src/test/java/com/example/solidconnection/concurrency/PostLikeCountConcurrencyTest.java
@@ -7,6 +7,7 @@ import com.example.solidconnection.post.repository.PostRepository;
 import com.example.solidconnection.post.service.PostService;
 import com.example.solidconnection.siteuser.domain.SiteUser;
 import com.example.solidconnection.siteuser.repository.SiteUserRepository;
+import com.example.solidconnection.support.TestContainerSpringBootTest;
 import com.example.solidconnection.type.Gender;
 import com.example.solidconnection.type.PostCategory;
 import com.example.solidconnection.type.PreparationStatus;
@@ -16,8 +17,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -26,8 +25,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@SpringBootTest
-@ActiveProfiles("test")
+@TestContainerSpringBootTest
 @DisplayName("게시글 좋아요 동시성 테스트")
 class PostLikeCountConcurrencyTest {
 

--- a/src/test/java/com/example/solidconnection/concurrency/PostViewCountConcurrencyTest.java
+++ b/src/test/java/com/example/solidconnection/concurrency/PostViewCountConcurrencyTest.java
@@ -7,6 +7,7 @@ import com.example.solidconnection.post.repository.PostRepository;
 import com.example.solidconnection.service.RedisService;
 import com.example.solidconnection.siteuser.domain.SiteUser;
 import com.example.solidconnection.siteuser.repository.SiteUserRepository;
+import com.example.solidconnection.support.TestContainerSpringBootTest;
 import com.example.solidconnection.type.Gender;
 import com.example.solidconnection.type.PostCategory;
 import com.example.solidconnection.type.PreparationStatus;
@@ -17,8 +18,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -28,8 +27,7 @@ import java.util.concurrent.TimeUnit;
 import static com.example.solidconnection.type.RedisConstants.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@SpringBootTest
-@ActiveProfiles("test")
+@TestContainerSpringBootTest
 @DisplayName("게시글 조회수 동시성 테스트")
 public class PostViewCountConcurrencyTest {
 

--- a/src/test/java/com/example/solidconnection/concurrency/ThunderingHerdTest.java
+++ b/src/test/java/com/example/solidconnection/concurrency/ThunderingHerdTest.java
@@ -3,6 +3,7 @@ package com.example.solidconnection.concurrency;
 import com.example.solidconnection.application.service.ApplicationQueryService;
 import com.example.solidconnection.siteuser.domain.SiteUser;
 import com.example.solidconnection.siteuser.repository.SiteUserRepository;
+import com.example.solidconnection.support.TestContainerSpringBootTest;
 import com.example.solidconnection.type.Gender;
 import com.example.solidconnection.type.PreparationStatus;
 import com.example.solidconnection.type.Role;
@@ -10,9 +11,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.test.context.ActiveProfiles;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -22,8 +21,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-@SpringBootTest
-@ActiveProfiles("test")
+@TestContainerSpringBootTest
 @DisplayName("ThunderingHerd 테스트")
 public class ThunderingHerdTest {
     @Autowired

--- a/src/test/java/com/example/solidconnection/database/DatabaseConnectionTest.java
+++ b/src/test/java/com/example/solidconnection/database/DatabaseConnectionTest.java
@@ -1,5 +1,6 @@
 package com.example.solidconnection.database;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,6 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+@Disabled
 @AutoConfigureTestDatabase(connection = EmbeddedDatabaseConnection.H2, replace = AutoConfigureTestDatabase.Replace.ANY)
 @ActiveProfiles("test")
 @DataJpaTest

--- a/src/test/java/com/example/solidconnection/database/RedisConnectionTest.java
+++ b/src/test/java/com/example/solidconnection/database/RedisConnectionTest.java
@@ -1,5 +1,6 @@
 package com.example.solidconnection.database;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -9,6 +10,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Disabled
 @ActiveProfiles("test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class RedisConnectionTest {

--- a/src/test/java/com/example/solidconnection/e2e/BaseEndToEndTest.java
+++ b/src/test/java/com/example/solidconnection/e2e/BaseEndToEndTest.java
@@ -1,16 +1,14 @@
 package com.example.solidconnection.e2e;
 
 import com.example.solidconnection.support.DatabaseClearExtension;
+import com.example.solidconnection.support.TestContainerSpringBootTest;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
-import org.springframework.test.context.ActiveProfiles;
 
+@TestContainerSpringBootTest
 @ExtendWith(DatabaseClearExtension.class)
-@ActiveProfiles("test")
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 abstract class BaseEndToEndTest {
 
     @LocalServerPort

--- a/src/test/java/com/example/solidconnection/e2e/SignUpTest.java
+++ b/src/test/java/com/example/solidconnection/e2e/SignUpTest.java
@@ -105,7 +105,7 @@ class SignUpTest extends BaseEndToEndTest {
         assertAll(
                 "관심 지역과 나라 정보를 저장한다.",
                 () -> assertThat(interestedRegions).containsExactlyInAnyOrder(region),
-                () -> assertThat(interestedCountries).containsExactlyElementsOf(countries)
+                () -> assertThat(interestedCountries).containsExactlyInAnyOrderElementsOf(countries)
         );
 
         assertThat(redisTemplate.opsForValue().get(TokenType.REFRESH.addTokenPrefixToSubject(email)))

--- a/src/test/java/com/example/solidconnection/e2e/UniversityDataSetUpEndToEndTest.java
+++ b/src/test/java/com/example/solidconnection/e2e/UniversityDataSetUpEndToEndTest.java
@@ -5,6 +5,7 @@ import com.example.solidconnection.entity.Region;
 import com.example.solidconnection.repositories.CountryRepository;
 import com.example.solidconnection.repositories.RegionRepository;
 import com.example.solidconnection.support.DatabaseClearExtension;
+import com.example.solidconnection.support.TestContainerSpringBootTest;
 import com.example.solidconnection.type.LanguageTestType;
 import com.example.solidconnection.university.domain.LanguageRequirement;
 import com.example.solidconnection.university.domain.University;
@@ -17,9 +18,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
-import org.springframework.test.context.ActiveProfiles;
 
 import java.util.HashSet;
 
@@ -27,8 +26,7 @@ import static com.example.solidconnection.type.SemesterAvailableForDispatch.ONE_
 import static com.example.solidconnection.type.TuitionFeeType.HOME_UNIVERSITY_PAYMENT;
 
 @ExtendWith(DatabaseClearExtension.class)
-@ActiveProfiles("test")
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestContainerSpringBootTest
 abstract class UniversityDataSetUpEndToEndTest {
 
     public static Region 영미권;

--- a/src/test/java/com/example/solidconnection/support/DatabaseCleaner.java
+++ b/src/test/java/com/example/solidconnection/support/DatabaseCleaner.java
@@ -32,17 +32,18 @@ public class DatabaseCleaner {
     }
 
     private void truncate() {
-        em.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate();
+        em.createNativeQuery("SET FOREIGN_KEY_CHECKS = 0").executeUpdate();
         getTruncateQueries().forEach(query -> em.createNativeQuery(query).executeUpdate());
-        em.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();
+        em.createNativeQuery("SET FOREIGN_KEY_CHECKS = 1").executeUpdate();
     }
 
     @SuppressWarnings("unchecked")
     private List<String> getTruncateQueries() {
         String sql = """
-                SELECT Concat('TRUNCATE TABLE ', TABLE_NAME, ' RESTART IDENTITY', ';') AS q
+                SELECT CONCAT('TRUNCATE TABLE ', TABLE_NAME, ';') AS q
                 FROM INFORMATION_SCHEMA.TABLES
-                WHERE TABLE_SCHEMA = 'PUBLIC'
+                WHERE TABLE_SCHEMA = (SELECT DATABASE())
+                AND TABLE_TYPE = 'BASE TABLE'
                 """;
 
         return em.createNativeQuery(sql).getResultList();

--- a/src/test/java/com/example/solidconnection/support/MySQLTestContainer.java
+++ b/src/test/java/com/example/solidconnection/support/MySQLTestContainer.java
@@ -1,0 +1,34 @@
+package com.example.solidconnection.support;
+
+import jakarta.annotation.PostConstruct;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+
+import javax.sql.DataSource;
+
+@TestConfiguration
+public class MySQLTestContainer {
+
+    @Container
+    private static final MySQLContainer<?> CONTAINER = new MySQLContainer<>("mysql:8.0");
+
+    @Bean
+    public DataSource dataSource() {
+        return DataSourceBuilder.create()
+                .url(CONTAINER.getJdbcUrl())
+                .username(CONTAINER.getUsername())
+                .password(CONTAINER.getPassword())
+                .driverClassName(CONTAINER.getDriverClassName())
+                .build();
+    }
+
+    @PostConstruct
+    void startContainer() {
+        if (!CONTAINER.isRunning()) {
+            CONTAINER.start();
+        }
+    }
+}

--- a/src/test/java/com/example/solidconnection/support/RedisTestContainer.java
+++ b/src/test/java/com/example/solidconnection/support/RedisTestContainer.java
@@ -1,0 +1,28 @@
+package com.example.solidconnection.support;
+
+import jakarta.annotation.PostConstruct;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+
+@TestConfiguration
+public class RedisTestContainer {
+
+    @Container
+    private static final GenericContainer<?> CONTAINER = new GenericContainer<>("redis:7.0");
+
+    @DynamicPropertySource
+    static void redisProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.redis.host", CONTAINER::getHost);
+        registry.add("spring.redis.port", CONTAINER::getFirstMappedPort);
+    }
+
+    @PostConstruct
+    void startContainer() {
+        if (!CONTAINER.isRunning()) {
+            CONTAINER.start();
+        }
+    }
+}

--- a/src/test/java/com/example/solidconnection/support/TestContainerDataJpaTest.java
+++ b/src/test/java/com/example/solidconnection/support/TestContainerDataJpaTest.java
@@ -1,0 +1,22 @@
+package com.example.solidconnection.support;
+
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
+@Testcontainers
+@Import(MySQLTestContainer.class)
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TestContainerDataJpaTest {
+}

--- a/src/test/java/com/example/solidconnection/support/TestContainerSpringBootTest.java
+++ b/src/test/java/com/example/solidconnection/support/TestContainerSpringBootTest.java
@@ -1,0 +1,22 @@
+package com.example.solidconnection.support;
+
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
+@Testcontainers
+@Import({MySQLTestContainer.class, RedisTestContainer.class})
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TestContainerSpringBootTest {
+}

--- a/src/test/java/com/example/solidconnection/unit/repository/BoardRepositoryTest.java
+++ b/src/test/java/com/example/solidconnection/unit/repository/BoardRepositoryTest.java
@@ -7,6 +7,7 @@ import com.example.solidconnection.post.domain.Post;
 import com.example.solidconnection.post.repository.PostRepository;
 import com.example.solidconnection.siteuser.domain.SiteUser;
 import com.example.solidconnection.siteuser.repository.SiteUserRepository;
+import com.example.solidconnection.support.TestContainerDataJpaTest;
 import com.example.solidconnection.type.Gender;
 import com.example.solidconnection.type.PostCategory;
 import com.example.solidconnection.type.PreparationStatus;
@@ -16,16 +17,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import static com.example.solidconnection.custom.exception.ErrorCode.INVALID_BOARD_CODE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
-@DataJpaTest
-@ActiveProfiles("test")
+@TestContainerDataJpaTest
 @DisplayName("게시판 레포지토리 테스트")
 class BoardRepositoryTest {
     @Autowired

--- a/src/test/java/com/example/solidconnection/unit/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/example/solidconnection/unit/repository/CommentRepositoryTest.java
@@ -9,6 +9,7 @@ import com.example.solidconnection.post.domain.Post;
 import com.example.solidconnection.post.repository.PostRepository;
 import com.example.solidconnection.siteuser.domain.SiteUser;
 import com.example.solidconnection.siteuser.repository.SiteUserRepository;
+import com.example.solidconnection.support.TestContainerDataJpaTest;
 import com.example.solidconnection.type.Gender;
 import com.example.solidconnection.type.PostCategory;
 import com.example.solidconnection.type.PreparationStatus;
@@ -17,8 +18,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -28,9 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-
-@SpringBootTest
-@ActiveProfiles("dev")
+@TestContainerDataJpaTest
 @DisplayName("댓글 레포지토리 테스트")
 class CommentRepositoryTest {
     @Autowired

--- a/src/test/java/com/example/solidconnection/unit/repository/GpaScoreRepositoryTest.java
+++ b/src/test/java/com/example/solidconnection/unit/repository/GpaScoreRepositoryTest.java
@@ -5,6 +5,7 @@ import com.example.solidconnection.score.domain.GpaScore;
 import com.example.solidconnection.score.repository.GpaScoreRepository;
 import com.example.solidconnection.siteuser.domain.SiteUser;
 import com.example.solidconnection.siteuser.repository.SiteUserRepository;
+import com.example.solidconnection.support.TestContainerDataJpaTest;
 import com.example.solidconnection.type.Gender;
 import com.example.solidconnection.type.PreparationStatus;
 import com.example.solidconnection.type.Role;
@@ -12,8 +13,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
@@ -21,8 +20,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DataJpaTest
-@ActiveProfiles("test")
+@TestContainerDataJpaTest
 @DisplayName("학점 레포지토리 테스트")
 @Transactional
 public class GpaScoreRepositoryTest {

--- a/src/test/java/com/example/solidconnection/unit/repository/LanguageTestScoreRepositoryTest.java
+++ b/src/test/java/com/example/solidconnection/unit/repository/LanguageTestScoreRepositoryTest.java
@@ -5,6 +5,7 @@ import com.example.solidconnection.score.domain.LanguageTestScore;
 import com.example.solidconnection.score.repository.LanguageTestScoreRepository;
 import com.example.solidconnection.siteuser.domain.SiteUser;
 import com.example.solidconnection.siteuser.repository.SiteUserRepository;
+import com.example.solidconnection.support.TestContainerDataJpaTest;
 import com.example.solidconnection.type.Gender;
 import com.example.solidconnection.type.LanguageTestType;
 import com.example.solidconnection.type.PreparationStatus;
@@ -13,8 +14,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
@@ -22,8 +21,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DataJpaTest
-@ActiveProfiles("test")
+@TestContainerDataJpaTest
 @DisplayName("어학성적 레포지토리 테스트")
 @Transactional
 public class LanguageTestScoreRepositoryTest {

--- a/src/test/java/com/example/solidconnection/unit/repository/PostLikeRepositoryTest.java
+++ b/src/test/java/com/example/solidconnection/unit/repository/PostLikeRepositoryTest.java
@@ -3,12 +3,13 @@ package com.example.solidconnection.unit.repository;
 import com.example.solidconnection.board.domain.Board;
 import com.example.solidconnection.board.repository.BoardRepository;
 import com.example.solidconnection.custom.exception.CustomException;
+import com.example.solidconnection.post.domain.Post;
 import com.example.solidconnection.post.domain.PostLike;
 import com.example.solidconnection.post.repository.PostLikeRepository;
-import com.example.solidconnection.post.domain.Post;
 import com.example.solidconnection.post.repository.PostRepository;
 import com.example.solidconnection.siteuser.domain.SiteUser;
 import com.example.solidconnection.siteuser.repository.SiteUserRepository;
+import com.example.solidconnection.support.TestContainerDataJpaTest;
 import com.example.solidconnection.type.Gender;
 import com.example.solidconnection.type.PostCategory;
 import com.example.solidconnection.type.PreparationStatus;
@@ -17,8 +18,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import static com.example.solidconnection.custom.exception.ErrorCode.INVALID_POST_LIKE;
@@ -26,8 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@DataJpaTest
-@ActiveProfiles("test")
+@TestContainerDataJpaTest
 @DisplayName("게시글 좋아요 레포지토리 테스트")
 class PostLikeRepositoryTest {
     @Autowired

--- a/src/test/java/com/example/solidconnection/unit/repository/PostRepositoryTest.java
+++ b/src/test/java/com/example/solidconnection/unit/repository/PostRepositoryTest.java
@@ -8,6 +8,7 @@ import com.example.solidconnection.post.domain.Post;
 import com.example.solidconnection.post.repository.PostRepository;
 import com.example.solidconnection.siteuser.domain.SiteUser;
 import com.example.solidconnection.siteuser.repository.SiteUserRepository;
+import com.example.solidconnection.support.TestContainerDataJpaTest;
 import com.example.solidconnection.type.Gender;
 import com.example.solidconnection.type.PostCategory;
 import com.example.solidconnection.type.PreparationStatus;
@@ -16,20 +17,17 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import static com.example.solidconnection.custom.exception.ErrorCode.INVALID_POST_ID;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@DataJpaTest
-@ActiveProfiles("test")
+@TestContainerDataJpaTest
 @DisplayName("게시글 레포지토리 테스트")
 class PostRepositoryTest {
     @Autowired


### PR DESCRIPTION
## 관련 이슈

- resolves: #119 

## 작업 내용

테스트 컨테이너를 적용했습니다.
도입 배경 / 적용 방법은 위키에 정리해두었습니다.
https://github.com/solid-connection/solid-connect-server/wiki/TestContainers-도입기

## 특이 사항
테스트 실행 시간이 제 컴퓨터 기준 13s → 25s 로 늘어났습니다 🐢
하지만 위 위키에서 정리한 4가지 장점이, 테스트 실행 시간 증가로 인한 단점보다 더 크다고 생각합니다.
이에 대한 다른 분들의 생각을 듣고 싶습니다.

## 리뷰 요구사항 (선택)
1/
❗️이 브랜치 pull 받아서, 본인 컴퓨터에서는 테스트 시간 얼마나 늘어났는지 알려주세요❗️
다른 분들이 불편할만큼 테스트 시간이 늘어난거라면 도입을 재고해봐야 할 것 같습니다😞

2/
그리고 '데이터베이스 연결 및 테이블 존재 여부 테스트'랑 '레디스 연결 및 작동 테스트'는
전체 테스트에 포함시키지 않도록 Disabled 어노테이션 달아줬습니다.
연결에 문제가 있다고 생각되시는 분들만 Disabled 해제하셔서 테스트하는게 좋을 것 다 생각했습니다.
괜찮나요?

3/
application-db.yml 에도 변경사항 생겨서 PR 만들어두었어요. https://github.com/solid-connection/solid-connect-secret/pull/3
이 코드 내용에 대해서 다 approve 하시면 
secret에 올려둔 PR머지 → 이 PR에 서브모듈 HEAD 업데이터 커밋 추가 → 머지
하겠습니다.