### PR TITLE
refactor: TokenProvider 에서 각 토큰에 대한 로직을 캡슐화

### DIFF
--- a/src/main/java/com/example/solidconnection/auth/domain/TokenType.java
+++ b/src/main/java/com/example/solidconnection/auth/domain/TokenType.java
@@ -7,8 +7,8 @@ public enum TokenType {
 
     ACCESS("ACCESS:", 1000 * 60 * 60), // 1hour
     REFRESH("REFRESH:", 1000 * 60 * 60 * 24 * 7), // 7days
-    KAKAO_OAUTH("KAKAO:", 1000 * 60 * 60), // 1hour
-    BLACKLIST("BLACKLIST:", ACCESS.expireTime)
+    BLACKLIST("BLACKLIST:", ACCESS.expireTime),
+    SIGN_UP("SIGN_UP:", 1000 * 60 * 10), // 10min
     ;
 
     private final String prefix;

--- a/src/main/java/com/example/solidconnection/auth/domain/TokenType.java
+++ b/src/main/java/com/example/solidconnection/auth/domain/TokenType.java
@@ -19,7 +19,7 @@ public enum TokenType {
         this.expireTime = expireTime;
     }
 
-    public String addPrefixToSubject(String subject) {
-        return prefix + subject;
+    public String addPrefix(String string) {
+        return prefix + string;
     }
 }

--- a/src/main/java/com/example/solidconnection/auth/service/AuthService.java
+++ b/src/main/java/com/example/solidconnection/auth/service/AuthService.java
@@ -5,24 +5,18 @@ import com.example.solidconnection.auth.dto.ReissueResponse;
 import com.example.solidconnection.custom.exception.CustomException;
 import com.example.solidconnection.siteuser.domain.SiteUser;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.ObjectUtils;
 
 import java.time.LocalDate;
-import java.util.concurrent.TimeUnit;
+import java.util.Optional;
 
-import static com.example.solidconnection.auth.domain.TokenType.ACCESS;
-import static com.example.solidconnection.auth.domain.TokenType.BLACKLIST;
-import static com.example.solidconnection.auth.domain.TokenType.REFRESH;
 import static com.example.solidconnection.custom.exception.ErrorCode.REFRESH_TOKEN_EXPIRED;
 
 @RequiredArgsConstructor
 @Service
 public class AuthService {
 
-    private final RedisTemplate<String, String> redisTemplate;
     private final TokenProvider tokenProvider;
 
     /*
@@ -30,12 +24,7 @@ public class AuthService {
      * - 엑세스 토큰을 블랙리스트에 추가한다.
      * */
     public void signOut(String accessToken) {
-        redisTemplate.opsForValue().set(
-                BLACKLIST.addPrefixToSubject(accessToken),
-                accessToken,
-                BLACKLIST.getExpireTime(),
-                TimeUnit.MILLISECONDS
-        );
+        tokenProvider.generateAndSaveBlackListToken(accessToken);
     }
 
     /*
@@ -56,14 +45,12 @@ public class AuthService {
      * */
     public ReissueResponse reissue(String subject) {
         // 리프레시 토큰 만료 확인
-        String refreshTokenKey = REFRESH.addPrefixToSubject(subject);
-        String refreshToken = redisTemplate.opsForValue().get(refreshTokenKey);
-        if (ObjectUtils.isEmpty(refreshToken)) {
+        Optional<String> optionalRefreshToken = tokenProvider.findRefreshToken(subject);
+        if (optionalRefreshToken.isEmpty()) {
             throw new CustomException(REFRESH_TOKEN_EXPIRED);
         }
         // 액세스 토큰 재발급
-        String newAccessToken = tokenProvider.generateToken(subject, ACCESS);
-        tokenProvider.saveToken(newAccessToken, ACCESS);
+        String newAccessToken = tokenProvider.generateAccessToken(subject);
         return new ReissueResponse(newAccessToken);
     }
 }

--- a/src/main/java/com/example/solidconnection/auth/service/AuthService.java
+++ b/src/main/java/com/example/solidconnection/auth/service/AuthService.java
@@ -17,14 +17,14 @@ import static com.example.solidconnection.custom.exception.ErrorCode.REFRESH_TOK
 @Service
 public class AuthService {
 
-    private final TokenProvider tokenProvider;
+    private final AuthTokenProvider authTokenProvider;
 
     /*
      * 로그아웃 한다.
      * - 엑세스 토큰을 블랙리스트에 추가한다.
      * */
     public void signOut(String accessToken) {
-        tokenProvider.generateAndSaveBlackListToken(accessToken);
+        authTokenProvider.generateAndSaveBlackListToken(accessToken);
     }
 
     /*
@@ -45,12 +45,12 @@ public class AuthService {
      * */
     public ReissueResponse reissue(String subject) {
         // 리프레시 토큰 만료 확인
-        Optional<String> optionalRefreshToken = tokenProvider.findRefreshToken(subject);
+        Optional<String> optionalRefreshToken = authTokenProvider.findRefreshToken(subject);
         if (optionalRefreshToken.isEmpty()) {
             throw new CustomException(REFRESH_TOKEN_EXPIRED);
         }
         // 액세스 토큰 재발급
-        String newAccessToken = tokenProvider.generateAccessToken(subject);
+        String newAccessToken = authTokenProvider.generateAccessToken(subject);
         return new ReissueResponse(newAccessToken);
     }
 }

--- a/src/main/java/com/example/solidconnection/auth/service/AuthTokenProvider.java
+++ b/src/main/java/com/example/solidconnection/auth/service/AuthTokenProvider.java
@@ -1,0 +1,53 @@
+package com.example.solidconnection.auth.service;
+
+import com.example.solidconnection.auth.domain.TokenType;
+import com.example.solidconnection.config.security.JwtProperties;
+import com.example.solidconnection.siteuser.domain.SiteUser;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+import static com.example.solidconnection.util.JwtUtils.parseSubjectIgnoringExpiration;
+
+@Component
+public class AuthTokenProvider extends TokenProvider {
+
+    public AuthTokenProvider(JwtProperties jwtProperties, RedisTemplate<String, String> redisTemplate) {
+        super(jwtProperties, redisTemplate);
+    }
+
+    public String generateAccessToken(SiteUser siteUser) {
+        String subject = siteUser.getId().toString();
+        return generateToken(subject, TokenType.ACCESS);
+    }
+
+    public String generateAccessToken(String subject) {
+        return generateToken(subject, TokenType.ACCESS);
+    }
+
+    public String generateAndSaveRefreshToken(SiteUser siteUser) {
+        String subject = siteUser.getId().toString();
+        String refreshToken = generateToken(subject, TokenType.REFRESH);
+        return saveToken(refreshToken, TokenType.REFRESH);
+    }
+
+    public String generateAndSaveBlackListToken(String accessToken) {
+        String refreshToken = generateToken(accessToken, TokenType.BLACKLIST);
+        return saveToken(refreshToken, TokenType.BLACKLIST);
+    }
+
+    public Optional<String> findRefreshToken(String subject) {
+        String refreshTokenKey = TokenType.REFRESH.addPrefixToSubject(subject);
+        return Optional.ofNullable(redisTemplate.opsForValue().get(refreshTokenKey));
+    }
+
+    public Optional<String> findBlackListToken(String subject) {
+        String refreshTokenKey = TokenType.BLACKLIST.addPrefixToSubject(subject);
+        return Optional.ofNullable(redisTemplate.opsForValue().get(refreshTokenKey));
+    }
+
+    public String getEmail(String token) {
+        return parseSubjectIgnoringExpiration(token, jwtProperties.secret());
+    }
+}

--- a/src/main/java/com/example/solidconnection/auth/service/AuthTokenProvider.java
+++ b/src/main/java/com/example/solidconnection/auth/service/AuthTokenProvider.java
@@ -33,8 +33,8 @@ public class AuthTokenProvider extends TokenProvider {
     }
 
     public String generateAndSaveBlackListToken(String accessToken) {
-        String refreshToken = generateToken(accessToken, TokenType.BLACKLIST);
-        return saveToken(refreshToken, TokenType.BLACKLIST);
+        String blackListToken = generateToken(accessToken, TokenType.BLACKLIST);
+        return saveToken(blackListToken, TokenType.BLACKLIST);
     }
 
     public Optional<String> findRefreshToken(String subject) {
@@ -43,8 +43,8 @@ public class AuthTokenProvider extends TokenProvider {
     }
 
     public Optional<String> findBlackListToken(String subject) {
-        String refreshTokenKey = TokenType.BLACKLIST.addPrefix(subject);
-        return Optional.ofNullable(redisTemplate.opsForValue().get(refreshTokenKey));
+        String blackListTokenKey = TokenType.BLACKLIST.addPrefix(subject);
+        return Optional.ofNullable(redisTemplate.opsForValue().get(blackListTokenKey));
     }
 
     public String getEmail(String token) {

--- a/src/main/java/com/example/solidconnection/auth/service/AuthTokenProvider.java
+++ b/src/main/java/com/example/solidconnection/auth/service/AuthTokenProvider.java
@@ -38,12 +38,12 @@ public class AuthTokenProvider extends TokenProvider {
     }
 
     public Optional<String> findRefreshToken(String subject) {
-        String refreshTokenKey = TokenType.REFRESH.addPrefixToSubject(subject);
+        String refreshTokenKey = TokenType.REFRESH.addPrefix(subject);
         return Optional.ofNullable(redisTemplate.opsForValue().get(refreshTokenKey));
     }
 
     public Optional<String> findBlackListToken(String subject) {
-        String refreshTokenKey = TokenType.BLACKLIST.addPrefixToSubject(subject);
+        String refreshTokenKey = TokenType.BLACKLIST.addPrefix(subject);
         return Optional.ofNullable(redisTemplate.opsForValue().get(refreshTokenKey));
     }
 

--- a/src/main/java/com/example/solidconnection/auth/service/SignInService.java
+++ b/src/main/java/com/example/solidconnection/auth/service/SignInService.java
@@ -60,12 +60,12 @@ public class SignInService {
     }
 
     private SignInResponse getSignInInfo(SiteUser siteUser) {
-        String accessToken = tokenProvider.generateToken(siteUser, TokenType.ACCESS);
-        String refreshToken = tokenProvider.generateToken(siteUser, TokenType.REFRESH);
-        tokenProvider.saveToken(refreshToken, TokenType.REFRESH);
+        String accessToken = tokenProvider.generateAccessToken(siteUser);
+        String refreshToken = tokenProvider.generateAndSaveRefreshToken(siteUser);
         return new SignInResponse(true, accessToken, refreshToken);
     }
 
+    // todo: SignUpTokenProvider 를 만들어서 거기에만 의존하도록 변경 필요
     private FirstAccessResponse getFirstAccessInfo(KakaoUserInfoDto kakaoUserInfoDto) {
         String kakaoOauthToken = tokenProvider.generateToken(kakaoUserInfoDto.kakaoAccountDto().email(), TokenType.KAKAO_OAUTH);
         tokenProvider.saveToken(kakaoOauthToken, TokenType.KAKAO_OAUTH);

--- a/src/main/java/com/example/solidconnection/auth/service/SignInService.java
+++ b/src/main/java/com/example/solidconnection/auth/service/SignInService.java
@@ -65,7 +65,6 @@ public class SignInService {
         return new SignInResponse(true, accessToken, refreshToken);
     }
 
-    // todo: SignUpTokenProvider 를 만들어서 거기에만 의존하도록 변경 필요
     private FirstAccessResponse getFirstAccessInfo(KakaoUserInfoDto kakaoUserInfoDto) {
         String kakaoOauthToken = signUpTokenProvider.generateAndSaveSignUpToken(kakaoUserInfoDto.kakaoAccountDto().email());
         return FirstAccessResponse.of(kakaoUserInfoDto, kakaoOauthToken);

--- a/src/main/java/com/example/solidconnection/auth/service/SignInService.java
+++ b/src/main/java/com/example/solidconnection/auth/service/SignInService.java
@@ -6,7 +6,6 @@ import com.example.solidconnection.auth.dto.kakao.FirstAccessResponse;
 import com.example.solidconnection.auth.dto.kakao.KakaoCodeRequest;
 import com.example.solidconnection.auth.dto.kakao.KakaoOauthResponse;
 import com.example.solidconnection.auth.dto.kakao.KakaoUserInfoDto;
-import com.example.solidconnection.auth.domain.TokenType;
 import com.example.solidconnection.siteuser.domain.AuthType;
 import com.example.solidconnection.siteuser.domain.SiteUser;
 import com.example.solidconnection.siteuser.repository.SiteUserRepository;
@@ -20,7 +19,8 @@ import java.util.Optional;
 @Service
 public class SignInService {
 
-    private final TokenProvider tokenProvider;
+    private final AuthTokenProvider authTokenProvider;
+    private final SignUpTokenProvider signUpTokenProvider;
     private final SiteUserRepository siteUserRepository;
     private final KakaoOAuthClient kakaoOAuthClient;
 
@@ -60,15 +60,14 @@ public class SignInService {
     }
 
     private SignInResponse getSignInInfo(SiteUser siteUser) {
-        String accessToken = tokenProvider.generateAccessToken(siteUser);
-        String refreshToken = tokenProvider.generateAndSaveRefreshToken(siteUser);
+        String accessToken = authTokenProvider.generateAccessToken(siteUser);
+        String refreshToken = authTokenProvider.generateAndSaveRefreshToken(siteUser);
         return new SignInResponse(true, accessToken, refreshToken);
     }
 
     // todo: SignUpTokenProvider 를 만들어서 거기에만 의존하도록 변경 필요
     private FirstAccessResponse getFirstAccessInfo(KakaoUserInfoDto kakaoUserInfoDto) {
-        String kakaoOauthToken = tokenProvider.generateToken(kakaoUserInfoDto.kakaoAccountDto().email(), TokenType.KAKAO_OAUTH);
-        tokenProvider.saveToken(kakaoOauthToken, TokenType.KAKAO_OAUTH);
+        String kakaoOauthToken = signUpTokenProvider.generateAndSaveSignUpToken(kakaoUserInfoDto.kakaoAccountDto().email());
         return FirstAccessResponse.of(kakaoUserInfoDto, kakaoOauthToken);
     }
 }

--- a/src/main/java/com/example/solidconnection/auth/service/SignUpService.java
+++ b/src/main/java/com/example/solidconnection/auth/service/SignUpService.java
@@ -27,7 +27,7 @@ import static com.example.solidconnection.custom.exception.ErrorCode.USER_ALREAD
 public class SignUpService {
 
     private final TokenValidator tokenValidator;
-    private final TokenProvider tokenProvider;
+    private final AuthTokenProvider authTokenProvider;
     private final SiteUserRepository siteUserRepository;
     private final RegionRepository regionRepository;
     private final InterestedRegionRepository interestedRegionRepository;
@@ -50,7 +50,7 @@ public class SignUpService {
     public SignUpResponse signUp(SignUpRequest signUpRequest) {
         // 검증
         tokenValidator.validateKakaoToken(signUpRequest.kakaoOauthToken());
-        String email = tokenProvider.getEmail(signUpRequest.kakaoOauthToken());
+        String email = authTokenProvider.getEmail(signUpRequest.kakaoOauthToken());
         validateNicknameDuplicated(signUpRequest.nickname());
         validateUserNotDuplicated(email);
 
@@ -63,8 +63,8 @@ public class SignUpService {
         saveInterestedCountry(signUpRequest, savedSiteUser);
 
         // 토큰 발급
-        String accessToken = tokenProvider.generateAccessToken(siteUser);
-        String refreshToken = tokenProvider.generateAndSaveRefreshToken(siteUser);
+        String accessToken = authTokenProvider.generateAccessToken(siteUser);
+        String refreshToken = authTokenProvider.generateAndSaveRefreshToken(siteUser);
         return new SignUpResponse(accessToken, refreshToken);
     }
 

--- a/src/main/java/com/example/solidconnection/auth/service/SignUpService.java
+++ b/src/main/java/com/example/solidconnection/auth/service/SignUpService.java
@@ -2,7 +2,6 @@ package com.example.solidconnection.auth.service;
 
 import com.example.solidconnection.auth.dto.SignUpRequest;
 import com.example.solidconnection.auth.dto.SignUpResponse;
-import com.example.solidconnection.auth.domain.TokenType;
 import com.example.solidconnection.custom.exception.CustomException;
 import com.example.solidconnection.entity.InterestedCountry;
 import com.example.solidconnection.entity.InterestedRegion;
@@ -64,9 +63,8 @@ public class SignUpService {
         saveInterestedCountry(signUpRequest, savedSiteUser);
 
         // 토큰 발급
-        String accessToken = tokenProvider.generateToken(siteUser, TokenType.ACCESS);
-        String refreshToken = tokenProvider.generateToken(siteUser, TokenType.REFRESH);
-        tokenProvider.saveToken(refreshToken, TokenType.REFRESH);
+        String accessToken = tokenProvider.generateAccessToken(siteUser);
+        String refreshToken = tokenProvider.generateAndSaveRefreshToken(siteUser);
         return new SignUpResponse(accessToken, refreshToken);
     }
 

--- a/src/main/java/com/example/solidconnection/auth/service/SignUpTokenProvider.java
+++ b/src/main/java/com/example/solidconnection/auth/service/SignUpTokenProvider.java
@@ -20,7 +20,7 @@ public class SignUpTokenProvider extends TokenProvider {
     }
 
     public Optional<String> findSignUpToken(String email) {
-        String signUpKey = TokenType.SIGN_UP.addPrefixToSubject(email);
+        String signUpKey = TokenType.SIGN_UP.addPrefix(email);
         return Optional.ofNullable(redisTemplate.opsForValue().get(signUpKey));
     }
 }

--- a/src/main/java/com/example/solidconnection/auth/service/SignUpTokenProvider.java
+++ b/src/main/java/com/example/solidconnection/auth/service/SignUpTokenProvider.java
@@ -1,0 +1,26 @@
+package com.example.solidconnection.auth.service;
+
+import com.example.solidconnection.auth.domain.TokenType;
+import com.example.solidconnection.config.security.JwtProperties;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+public class SignUpTokenProvider extends TokenProvider {
+
+    public SignUpTokenProvider(JwtProperties jwtProperties, RedisTemplate<String, String> redisTemplate) {
+        super(jwtProperties, redisTemplate);
+    }
+
+    public String generateAndSaveSignUpToken(String email) {
+        String signUpToken = generateToken(email, TokenType.SIGN_UP);
+        return saveToken(signUpToken, TokenType.SIGN_UP);
+    }
+
+    public Optional<String> findSignUpToken(String email) {
+        String signUpKey = TokenType.SIGN_UP.addPrefixToSubject(email);
+        return Optional.ofNullable(redisTemplate.opsForValue().get(signUpKey));
+    }
+}

--- a/src/main/java/com/example/solidconnection/auth/service/TokenProvider.java
+++ b/src/main/java/com/example/solidconnection/auth/service/TokenProvider.java
@@ -37,7 +37,7 @@ public abstract class TokenProvider {
     protected final String saveToken(String token, TokenType tokenType) {
         String subject = parseSubject(token, jwtProperties.secret());
         redisTemplate.opsForValue().set(
-                tokenType.addPrefixToSubject(subject),
+                tokenType.addPrefix(subject),
                 token,
                 tokenType.getExpireTime(),
                 TimeUnit.MILLISECONDS

--- a/src/main/java/com/example/solidconnection/auth/service/TokenProvider.java
+++ b/src/main/java/com/example/solidconnection/auth/service/TokenProvider.java
@@ -2,60 +2,27 @@ package com.example.solidconnection.auth.service;
 
 import com.example.solidconnection.auth.domain.TokenType;
 import com.example.solidconnection.config.security.JwtProperties;
-import com.example.solidconnection.siteuser.domain.SiteUser;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
-import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.stereotype.Component;
 
 import java.util.Date;
-import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static com.example.solidconnection.util.JwtUtils.parseSubject;
-import static com.example.solidconnection.util.JwtUtils.parseSubjectIgnoringExpiration;
 
-@RequiredArgsConstructor
-@Component
-public class TokenProvider {
+public abstract class TokenProvider {
 
-    private final RedisTemplate<String, String> redisTemplate;
-    private final JwtProperties jwtProperties;
+    protected final JwtProperties jwtProperties;
+    protected final RedisTemplate<String, String> redisTemplate;
 
-    public String generateAccessToken(SiteUser siteUser) {
-        String subject = siteUser.getId().toString();
-        return generateToken(subject, TokenType.ACCESS);
+    public TokenProvider(JwtProperties jwtProperties, RedisTemplate<String, String> redisTemplate) {
+        this.jwtProperties = jwtProperties;
+        this.redisTemplate = redisTemplate;
     }
 
-    public String generateAccessToken(String subject) {
-        return generateToken(subject, TokenType.ACCESS);
-    }
-
-    public String generateAndSaveRefreshToken(SiteUser siteUser) {
-        String subject = siteUser.getId().toString();
-        String refreshToken = generateToken(subject, TokenType.REFRESH);
-        return saveToken(refreshToken, TokenType.REFRESH);
-    }
-
-    public String generateAndSaveBlackListToken(String accessToken) {
-        String refreshToken = generateToken(accessToken, TokenType.BLACKLIST);
-        return saveToken(refreshToken, TokenType.BLACKLIST);
-    }
-
-    public Optional<String> findRefreshToken(String subject) {
-        String refreshTokenKey = TokenType.REFRESH.addPrefixToSubject(subject);
-        return Optional.ofNullable(redisTemplate.opsForValue().get(refreshTokenKey));
-    }
-
-    public Optional<String> findBlackListToken(String subject) {
-        String refreshTokenKey = TokenType.BLACKLIST.addPrefixToSubject(subject);
-        return Optional.ofNullable(redisTemplate.opsForValue().get(refreshTokenKey));
-    }
-
-    // todo: SignUpTokenProvider 가 생기면 private 으로 변경
-    public String generateToken(String string, TokenType tokenType) {
+    protected final String generateToken(String string, TokenType tokenType) {
         Claims claims = Jwts.claims().setSubject(string);
         Date now = new Date();
         Date expiredDate = new Date(now.getTime() + tokenType.getExpireTime());
@@ -67,8 +34,7 @@ public class TokenProvider {
                 .compact();
     }
 
-    // todo: SignUpTokenProvider 가 생기면 private 으로 변경
-    public String saveToken(String token, TokenType tokenType) {
+    protected final String saveToken(String token, TokenType tokenType) {
         String subject = parseSubject(token, jwtProperties.secret());
         redisTemplate.opsForValue().set(
                 tokenType.addPrefixToSubject(subject),
@@ -77,9 +43,5 @@ public class TokenProvider {
                 TimeUnit.MILLISECONDS
         );
         return token;
-    }
-
-    public String getEmail(String token) {
-        return parseSubjectIgnoringExpiration(token, jwtProperties.secret());
     }
 }

--- a/src/main/java/com/example/solidconnection/auth/service/TokenValidator.java
+++ b/src/main/java/com/example/solidconnection/auth/service/TokenValidator.java
@@ -14,8 +14,8 @@ import java.util.Date;
 import java.util.Objects;
 
 import static com.example.solidconnection.auth.domain.TokenType.ACCESS;
-import static com.example.solidconnection.auth.domain.TokenType.KAKAO_OAUTH;
 import static com.example.solidconnection.auth.domain.TokenType.REFRESH;
+import static com.example.solidconnection.auth.domain.TokenType.SIGN_UP;
 import static com.example.solidconnection.custom.exception.ErrorCode.ACCESS_TOKEN_EXPIRED;
 import static com.example.solidconnection.custom.exception.ErrorCode.EMPTY_TOKEN;
 import static com.example.solidconnection.custom.exception.ErrorCode.INVALID_SERVICE_PUBLISHED_KAKAO_TOKEN;
@@ -38,7 +38,7 @@ public class TokenValidator {
 
     public void validateKakaoToken(String token) {
         validateTokenNotEmpty(token);
-        validateTokenNotExpired(token, KAKAO_OAUTH);
+        validateTokenNotExpired(token, SIGN_UP);
         validateKakaoTokenNotUsed(token);
     }
 
@@ -55,7 +55,7 @@ public class TokenValidator {
             if (tokenType.equals(ACCESS)) {
                 throw new CustomException(ACCESS_TOKEN_EXPIRED);
             }
-            if (token.equals(KAKAO_OAUTH)) {
+            if (token.equals(SIGN_UP)) {
                 throw new CustomException(INVALID_SERVICE_PUBLISHED_KAKAO_TOKEN);
             }
         }
@@ -70,7 +70,7 @@ public class TokenValidator {
 
     private void validateKakaoTokenNotUsed(String token) {
         String email = getClaim(token).getSubject();
-        if (!Objects.equals(redisTemplate.opsForValue().get(KAKAO_OAUTH.addPrefixToSubject(email)), token)) {
+        if (!Objects.equals(redisTemplate.opsForValue().get(SIGN_UP.addPrefixToSubject(email)), token)) {
             throw new CustomException(INVALID_SERVICE_PUBLISHED_KAKAO_TOKEN);
         }
     }

--- a/src/main/java/com/example/solidconnection/auth/service/TokenValidator.java
+++ b/src/main/java/com/example/solidconnection/auth/service/TokenValidator.java
@@ -63,14 +63,14 @@ public class TokenValidator {
 
     private void validateRefreshToken(String token) {
         String email = getClaim(token).getSubject();
-        if (redisTemplate.opsForValue().get(REFRESH.addPrefixToSubject(email)) == null) {
+        if (redisTemplate.opsForValue().get(REFRESH.addPrefix(email)) == null) {
             throw new CustomException(REFRESH_TOKEN_EXPIRED);
         }
     }
 
     private void validateKakaoTokenNotUsed(String token) {
         String email = getClaim(token).getSubject();
-        if (!Objects.equals(redisTemplate.opsForValue().get(SIGN_UP.addPrefixToSubject(email)), token)) {
+        if (!Objects.equals(redisTemplate.opsForValue().get(SIGN_UP.addPrefix(email)), token)) {
             throw new CustomException(INVALID_SERVICE_PUBLISHED_KAKAO_TOKEN);
         }
     }

--- a/src/main/java/com/example/solidconnection/custom/security/filter/SignOutCheckFilter.java
+++ b/src/main/java/com/example/solidconnection/custom/security/filter/SignOutCheckFilter.java
@@ -12,7 +12,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
-import java.util.Optional;
 
 import static com.example.solidconnection.custom.exception.ErrorCode.USER_ALREADY_SIGN_OUT;
 import static com.example.solidconnection.util.JwtUtils.parseTokenFromRequest;
@@ -35,7 +34,6 @@ public class SignOutCheckFilter extends OncePerRequestFilter {
     }
 
     private boolean hasSignedOut(String accessToken) {
-        Optional<String> blackListToken = authTokenProvider.findBlackListToken(accessToken);
-        return blackListToken.isPresent();
+        return authTokenProvider.findBlackListToken(accessToken).isPresent();
     }
 }

--- a/src/main/java/com/example/solidconnection/custom/security/filter/SignOutCheckFilter.java
+++ b/src/main/java/com/example/solidconnection/custom/security/filter/SignOutCheckFilter.java
@@ -1,6 +1,6 @@
 package com.example.solidconnection.custom.security.filter;
 
-import com.example.solidconnection.config.security.JwtProperties;
+import com.example.solidconnection.auth.service.TokenProvider;
 import com.example.solidconnection.custom.exception.CustomException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -8,13 +8,12 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.Optional;
 
-import static com.example.solidconnection.auth.domain.TokenType.BLACKLIST;
 import static com.example.solidconnection.custom.exception.ErrorCode.USER_ALREADY_SIGN_OUT;
 import static com.example.solidconnection.util.JwtUtils.parseTokenFromRequest;
 
@@ -22,8 +21,7 @@ import static com.example.solidconnection.util.JwtUtils.parseTokenFromRequest;
 @RequiredArgsConstructor
 public class SignOutCheckFilter extends OncePerRequestFilter {
 
-    private final RedisTemplate<String, String> redisTemplate;
-    private final JwtProperties jwtProperties;
+    private final TokenProvider tokenProvider;
 
     @Override
     protected void doFilterInternal(@NonNull HttpServletRequest request,
@@ -37,7 +35,7 @@ public class SignOutCheckFilter extends OncePerRequestFilter {
     }
 
     private boolean hasSignedOut(String accessToken) {
-        String blacklistKey = BLACKLIST.addPrefixToSubject(accessToken);
-        return redisTemplate.opsForValue().get(blacklistKey) != null;
+        Optional<String> blackListToken = tokenProvider.findBlackListToken(accessToken);
+        return blackListToken.isPresent();
     }
 }

--- a/src/main/java/com/example/solidconnection/custom/security/filter/SignOutCheckFilter.java
+++ b/src/main/java/com/example/solidconnection/custom/security/filter/SignOutCheckFilter.java
@@ -1,6 +1,6 @@
 package com.example.solidconnection.custom.security.filter;
 
-import com.example.solidconnection.auth.service.TokenProvider;
+import com.example.solidconnection.auth.service.AuthTokenProvider;
 import com.example.solidconnection.custom.exception.CustomException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -21,7 +21,7 @@ import static com.example.solidconnection.util.JwtUtils.parseTokenFromRequest;
 @RequiredArgsConstructor
 public class SignOutCheckFilter extends OncePerRequestFilter {
 
-    private final TokenProvider tokenProvider;
+    private final AuthTokenProvider authTokenProvider;
 
     @Override
     protected void doFilterInternal(@NonNull HttpServletRequest request,
@@ -35,7 +35,7 @@ public class SignOutCheckFilter extends OncePerRequestFilter {
     }
 
     private boolean hasSignedOut(String accessToken) {
-        Optional<String> blackListToken = tokenProvider.findBlackListToken(accessToken);
+        Optional<String> blackListToken = authTokenProvider.findBlackListToken(accessToken);
         return blackListToken.isPresent();
     }
 }

--- a/src/test/java/com/example/solidconnection/auth/service/AuthTokenProviderTest.java
+++ b/src/test/java/com/example/solidconnection/auth/service/AuthTokenProviderTest.java
@@ -85,7 +85,7 @@ class AuthTokenProviderTest {
 
             // then
             String actualSubject = JwtUtils.parseSubject(refreshToken, jwtProperties.secret());
-            String refreshTokenKey = TokenType.REFRESH.addPrefixToSubject(subject);
+            String refreshTokenKey = TokenType.REFRESH.addPrefix(subject);
             assertAll(
                     () -> assertThat(actualSubject).isEqualTo(subject),
                     () -> assertThat(redisTemplate.opsForValue().get(refreshTokenKey)).isEqualTo(refreshToken)
@@ -96,7 +96,7 @@ class AuthTokenProviderTest {
         void 저장된_리프레시_토큰을_조회한다() {
             // given
             String refreshToken = "refreshToken";
-            redisTemplate.opsForValue().set(TokenType.REFRESH.addPrefixToSubject(subject), refreshToken);
+            redisTemplate.opsForValue().set(TokenType.REFRESH.addPrefix(subject), refreshToken);
 
             // when
             Optional<String> optionalRefreshToken = authTokenProvider.findRefreshToken(subject);
@@ -126,7 +126,7 @@ class AuthTokenProviderTest {
 
             // then
             String actualSubject = JwtUtils.parseSubject(blackListToken, jwtProperties.secret());
-            String blackListTokenKey = TokenType.BLACKLIST.addPrefixToSubject(accessToken);
+            String blackListTokenKey = TokenType.BLACKLIST.addPrefix(accessToken);
             assertAll(
                     () -> assertThat(actualSubject).isEqualTo(accessToken),
                     () -> assertThat(redisTemplate.opsForValue().get(blackListTokenKey)).isEqualTo(blackListToken)
@@ -138,7 +138,7 @@ class AuthTokenProviderTest {
             // given
             String accessToken = "accessToken";
             String blackListToken = "token";
-            redisTemplate.opsForValue().set(TokenType.BLACKLIST.addPrefixToSubject(accessToken), blackListToken);
+            redisTemplate.opsForValue().set(TokenType.BLACKLIST.addPrefix(accessToken), blackListToken);
 
             // when
             Optional<String> optionalBlackListToken = authTokenProvider.findBlackListToken(accessToken);

--- a/src/test/java/com/example/solidconnection/auth/service/AuthTokenProviderTest.java
+++ b/src/test/java/com/example/solidconnection/auth/service/AuthTokenProviderTest.java
@@ -23,11 +23,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 @TestContainerSpringBootTest
-@DisplayName("TokenProvider 테스트")
-class TokenProviderTest {
+@DisplayName("인증 토큰 제공자 테스트")
+class AuthTokenProviderTest {
 
     @Autowired
-    private TokenProvider tokenProvider;
+    private AuthTokenProvider authTokenProvider;
     
     @Autowired
     private SiteUserRepository siteUserRepository;
@@ -54,7 +54,7 @@ class TokenProviderTest {
         @Test
         void SiteUser_로_액세스_토큰을_생성한다() {
             // when
-            String token = tokenProvider.generateAccessToken(siteUser);
+            String token = authTokenProvider.generateAccessToken(siteUser);
 
             // then
             String actualSubject = JwtUtils.parseSubject(token, jwtProperties.secret());
@@ -67,7 +67,7 @@ class TokenProviderTest {
             String subject = "subject123";
 
             // when
-            String token = tokenProvider.generateAccessToken(subject);
+            String token = authTokenProvider.generateAccessToken(subject);
 
             // then
             String actualSubject = JwtUtils.parseSubject(token, jwtProperties.secret());
@@ -81,7 +81,7 @@ class TokenProviderTest {
         @Test
         void SiteUser_로_리프레시_토큰을_생성하고_저장한다() {
             // when
-            String refreshToken = tokenProvider.generateAndSaveRefreshToken(siteUser);
+            String refreshToken = authTokenProvider.generateAndSaveRefreshToken(siteUser);
 
             // then
             String actualSubject = JwtUtils.parseSubject(refreshToken, jwtProperties.secret());
@@ -99,7 +99,7 @@ class TokenProviderTest {
             redisTemplate.opsForValue().set(TokenType.REFRESH.addPrefixToSubject(subject), refreshToken);
 
             // when
-            Optional<String> optionalRefreshToken = tokenProvider.findRefreshToken(subject);
+            Optional<String> optionalRefreshToken = authTokenProvider.findRefreshToken(subject);
 
             // then
             assertThat(optionalRefreshToken.get()).isEqualTo(refreshToken);
@@ -108,7 +108,7 @@ class TokenProviderTest {
         @Test
         void 저장되지_않은_리프레시_토큰을_조회한다() {
             // when
-            Optional<String> optionalRefreshToken = tokenProvider.findRefreshToken(subject);
+            Optional<String> optionalRefreshToken = authTokenProvider.findRefreshToken(subject);
 
             // then
             assertThat(optionalRefreshToken).isEmpty();
@@ -122,7 +122,7 @@ class TokenProviderTest {
         void 엑세스_토큰으로_블랙리스트_토큰을_생성하고_저장한다() {
             // when
             String accessToken = "accessToken";
-            String blackListToken = tokenProvider.generateAndSaveBlackListToken(accessToken);
+            String blackListToken = authTokenProvider.generateAndSaveBlackListToken(accessToken);
 
             // then
             String actualSubject = JwtUtils.parseSubject(blackListToken, jwtProperties.secret());
@@ -141,16 +141,16 @@ class TokenProviderTest {
             redisTemplate.opsForValue().set(TokenType.BLACKLIST.addPrefixToSubject(accessToken), blackListToken);
 
             // when
-            Optional<String> optionalBlackListToken = tokenProvider.findBlackListToken(accessToken);
+            Optional<String> optionalBlackListToken = authTokenProvider.findBlackListToken(accessToken);
 
             // then
-            assertThat(optionalBlackListToken.get()).isEqualTo(blackListToken);
+            assertThat(optionalBlackListToken).hasValue(blackListToken);
         }
 
         @Test
         void 저장되지_않은_블랙리스트_토큰을_조회한다() {
             // when
-            Optional<String> optionalBlackListToken = tokenProvider.findBlackListToken("accessToken");
+            Optional<String> optionalBlackListToken = authTokenProvider.findBlackListToken("accessToken");
 
             // then
             assertThat(optionalBlackListToken).isEmpty();
@@ -161,7 +161,7 @@ class TokenProviderTest {
     void 토큰을_생성한다() {
         // when
         String subject = "subject123";
-        String token = tokenProvider.generateToken(subject, TokenType.ACCESS);
+        String token = authTokenProvider.generateToken(subject, TokenType.ACCESS);
 
         // then
         String extractedSubject = Jwts.parser()

--- a/src/test/java/com/example/solidconnection/auth/service/SignUpTokenProviderTest.java
+++ b/src/test/java/com/example/solidconnection/auth/service/SignUpTokenProviderTest.java
@@ -35,7 +35,7 @@ class SignUpTokenProviderTest {
 
         // then
         String actualSubject = JwtUtils.parseSubject(signUpToken, jwtProperties.secret());
-        String signUpTokenKey = TokenType.SIGN_UP.addPrefixToSubject(email);
+        String signUpTokenKey = TokenType.SIGN_UP.addPrefix(email);
         assertAll(
                 () -> assertThat(actualSubject).isEqualTo(email),
                 () -> assertThat(redisTemplate.opsForValue().get(signUpTokenKey)).isEqualTo(signUpToken)
@@ -47,7 +47,7 @@ class SignUpTokenProviderTest {
         // given
         String email = "email";
         String signUpToken = "token";
-        redisTemplate.opsForValue().set(TokenType.SIGN_UP.addPrefixToSubject(email), signUpToken);
+        redisTemplate.opsForValue().set(TokenType.SIGN_UP.addPrefix(email), signUpToken);
 
         // when
         Optional<String> actualSignUpToken = signUpTokenProvider.findSignUpToken(email);

--- a/src/test/java/com/example/solidconnection/auth/service/SignUpTokenProviderTest.java
+++ b/src/test/java/com/example/solidconnection/auth/service/SignUpTokenProviderTest.java
@@ -1,0 +1,70 @@
+package com.example.solidconnection.auth.service;
+
+import com.example.solidconnection.auth.domain.TokenType;
+import com.example.solidconnection.config.security.JwtProperties;
+import com.example.solidconnection.support.TestContainerSpringBootTest;
+import com.example.solidconnection.util.JwtUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@TestContainerSpringBootTest
+@DisplayName("회원가입 토큰 제공자 테스트")
+class SignUpTokenProviderTest {
+
+    @Autowired
+    private SignUpTokenProvider signUpTokenProvider;
+
+    @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Autowired
+    private JwtProperties jwtProperties;
+
+    @Test
+    void 회원가입_토큰을_생성하고_저장한다() {
+        // when
+        String email = "email";
+        String signUpToken = signUpTokenProvider.generateAndSaveSignUpToken(email);
+
+        // then
+        String actualSubject = JwtUtils.parseSubject(signUpToken, jwtProperties.secret());
+        String signUpTokenKey = TokenType.SIGN_UP.addPrefixToSubject(email);
+        assertAll(
+                () -> assertThat(actualSubject).isEqualTo(email),
+                () -> assertThat(redisTemplate.opsForValue().get(signUpTokenKey)).isEqualTo(signUpToken)
+        );
+    }
+
+    @Test
+    void 저장된_회원가입_토큰을_조회한다() {
+        // given
+        String email = "email";
+        String signUpToken = "token";
+        redisTemplate.opsForValue().set(TokenType.SIGN_UP.addPrefixToSubject(email), signUpToken);
+
+        // when
+        Optional<String> actualSignUpToken = signUpTokenProvider.findSignUpToken(email);
+
+        // then
+        assertThat(actualSignUpToken).hasValue(signUpToken);
+    }
+
+    @Test
+    void 저장되지_않은_회원가입_토큰을_조회한다() {
+        // given
+        String email = "email";
+
+        // when
+        Optional<String> actualSignUpToken = signUpTokenProvider.findSignUpToken(email);
+
+        // then
+        assertThat(actualSignUpToken).isEmpty();
+    }
+}

--- a/src/test/java/com/example/solidconnection/custom/security/filter/SignOutCheckFilterTest.java
+++ b/src/test/java/com/example/solidconnection/custom/security/filter/SignOutCheckFilterTest.java
@@ -59,7 +59,7 @@ class SignOutCheckFilterTest {
         // given
         String token = createToken(subject);
         request = createRequest(token);
-        String refreshTokenKey = BLACKLIST.addPrefixToSubject(token);
+        String refreshTokenKey = BLACKLIST.addPrefix(token);
         redisTemplate.opsForValue().set(refreshTokenKey, "signOut");
 
         // when & then

--- a/src/test/java/com/example/solidconnection/e2e/ApplicantsQueryTest.java
+++ b/src/test/java/com/example/solidconnection/e2e/ApplicantsQueryTest.java
@@ -65,17 +65,14 @@ class ApplicantsQueryTest extends UniversityDataSetUpEndToEndTest {
         SiteUser 사용자6 = siteUserRepository.save(createSiteUserByEmail("email6"));
 
         // setUp - 엑세스 토큰 생성과 리프레시 토큰 생성 및 저장
-        accessToken = tokenProvider.generateToken(나, TokenType.ACCESS);
-        String refreshToken = tokenProvider.generateToken(나, TokenType.REFRESH);
-        tokenProvider.saveToken(refreshToken, TokenType.REFRESH);
+        accessToken = tokenProvider.generateAccessToken(나);
+        tokenProvider.generateAndSaveRefreshToken(나);
 
-        adminAccessToken = tokenProvider.generateToken(사용자5_관리자, TokenType.ACCESS);
-        String adminRefreshToken = tokenProvider.generateToken(사용자5_관리자, TokenType.REFRESH);
-        tokenProvider.saveToken(adminRefreshToken, TokenType.REFRESH);
+        adminAccessToken = tokenProvider.generateAccessToken(사용자5_관리자);
+        tokenProvider.generateAndSaveRefreshToken(사용자5_관리자);
 
-        user6AccessToken = tokenProvider.generateToken(사용자6, TokenType.ACCESS);
-        String user6RefreshToken = tokenProvider.generateToken(사용자6, TokenType.REFRESH);
-        tokenProvider.saveToken(user6RefreshToken, TokenType.REFRESH);
+        user6AccessToken = tokenProvider.generateAccessToken(사용자6);
+        tokenProvider.generateAndSaveRefreshToken(사용자6);
 
         // setUp - 지원 정보 저장
         Gpa gpa = createDummyGpa();

--- a/src/test/java/com/example/solidconnection/e2e/ApplicantsQueryTest.java
+++ b/src/test/java/com/example/solidconnection/e2e/ApplicantsQueryTest.java
@@ -7,8 +7,7 @@ import com.example.solidconnection.application.dto.ApplicantResponse;
 import com.example.solidconnection.application.dto.ApplicationsResponse;
 import com.example.solidconnection.application.dto.UniversityApplicantsResponse;
 import com.example.solidconnection.application.repository.ApplicationRepository;
-import com.example.solidconnection.auth.domain.TokenType;
-import com.example.solidconnection.auth.service.TokenProvider;
+import com.example.solidconnection.auth.service.AuthTokenProvider;
 import com.example.solidconnection.siteuser.domain.SiteUser;
 import com.example.solidconnection.siteuser.repository.SiteUserRepository;
 import com.example.solidconnection.type.VerifyStatus;
@@ -36,7 +35,7 @@ class ApplicantsQueryTest extends UniversityDataSetUpEndToEndTest {
     private ApplicationRepository applicationRepository;
 
     @Autowired
-    private TokenProvider tokenProvider;
+    private AuthTokenProvider authTokenProvider;
 
     private String accessToken;
     private String adminAccessToken;
@@ -65,14 +64,14 @@ class ApplicantsQueryTest extends UniversityDataSetUpEndToEndTest {
         SiteUser 사용자6 = siteUserRepository.save(createSiteUserByEmail("email6"));
 
         // setUp - 엑세스 토큰 생성과 리프레시 토큰 생성 및 저장
-        accessToken = tokenProvider.generateAccessToken(나);
-        tokenProvider.generateAndSaveRefreshToken(나);
+        accessToken = authTokenProvider.generateAccessToken(나);
+        authTokenProvider.generateAndSaveRefreshToken(나);
 
-        adminAccessToken = tokenProvider.generateAccessToken(사용자5_관리자);
-        tokenProvider.generateAndSaveRefreshToken(사용자5_관리자);
+        adminAccessToken = authTokenProvider.generateAccessToken(사용자5_관리자);
+        authTokenProvider.generateAndSaveRefreshToken(사용자5_관리자);
 
-        user6AccessToken = tokenProvider.generateAccessToken(사용자6);
-        tokenProvider.generateAndSaveRefreshToken(사용자6);
+        user6AccessToken = authTokenProvider.generateAccessToken(사용자6);
+        authTokenProvider.generateAndSaveRefreshToken(사용자6);
 
         // setUp - 지원 정보 저장
         Gpa gpa = createDummyGpa();

--- a/src/test/java/com/example/solidconnection/e2e/MyPageTest.java
+++ b/src/test/java/com/example/solidconnection/e2e/MyPageTest.java
@@ -1,6 +1,6 @@
 package com.example.solidconnection.e2e;
 
-import com.example.solidconnection.auth.service.TokenProvider;
+import com.example.solidconnection.auth.service.AuthTokenProvider;
 import com.example.solidconnection.siteuser.domain.SiteUser;
 import com.example.solidconnection.siteuser.dto.MyPageResponse;
 import com.example.solidconnection.siteuser.repository.SiteUserRepository;
@@ -24,7 +24,7 @@ class MyPageTest extends BaseEndToEndTest {
     private SiteUserRepository siteUserRepository;
 
     @Autowired
-    private TokenProvider tokenProvider;
+    private AuthTokenProvider authTokenProvider;
 
     private String accessToken;
 
@@ -34,8 +34,8 @@ class MyPageTest extends BaseEndToEndTest {
         siteUser = siteUserRepository.save(createSiteUserByEmail("email"));
 
         // setUp - 엑세스 토큰 생성과 리프레시 토큰 생성 및 저장
-        accessToken = tokenProvider.generateAccessToken(siteUser);
-        tokenProvider.generateAndSaveRefreshToken(siteUser);
+        accessToken = authTokenProvider.generateAccessToken(siteUser);
+        authTokenProvider.generateAndSaveRefreshToken(siteUser);
     }
 
     @Test

--- a/src/test/java/com/example/solidconnection/e2e/MyPageTest.java
+++ b/src/test/java/com/example/solidconnection/e2e/MyPageTest.java
@@ -1,7 +1,6 @@
 package com.example.solidconnection.e2e;
 
 import com.example.solidconnection.auth.service.TokenProvider;
-import com.example.solidconnection.auth.domain.TokenType;
 import com.example.solidconnection.siteuser.domain.SiteUser;
 import com.example.solidconnection.siteuser.dto.MyPageResponse;
 import com.example.solidconnection.siteuser.repository.SiteUserRepository;
@@ -35,9 +34,8 @@ class MyPageTest extends BaseEndToEndTest {
         siteUser = siteUserRepository.save(createSiteUserByEmail("email"));
 
         // setUp - 엑세스 토큰 생성과 리프레시 토큰 생성 및 저장
-        accessToken = tokenProvider.generateToken(siteUser, TokenType.ACCESS);
-        String refreshToken = tokenProvider.generateToken(siteUser, TokenType.REFRESH);
-        tokenProvider.saveToken(refreshToken, TokenType.REFRESH);
+        accessToken = tokenProvider.generateAccessToken(siteUser);
+        tokenProvider.generateAndSaveRefreshToken(siteUser);
     }
 
     @Test

--- a/src/test/java/com/example/solidconnection/e2e/MyPageUpdateTest.java
+++ b/src/test/java/com/example/solidconnection/e2e/MyPageUpdateTest.java
@@ -1,7 +1,6 @@
 package com.example.solidconnection.e2e;
 
 import com.example.solidconnection.auth.service.TokenProvider;
-import com.example.solidconnection.auth.domain.TokenType;
 import com.example.solidconnection.custom.response.ErrorResponse;
 import com.example.solidconnection.siteuser.domain.SiteUser;
 import com.example.solidconnection.siteuser.dto.MyPageUpdateResponse;
@@ -44,9 +43,8 @@ class MyPageUpdateTest extends BaseEndToEndTest {
         siteUserRepository.save(siteUser);
 
         // setUp - 엑세스 토큰 생성과 리프레시 토큰 생성 및 저장
-        accessToken = tokenProvider.generateToken(siteUser, TokenType.ACCESS);
-        String refreshToken = tokenProvider.generateToken(siteUser, TokenType.REFRESH);
-        tokenProvider.saveToken(refreshToken, TokenType.REFRESH);
+        accessToken = tokenProvider.generateAccessToken(siteUser);
+        tokenProvider.generateAndSaveRefreshToken(siteUser);
     }
 
     @Test

--- a/src/test/java/com/example/solidconnection/e2e/MyPageUpdateTest.java
+++ b/src/test/java/com/example/solidconnection/e2e/MyPageUpdateTest.java
@@ -1,6 +1,6 @@
 package com.example.solidconnection.e2e;
 
-import com.example.solidconnection.auth.service.TokenProvider;
+import com.example.solidconnection.auth.service.AuthTokenProvider;
 import com.example.solidconnection.custom.response.ErrorResponse;
 import com.example.solidconnection.siteuser.domain.SiteUser;
 import com.example.solidconnection.siteuser.dto.MyPageUpdateResponse;
@@ -30,7 +30,7 @@ class MyPageUpdateTest extends BaseEndToEndTest {
     private SiteUserRepository siteUserRepository;
 
     @Autowired
-    private TokenProvider tokenProvider;
+    private AuthTokenProvider authTokenProvider;
 
     private String accessToken;
 
@@ -43,8 +43,8 @@ class MyPageUpdateTest extends BaseEndToEndTest {
         siteUserRepository.save(siteUser);
 
         // setUp - 엑세스 토큰 생성과 리프레시 토큰 생성 및 저장
-        accessToken = tokenProvider.generateAccessToken(siteUser);
-        tokenProvider.generateAndSaveRefreshToken(siteUser);
+        accessToken = authTokenProvider.generateAccessToken(siteUser);
+        authTokenProvider.generateAndSaveRefreshToken(siteUser);
     }
 
     @Test

--- a/src/test/java/com/example/solidconnection/e2e/SignInTest.java
+++ b/src/test/java/com/example/solidconnection/e2e/SignInTest.java
@@ -18,8 +18,8 @@ import org.springframework.http.HttpStatus;
 
 import java.time.LocalDate;
 
-import static com.example.solidconnection.auth.domain.TokenType.KAKAO_OAUTH;
 import static com.example.solidconnection.auth.domain.TokenType.REFRESH;
+import static com.example.solidconnection.auth.domain.TokenType.SIGN_UP;
 import static com.example.solidconnection.e2e.DynamicFixture.createKakaoUserInfoDtoByEmail;
 import static com.example.solidconnection.e2e.DynamicFixture.createSiteUserByEmail;
 import static com.example.solidconnection.scheduler.UserRemovalScheduler.ACCOUNT_RECOVER_DURATION;
@@ -65,7 +65,7 @@ class SignInTest extends BaseEndToEndTest {
                 () -> assertThat(response.nickname()).isEqualTo(kakaoProfileDto.nickname()),
                 () -> assertThat(response.profileImageUrl()).isEqualTo(kakaoProfileDto.profileImageUrl()),
                 () -> assertThat(response.kakaoOauthToken()).isNotNull());
-        assertThat(redisTemplate.opsForValue().get(KAKAO_OAUTH.addPrefixToSubject(email)))
+        assertThat(redisTemplate.opsForValue().get(SIGN_UP.addPrefixToSubject(email)))
                 .as("카카오 인증 토큰을 저장한다.")
                 .isEqualTo(response.kakaoOauthToken());
     }

--- a/src/test/java/com/example/solidconnection/e2e/SignInTest.java
+++ b/src/test/java/com/example/solidconnection/e2e/SignInTest.java
@@ -65,7 +65,7 @@ class SignInTest extends BaseEndToEndTest {
                 () -> assertThat(response.nickname()).isEqualTo(kakaoProfileDto.nickname()),
                 () -> assertThat(response.profileImageUrl()).isEqualTo(kakaoProfileDto.profileImageUrl()),
                 () -> assertThat(response.kakaoOauthToken()).isNotNull());
-        assertThat(redisTemplate.opsForValue().get(SIGN_UP.addPrefixToSubject(email)))
+        assertThat(redisTemplate.opsForValue().get(SIGN_UP.addPrefix(email)))
                 .as("카카오 인증 토큰을 저장한다.")
                 .isEqualTo(response.kakaoOauthToken());
     }
@@ -95,7 +95,7 @@ class SignInTest extends BaseEndToEndTest {
                 () -> assertThat(response.isRegistered()).isTrue(),
                 () -> assertThat(response.accessToken()).isNotNull(),
                 () -> assertThat(response.refreshToken()).isNotNull());
-        assertThat(redisTemplate.opsForValue().get(REFRESH.addPrefixToSubject(siteUser.getId().toString())))
+        assertThat(redisTemplate.opsForValue().get(REFRESH.addPrefix(siteUser.getId().toString())))
                 .as("리프레시 토큰을 저장한다.")
                 .isEqualTo(response.refreshToken());
     }
@@ -130,7 +130,7 @@ class SignInTest extends BaseEndToEndTest {
                 () -> assertThat(response.accessToken()).isNotNull(),
                 () -> assertThat(response.refreshToken()).isNotNull(),
                 () -> assertThat(updatedSiteUser.getQuitedAt()).isNull());
-        assertThat(redisTemplate.opsForValue().get(REFRESH.addPrefixToSubject(siteUser.getId().toString())))
+        assertThat(redisTemplate.opsForValue().get(REFRESH.addPrefix(siteUser.getId().toString())))
                 .as("리프레시 토큰을 저장한다.")
                 .isEqualTo(response.refreshToken());
     }

--- a/src/test/java/com/example/solidconnection/e2e/SignUpTest.java
+++ b/src/test/java/com/example/solidconnection/e2e/SignUpTest.java
@@ -2,7 +2,8 @@ package com.example.solidconnection.e2e;
 
 import com.example.solidconnection.auth.dto.SignUpRequest;
 import com.example.solidconnection.auth.dto.SignUpResponse;
-import com.example.solidconnection.auth.service.TokenProvider;
+import com.example.solidconnection.auth.service.AuthTokenProvider;
+import com.example.solidconnection.auth.service.SignUpTokenProvider;
 import com.example.solidconnection.custom.response.ErrorResponse;
 import com.example.solidconnection.entity.Country;
 import com.example.solidconnection.entity.InterestedCountry;
@@ -27,7 +28,6 @@ import org.springframework.http.HttpStatus;
 
 import java.util.List;
 
-import static com.example.solidconnection.auth.domain.TokenType.KAKAO_OAUTH;
 import static com.example.solidconnection.auth.domain.TokenType.REFRESH;
 import static com.example.solidconnection.custom.exception.ErrorCode.JWT_EXCEPTION;
 import static com.example.solidconnection.custom.exception.ErrorCode.NICKNAME_ALREADY_EXISTED;
@@ -56,7 +56,10 @@ class SignUpTest extends BaseEndToEndTest {
     InterestedCountyRepository interestedCountyRepository;
 
     @Autowired
-    TokenProvider tokenProvider;
+    AuthTokenProvider authTokenProvider;
+
+    @Autowired
+    SignUpTokenProvider signUpTokenProvider;
 
     @Autowired
     RedisTemplate<String, String> redisTemplate;
@@ -71,8 +74,7 @@ class SignUpTest extends BaseEndToEndTest {
 
         // setup - 카카오 토큰 발급
         String email = "email@email.com";
-        String generatedKakaoToken = tokenProvider.generateToken(email, KAKAO_OAUTH);
-        tokenProvider.saveToken(generatedKakaoToken, KAKAO_OAUTH);
+        String generatedKakaoToken = signUpTokenProvider.generateAndSaveSignUpToken(email);
 
         // request - body 생성 및 요청
         List<String> interestedRegionNames = List.of("유럽");
@@ -124,8 +126,7 @@ class SignUpTest extends BaseEndToEndTest {
 
         // setup - 카카오 토큰 발급
         String email = "email@email.com";
-        String generatedKakaoToken = tokenProvider.generateToken(email, KAKAO_OAUTH);
-        tokenProvider.saveToken(generatedKakaoToken, KAKAO_OAUTH);
+        String generatedKakaoToken = signUpTokenProvider.generateAndSaveSignUpToken(email);
 
         // request - body 생성 및 요청
         SignUpRequest signUpRequest = new SignUpRequest(generatedKakaoToken, null, null,
@@ -150,8 +151,7 @@ class SignUpTest extends BaseEndToEndTest {
         siteUserRepository.save(alreadyExistUser);
 
         // setup - 카카오 토큰 발급
-        String generatedKakaoToken = tokenProvider.generateToken(alreadyExistEmail, KAKAO_OAUTH);
-        tokenProvider.saveToken(generatedKakaoToken, KAKAO_OAUTH);
+        String generatedKakaoToken = signUpTokenProvider.generateAndSaveSignUpToken(alreadyExistEmail);
 
         // request - body 생성 및 요청
         SignUpRequest signUpRequest = new SignUpRequest(generatedKakaoToken, null, null,

--- a/src/test/java/com/example/solidconnection/e2e/SignUpTest.java
+++ b/src/test/java/com/example/solidconnection/e2e/SignUpTest.java
@@ -112,7 +112,7 @@ class SignUpTest extends BaseEndToEndTest {
                 () -> assertThat(interestedCountries).containsExactlyInAnyOrderElementsOf(countries)
         );
 
-        assertThat(redisTemplate.opsForValue().get(REFRESH.addPrefixToSubject(savedSiteUser.getId().toString())))
+        assertThat(redisTemplate.opsForValue().get(REFRESH.addPrefix(savedSiteUser.getId().toString())))
                 .as("리프레시 토큰을 저장한다.")
                 .isEqualTo(response.refreshToken());
     }

--- a/src/test/java/com/example/solidconnection/e2e/UniversityDetailTest.java
+++ b/src/test/java/com/example/solidconnection/e2e/UniversityDetailTest.java
@@ -1,6 +1,6 @@
 package com.example.solidconnection.e2e;
 
-import com.example.solidconnection.auth.service.TokenProvider;
+import com.example.solidconnection.auth.service.AuthTokenProvider;
 import com.example.solidconnection.siteuser.domain.SiteUser;
 import com.example.solidconnection.siteuser.repository.SiteUserRepository;
 import com.example.solidconnection.university.dto.LanguageRequirementResponse;
@@ -23,7 +23,7 @@ class UniversityDetailTest extends UniversityDataSetUpEndToEndTest {
     private SiteUserRepository siteUserRepository;
 
     @Autowired
-    private TokenProvider tokenProvider;
+    private AuthTokenProvider authTokenProvider;
 
     private String accessToken;
 
@@ -35,8 +35,8 @@ class UniversityDetailTest extends UniversityDataSetUpEndToEndTest {
         siteUserRepository.save(siteUser);
 
         // setUp - 엑세스 토큰 생성과 리프레시 토큰 생성 및 저장
-        accessToken = tokenProvider.generateAccessToken(siteUser);
-        tokenProvider.generateAndSaveRefreshToken(siteUser);
+        accessToken = authTokenProvider.generateAccessToken(siteUser);
+        authTokenProvider.generateAndSaveRefreshToken(siteUser);
     }
 
     @Test

--- a/src/test/java/com/example/solidconnection/e2e/UniversityDetailTest.java
+++ b/src/test/java/com/example/solidconnection/e2e/UniversityDetailTest.java
@@ -1,7 +1,6 @@
 package com.example.solidconnection.e2e;
 
 import com.example.solidconnection.auth.service.TokenProvider;
-import com.example.solidconnection.auth.domain.TokenType;
 import com.example.solidconnection.siteuser.domain.SiteUser;
 import com.example.solidconnection.siteuser.repository.SiteUserRepository;
 import com.example.solidconnection.university.dto.LanguageRequirementResponse;
@@ -36,11 +35,10 @@ class UniversityDetailTest extends UniversityDataSetUpEndToEndTest {
         siteUserRepository.save(siteUser);
 
         // setUp - 엑세스 토큰 생성과 리프레시 토큰 생성 및 저장
-        accessToken = tokenProvider.generateToken(siteUser, TokenType.ACCESS);
-        String refreshToken = tokenProvider.generateToken(siteUser, TokenType.REFRESH);
-        tokenProvider.saveToken(refreshToken, TokenType.REFRESH);
+        accessToken = tokenProvider.generateAccessToken(siteUser);
+        tokenProvider.generateAndSaveRefreshToken(siteUser);
     }
-    
+
     @Test
     void 대학교_정보를_조회한다() {
         // request - 요청

--- a/src/test/java/com/example/solidconnection/e2e/UniversityLikeTest.java
+++ b/src/test/java/com/example/solidconnection/e2e/UniversityLikeTest.java
@@ -1,7 +1,6 @@
 package com.example.solidconnection.e2e;
 
 import com.example.solidconnection.auth.service.TokenProvider;
-import com.example.solidconnection.auth.domain.TokenType;
 import com.example.solidconnection.siteuser.domain.SiteUser;
 import com.example.solidconnection.siteuser.repository.LikedUniversityRepository;
 import com.example.solidconnection.siteuser.repository.SiteUserRepository;
@@ -28,7 +27,7 @@ import static com.example.solidconnection.e2e.DynamicFixture.createUniversityFor
 import static com.example.solidconnection.university.service.UniversityLikeService.LIKE_CANCELED_MESSAGE;
 import static com.example.solidconnection.university.service.UniversityLikeService.LIKE_SUCCESS_MESSAGE;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 @DisplayName("대학교 좋아요 테스트")
 class UniversityLikeTest extends UniversityDataSetUpEndToEndTest {
@@ -55,9 +54,8 @@ class UniversityLikeTest extends UniversityDataSetUpEndToEndTest {
         siteUserRepository.save(siteUser);
 
         // setUp - 엑세스 토큰 생성과 리프레시 토큰 생성 및 저장
-        accessToken = tokenProvider.generateToken(siteUser, TokenType.ACCESS);
-        String refreshToken = tokenProvider.generateToken(siteUser, TokenType.REFRESH);
-        tokenProvider.saveToken(refreshToken, TokenType.REFRESH);
+        accessToken = tokenProvider.generateAccessToken(siteUser);
+        tokenProvider.generateAndSaveRefreshToken(siteUser);
     }
 
     @Test
@@ -138,7 +136,7 @@ class UniversityLikeTest extends UniversityDataSetUpEndToEndTest {
         // request - 요청
         IsLikeResponse response = RestAssured.given().log().all()
                 .header("Authorization", "Bearer " + accessToken)
-                .get("/university/"+ 괌대학_A_지원_정보.getId() +"/like")
+                .get("/university/" + 괌대학_A_지원_정보.getId() + "/like")
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())
                 .extract().as(IsLikeResponse.class);

--- a/src/test/java/com/example/solidconnection/e2e/UniversityLikeTest.java
+++ b/src/test/java/com/example/solidconnection/e2e/UniversityLikeTest.java
@@ -1,6 +1,6 @@
 package com.example.solidconnection.e2e;
 
-import com.example.solidconnection.auth.service.TokenProvider;
+import com.example.solidconnection.auth.service.AuthTokenProvider;
 import com.example.solidconnection.siteuser.domain.SiteUser;
 import com.example.solidconnection.siteuser.repository.LikedUniversityRepository;
 import com.example.solidconnection.siteuser.repository.SiteUserRepository;
@@ -42,7 +42,7 @@ class UniversityLikeTest extends UniversityDataSetUpEndToEndTest {
     private LikedUniversityRepository likedUniversityRepository;
 
     @Autowired
-    private TokenProvider tokenProvider;
+    private AuthTokenProvider authTokenProvider;
 
     private String accessToken;
     private SiteUser siteUser;
@@ -54,8 +54,8 @@ class UniversityLikeTest extends UniversityDataSetUpEndToEndTest {
         siteUserRepository.save(siteUser);
 
         // setUp - 엑세스 토큰 생성과 리프레시 토큰 생성 및 저장
-        accessToken = tokenProvider.generateAccessToken(siteUser);
-        tokenProvider.generateAndSaveRefreshToken(siteUser);
+        accessToken = authTokenProvider.generateAccessToken(siteUser);
+        authTokenProvider.generateAndSaveRefreshToken(siteUser);
     }
 
     @Test

--- a/src/test/java/com/example/solidconnection/e2e/UniversityRecommendTest.java
+++ b/src/test/java/com/example/solidconnection/e2e/UniversityRecommendTest.java
@@ -1,6 +1,6 @@
 package com.example.solidconnection.e2e;
 
-import com.example.solidconnection.auth.service.TokenProvider;
+import com.example.solidconnection.auth.service.AuthTokenProvider;
 import com.example.solidconnection.entity.InterestedCountry;
 import com.example.solidconnection.entity.InterestedRegion;
 import com.example.solidconnection.repositories.InterestedCountyRepository;
@@ -37,7 +37,7 @@ class UniversityRecommendTest extends UniversityDataSetUpEndToEndTest {
     private InterestedCountyRepository interestedCountyRepository;
 
     @Autowired
-    private TokenProvider tokenProvider;
+    private AuthTokenProvider authTokenProvider;
 
     @Autowired
     private GeneralUniversityRecommendService generalUniversityRecommendService;
@@ -53,8 +53,8 @@ class UniversityRecommendTest extends UniversityDataSetUpEndToEndTest {
         generalUniversityRecommendService.init();
 
         // setUp - 엑세스 토큰 생성과 리프레시 토큰 생성 및 저장
-        accessToken = tokenProvider.generateAccessToken(siteUser);
-        tokenProvider.generateAndSaveRefreshToken(siteUser);
+        accessToken = authTokenProvider.generateAccessToken(siteUser);
+        authTokenProvider.generateAndSaveRefreshToken(siteUser);
     }
 
     @Test

--- a/src/test/java/com/example/solidconnection/e2e/UniversityRecommendTest.java
+++ b/src/test/java/com/example/solidconnection/e2e/UniversityRecommendTest.java
@@ -1,7 +1,6 @@
 package com.example.solidconnection.e2e;
 
 import com.example.solidconnection.auth.service.TokenProvider;
-import com.example.solidconnection.auth.domain.TokenType;
 import com.example.solidconnection.entity.InterestedCountry;
 import com.example.solidconnection.entity.InterestedRegion;
 import com.example.solidconnection.repositories.InterestedCountyRepository;
@@ -54,9 +53,8 @@ class UniversityRecommendTest extends UniversityDataSetUpEndToEndTest {
         generalUniversityRecommendService.init();
 
         // setUp - 엑세스 토큰 생성과 리프레시 토큰 생성 및 저장
-        accessToken = tokenProvider.generateToken(siteUser, TokenType.ACCESS);
-        String refreshToken = tokenProvider.generateToken(siteUser, TokenType.REFRESH);
-        tokenProvider.saveToken(refreshToken, TokenType.REFRESH);
+        accessToken = tokenProvider.generateAccessToken(siteUser);
+        tokenProvider.generateAndSaveRefreshToken(siteUser);
     }
 
     @Test

--- a/src/test/java/com/example/solidconnection/e2e/UniversitySearchTest.java
+++ b/src/test/java/com/example/solidconnection/e2e/UniversitySearchTest.java
@@ -1,6 +1,6 @@
 package com.example.solidconnection.e2e;
 
-import com.example.solidconnection.auth.service.TokenProvider;
+import com.example.solidconnection.auth.service.AuthTokenProvider;
 import com.example.solidconnection.siteuser.domain.SiteUser;
 import com.example.solidconnection.siteuser.repository.SiteUserRepository;
 import com.example.solidconnection.university.dto.UniversityInfoForApplyPreviewResponse;
@@ -22,7 +22,7 @@ class UniversitySearchTest extends UniversityDataSetUpEndToEndTest {
     private SiteUserRepository siteUserRepository;
 
     @Autowired
-    private TokenProvider tokenProvider;
+    private AuthTokenProvider authTokenProvider;
 
     private String accessToken;
     private SiteUser siteUser;
@@ -34,8 +34,8 @@ class UniversitySearchTest extends UniversityDataSetUpEndToEndTest {
         siteUserRepository.save(siteUser);
 
         // setUp - 엑세스 토큰 생성과 리프레시 토큰 생성 및 저장
-        accessToken = tokenProvider.generateAccessToken(siteUser);
-        tokenProvider.generateAndSaveRefreshToken(siteUser);
+        accessToken = authTokenProvider.generateAccessToken(siteUser);
+        authTokenProvider.generateAndSaveRefreshToken(siteUser);
     }
 
     @Test

--- a/src/test/java/com/example/solidconnection/e2e/UniversitySearchTest.java
+++ b/src/test/java/com/example/solidconnection/e2e/UniversitySearchTest.java
@@ -1,6 +1,5 @@
 package com.example.solidconnection.e2e;
 
-import com.example.solidconnection.auth.domain.TokenType;
 import com.example.solidconnection.auth.service.TokenProvider;
 import com.example.solidconnection.siteuser.domain.SiteUser;
 import com.example.solidconnection.siteuser.repository.SiteUserRepository;
@@ -35,9 +34,8 @@ class UniversitySearchTest extends UniversityDataSetUpEndToEndTest {
         siteUserRepository.save(siteUser);
 
         // setUp - 엑세스 토큰 생성과 리프레시 토큰 생성 및 저장
-        accessToken = tokenProvider.generateToken(siteUser, TokenType.ACCESS);
-        String refreshToken = tokenProvider.generateToken(siteUser, TokenType.REFRESH);
-        tokenProvider.saveToken(refreshToken, TokenType.REFRESH);
+        accessToken = tokenProvider.generateAccessToken(siteUser);
+        tokenProvider.generateAndSaveRefreshToken(siteUser);
     }
 
     @Test


### PR DESCRIPTION
## 작업 내용

<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->
![image](https://github.com/user-attachments/assets/58ce0fbd-62a3-4062-9dfe-3d42c08f6aae)

https://github.com/solid-connection/solid-connect-server/pull/171#discussion_r1942132647 이 코멘트의 내용을 적용했습니다.
처음에는 리팩터링 우선순위가 높지 않다고 생각했었는데,. 
애플 로그인을 구현하며 SignUpToken 생성, 저장 로직을 구현하다보니 기존 함수들을 어떻게 사용해야할지 헷갈리더라고요😵‍💫
왜냐하면 기존에는 TokenProvider 에서 TokenType 을 인자로 받게하고, 
개발자가 이들을 함수를 조합해서 사용하게 했기 때문입니다.
**그래서 확장성은 고려되었지만, 각각의 타입에 맞는 제약은 개발자 개인에게 달려있었어요.**
게다가 위백님이 짚어주신 것처럼, '왜 여기에서는 오버로딩을 했지?'하는 의문도 들게 하고요.
그래서 TokenProvider 에서 각 토큰에 대한 로직을 캡슐화하도록 코드를 변경했습니다.

## 특이 사항

다른 특이사항은 코멘트로 남길게요!
