### PR TITLE
test: 게시판 관련 통합테스트 코드 추가

### DIFF
--- a/src/test/java/com/example/solidconnection/board/service/BoardServiceTest.java
+++ b/src/test/java/com/example/solidconnection/board/service/BoardServiceTest.java
@@ -1,0 +1,72 @@
+package com.example.solidconnection.board.service;
+
+import com.example.solidconnection.post.domain.Post;
+import com.example.solidconnection.post.dto.BoardFindPostResponse;
+import com.example.solidconnection.support.integration.BaseIntegrationTest;
+import com.example.solidconnection.type.BoardCode;
+import com.example.solidconnection.type.PostCategory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("게시판 서비스 테스트")
+class BoardServiceTest extends BaseIntegrationTest {
+
+    @Autowired
+    private BoardService boardService;
+
+    @Test
+    void 게시판_코드와_카테고리로_게시글_목록을_조회한다() {
+        // given
+        List<Post> posts = List.of(
+                미주권_자유게시글, 아시아권_자유게시글, 유럽권_자유게시글, 자유게시판_자유게시글,
+                미주권_질문게시글, 아시아권_질문게시글, 유럽권_질문게시글, 자유게시판_질문게시글
+        );
+        List<Post> expectedPosts = posts.stream()
+                .filter(post -> post.getCategory().equals(PostCategory.자유) && post.getBoard().getCode().equals(BoardCode.FREE.name()))
+                .toList();
+        List<BoardFindPostResponse> expectedResponses = BoardFindPostResponse.from(expectedPosts);
+
+        // when
+        List<BoardFindPostResponse> actualResponses = boardService.findPostsByCodeAndPostCategory(
+                BoardCode.FREE.name(),
+                PostCategory.자유.name()
+        );
+
+        // then
+        assertThat(actualResponses)
+                .usingRecursiveComparison()
+                .ignoringFieldsOfTypes(ZonedDateTime.class)
+                .isEqualTo(expectedResponses);
+    }
+
+    @Test
+    void 전체_카테고리로_조회시_해당_게시판의_모든_게시글을_조회한다() {
+        // given
+        List<Post> posts = List.of(
+                미주권_자유게시글, 아시아권_자유게시글, 유럽권_자유게시글, 자유게시판_자유게시글,
+                미주권_질문게시글, 아시아권_질문게시글, 유럽권_질문게시글, 자유게시판_질문게시글
+        );
+        List<Post> expectedPosts = posts.stream()
+                .filter(post -> post.getBoard().getCode().equals(BoardCode.FREE.name()))
+                .toList();
+        List<BoardFindPostResponse> expectedResponses = BoardFindPostResponse.from(expectedPosts);
+
+        // when
+        List<BoardFindPostResponse> actualResponses = boardService.findPostsByCodeAndPostCategory(
+                BoardCode.FREE.name(),
+                PostCategory.전체.name()
+        );
+
+        // then
+        assertThat(actualResponses)
+                .usingRecursiveComparison()
+                .ignoringFieldsOfTypes(ZonedDateTime.class)
+                .isEqualTo(expectedResponses);
+    }
+}

--- a/src/test/java/com/example/solidconnection/support/integration/BaseIntegrationTest.java
+++ b/src/test/java/com/example/solidconnection/support/integration/BaseIntegrationTest.java
@@ -3,8 +3,12 @@ package com.example.solidconnection.support.integration;
 import com.example.solidconnection.board.domain.Board;
 import com.example.solidconnection.board.repository.BoardRepository;
 import com.example.solidconnection.entity.Country;
+import com.example.solidconnection.entity.PostImage;
 import com.example.solidconnection.entity.Region;
+import com.example.solidconnection.post.domain.Post;
+import com.example.solidconnection.post.repository.PostRepository;
 import com.example.solidconnection.repositories.CountryRepository;
+import com.example.solidconnection.repositories.PostImageRepository;
 import com.example.solidconnection.repositories.RegionRepository;
 import com.example.solidconnection.siteuser.domain.SiteUser;
 import com.example.solidconnection.siteuser.repository.SiteUserRepository;
@@ -12,6 +16,7 @@ import com.example.solidconnection.support.DatabaseClearExtension;
 import com.example.solidconnection.support.TestContainerSpringBootTest;
 import com.example.solidconnection.type.Gender;
 import com.example.solidconnection.type.LanguageTestType;
+import com.example.solidconnection.type.PostCategory;
 import com.example.solidconnection.type.PreparationStatus;
 import com.example.solidconnection.type.Role;
 import com.example.solidconnection.university.domain.LanguageRequirement;
@@ -76,6 +81,15 @@ public abstract class BaseIntegrationTest {
     public static Board 유럽권;
     public static Board 자유게시판;
 
+    public static Post 미주권_자유게시글;
+    public static Post 아시아권_자유게시글;
+    public static Post 유럽권_자유게시글;
+    public static Post 자유게시판_자유게시글;
+    public static Post 미주권_질문게시글;
+    public static Post 아시아권_질문게시글;
+    public static Post 유럽권_질문게시글;
+    public static Post 자유게시판_질문게시글;
+
     @Autowired
     private SiteUserRepository siteUserRepository;
 
@@ -97,6 +111,12 @@ public abstract class BaseIntegrationTest {
     @Autowired
     private BoardRepository boardRepository;
 
+    @Autowired
+    private PostRepository postRepository;
+
+    @Autowired
+    private PostImageRepository postImageRepository;
+
     @Value("${university.term}")
     public String term;
 
@@ -109,6 +129,7 @@ public abstract class BaseIntegrationTest {
         setUpUniversityInfos();
         setUpLanguageRequirements();
         setUpBoards();
+        setUpPosts();
     }
 
     private void setUpSiteUsers() {
@@ -337,6 +358,17 @@ public abstract class BaseIntegrationTest {
         자유게시판 = boardRepository.save(new Board(FREE.name(), "자유게시판"));
     }
 
+    private void setUpPosts() {
+        미주권_자유게시글 = createPost(미주권, 테스트유저_1, "미주권 자유게시글", "미주권 자유게시글 내용", PostCategory.자유);
+        아시아권_자유게시글 = createPost(아시아권, 테스트유저_2, "아시아권 자유게시글", "아시아권 자유게시글 내용", PostCategory.자유);
+        유럽권_자유게시글 = createPost(유럽권, 테스트유저_1, "유럽권 자유게시글", "유럽권 자유게시글 내용", PostCategory.자유);
+        자유게시판_자유게시글 = createPost(자유게시판, 테스트유저_2, "자유게시판 자유게시글", "자유게시판 자유게시글 내용", PostCategory.자유);
+        미주권_질문게시글 = createPost(미주권, 테스트유저_1, "미주권 질문게시글", "미주권 질문게시글 내용", PostCategory.질문);
+        아시아권_질문게시글 = createPost(아시아권, 테스트유저_2, "아시아권 질문게시글", "아시아권 질문게시글 내용", PostCategory.질문);
+        유럽권_질문게시글 = createPost(유럽권, 테스트유저_1, "유럽권 질문게시글", "유럽권 질문게시글 내용", PostCategory.질문);
+        자유게시판_질문게시글 = createPost(자유게시판, 테스트유저_2, "자유게시판 질문게시글", "자유게시판 질문게시글 내용", PostCategory.질문);
+    }
+
     private void saveLanguageTestRequirement(
             UniversityInfoForApply universityInfoForApply,
             LanguageTestType testType,
@@ -350,5 +382,22 @@ public abstract class BaseIntegrationTest {
         universityInfoForApply.addLanguageRequirements(languageRequirement);
         universityInfoForApplyRepository.save(universityInfoForApply);
         languageRequirementRepository.save(languageRequirement);
+    }
+
+    private Post createPost(Board board, SiteUser siteUser, String title, String content, PostCategory category) {
+        Post post = new Post(
+                title,
+                content,
+                false,
+                0L,
+                0L,
+                category
+        );
+        post.setBoardAndSiteUser(board, siteUser);
+        Post savedPost = postRepository.save(post);
+        PostImage postImage = new PostImage("imageUrl");
+        postImage.setPost(savedPost);
+        postImageRepository.save(postImage);
+        return savedPost;
     }
 }


### PR DESCRIPTION
## 관련 이슈

- resolves: #174

## 작업 내용
게시글 관련 통합 테스트 코드 추가하였습니다.
<img width="418" alt="게시글관련통합테스트" src="https://github.com/user-attachments/assets/0ee75087-9848-49be-925b-a9acdeedbbfe" />

리뷰 요구사항 (선택)

작업을 하면서 느낀 게 현재 폴더구조에 board, post, comment가 있는데 전부 community 관련된 것들이더라구요. 특히 board에는 전체 게시글 조회하는 것만 있고 post에 게시글 생성, 단일조회, 수정, 삭제 등이 있는데 한 폴더에서 관리하는 게 더 좋을 거 같다는 생각이 드네요

추가로 게시글 전체 조회는 Page나 Slice 없이 그냥 List로 다 받아오던데 특별한 이유가 있는건가요?