### PR TITLE
refactor: 사용하지 않을 컬럼 제거

### DIFF
--- a/src/main/java/com/example/solidconnection/application/service/ApplicationSubmissionService.java
+++ b/src/main/java/com/example/solidconnection/application/service/ApplicationSubmissionService.java
@@ -10,7 +10,6 @@ import com.example.solidconnection.score.domain.LanguageTestScore;
 import com.example.solidconnection.score.repository.GpaScoreRepository;
 import com.example.solidconnection.score.repository.LanguageTestScoreRepository;
 import com.example.solidconnection.siteuser.domain.SiteUser;
-import com.example.solidconnection.siteuser.repository.SiteUserRepository;
 import com.example.solidconnection.type.VerifyStatus;
 import com.example.solidconnection.university.domain.UniversityInfoForApply;
 import com.example.solidconnection.university.repository.UniversityInfoForApplyRepository;

--- a/src/main/java/com/example/solidconnection/score/domain/GpaScore.java
+++ b/src/main/java/com/example/solidconnection/score/domain/GpaScore.java
@@ -33,8 +33,6 @@ public class GpaScore extends BaseEntity {
     @Embedded
     private Gpa gpa;
 
-    private LocalDate issueDate;
-
     @Setter
     @Column(columnDefinition = "varchar(50) not null default 'PENDING'")
     @Enumerated(EnumType.STRING)
@@ -45,10 +43,9 @@ public class GpaScore extends BaseEntity {
     @ManyToOne
     private SiteUser siteUser;
 
-    public GpaScore(Gpa gpa, SiteUser siteUser, LocalDate issueDate) {
+    public GpaScore(Gpa gpa, SiteUser siteUser) {
         this.gpa = gpa;
         this.siteUser = siteUser;
-        this.issueDate = issueDate;
         this.verifyStatus = VerifyStatus.PENDING;
         this.rejectedReason = null;
     }

--- a/src/main/java/com/example/solidconnection/score/domain/GpaScore.java
+++ b/src/main/java/com/example/solidconnection/score/domain/GpaScore.java
@@ -18,8 +18,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import java.time.LocalDate;
-
 @Getter
 @Entity
 @NoArgsConstructor

--- a/src/main/java/com/example/solidconnection/score/domain/LanguageTestScore.java
+++ b/src/main/java/com/example/solidconnection/score/domain/LanguageTestScore.java
@@ -33,8 +33,6 @@ public class LanguageTestScore extends BaseEntity {
     @Embedded
     private LanguageTest languageTest;
 
-    private LocalDate issueDate;
-
     @Setter
     @Column(columnDefinition = "varchar(50) not null default 'PENDING'")
     @Enumerated(EnumType.STRING)
@@ -45,9 +43,8 @@ public class LanguageTestScore extends BaseEntity {
     @ManyToOne
     private SiteUser siteUser;
 
-    public LanguageTestScore(LanguageTest languageTest, LocalDate issueDate, SiteUser siteUser) {
+    public LanguageTestScore(LanguageTest languageTest, SiteUser siteUser) {
         this.languageTest = languageTest;
-        this.issueDate = issueDate;
         this.verifyStatus = VerifyStatus.PENDING;
         this.siteUser = siteUser;
     }

--- a/src/main/java/com/example/solidconnection/score/domain/LanguageTestScore.java
+++ b/src/main/java/com/example/solidconnection/score/domain/LanguageTestScore.java
@@ -18,8 +18,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import java.time.LocalDate;
-
 @Getter
 @Entity
 @NoArgsConstructor

--- a/src/main/java/com/example/solidconnection/score/dto/GpaScoreRequest.java
+++ b/src/main/java/com/example/solidconnection/score/dto/GpaScoreRequest.java
@@ -13,9 +13,6 @@ public record GpaScoreRequest(
         @NotNull(message = "학점 기준을 입력해주세요.")
         Double gpaCriteria,
 
-        @NotNull(message = "발급일자를 입력해주세요.")
-        LocalDate issueDate,
-
         @NotBlank(message = "대학 성적 증명서를 첨부해주세요.")
         String gpaReportUrl) {
 

--- a/src/main/java/com/example/solidconnection/score/dto/GpaScoreRequest.java
+++ b/src/main/java/com/example/solidconnection/score/dto/GpaScoreRequest.java
@@ -4,8 +4,6 @@ import com.example.solidconnection.application.domain.Gpa;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
-import java.time.LocalDate;
-
 public record GpaScoreRequest(
         @NotNull(message = "학점을 입력해주세요.")
         Double gpa,

--- a/src/main/java/com/example/solidconnection/score/dto/GpaScoreStatus.java
+++ b/src/main/java/com/example/solidconnection/score/dto/GpaScoreStatus.java
@@ -4,8 +4,6 @@ import com.example.solidconnection.application.domain.Gpa;
 import com.example.solidconnection.score.domain.GpaScore;
 import com.example.solidconnection.type.VerifyStatus;
 
-import java.time.LocalDate;
-
 public record GpaScoreStatus(
         Long id,
         Gpa gpa,

--- a/src/main/java/com/example/solidconnection/score/dto/GpaScoreStatus.java
+++ b/src/main/java/com/example/solidconnection/score/dto/GpaScoreStatus.java
@@ -9,7 +9,6 @@ import java.time.LocalDate;
 public record GpaScoreStatus(
         Long id,
         Gpa gpa,
-        LocalDate issueDate,
         VerifyStatus verifyStatus,
         String rejectedReason
 ) {
@@ -17,7 +16,6 @@ public record GpaScoreStatus(
         return new GpaScoreStatus(
                 gpaScore.getId(),
                 gpaScore.getGpa(),
-                gpaScore.getIssueDate(),
                 gpaScore.getVerifyStatus(),
                 gpaScore.getRejectedReason()
         );

--- a/src/main/java/com/example/solidconnection/score/dto/LanguageTestScoreRequest.java
+++ b/src/main/java/com/example/solidconnection/score/dto/LanguageTestScoreRequest.java
@@ -1,12 +1,9 @@
 package com.example.solidconnection.score.dto;
 
-
 import com.example.solidconnection.application.domain.LanguageTest;
 import com.example.solidconnection.type.LanguageTestType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-
-import java.time.LocalDate;
 
 public record LanguageTestScoreRequest(
         @NotNull(message = "어학 종류를 입력해주세요.")

--- a/src/main/java/com/example/solidconnection/score/dto/LanguageTestScoreRequest.java
+++ b/src/main/java/com/example/solidconnection/score/dto/LanguageTestScoreRequest.java
@@ -15,9 +15,6 @@ public record LanguageTestScoreRequest(
         @NotBlank(message = "어학 점수를 입력해주세요.")
         String languageTestScore,
 
-        @NotNull(message = "발급일자를 입력해주세요.")
-        LocalDate issueDate,
-
         @NotBlank(message = "어학 증명서를 첨부해주세요.")
         String languageTestReportUrl) {
 

--- a/src/main/java/com/example/solidconnection/score/dto/LanguageTestScoreStatus.java
+++ b/src/main/java/com/example/solidconnection/score/dto/LanguageTestScoreStatus.java
@@ -4,8 +4,6 @@ import com.example.solidconnection.application.domain.LanguageTest;
 import com.example.solidconnection.score.domain.LanguageTestScore;
 import com.example.solidconnection.type.VerifyStatus;
 
-import java.time.LocalDate;
-
 public record LanguageTestScoreStatus(
         Long id,
         LanguageTest languageTest,

--- a/src/main/java/com/example/solidconnection/score/dto/LanguageTestScoreStatus.java
+++ b/src/main/java/com/example/solidconnection/score/dto/LanguageTestScoreStatus.java
@@ -9,7 +9,6 @@ import java.time.LocalDate;
 public record LanguageTestScoreStatus(
         Long id,
         LanguageTest languageTest,
-        LocalDate issueDate,
         VerifyStatus verifyStatus,
         String rejectedReason
 ) {
@@ -17,7 +16,6 @@ public record LanguageTestScoreStatus(
         return new LanguageTestScoreStatus(
                 languageTestScore.getId(),
                 languageTestScore.getLanguageTest(),
-                languageTestScore.getIssueDate(),
                 languageTestScore.getVerifyStatus(),
                 languageTestScore.getRejectedReason()
         );

--- a/src/main/java/com/example/solidconnection/score/dto/LanguageTestScoreStatusResponse.java
+++ b/src/main/java/com/example/solidconnection/score/dto/LanguageTestScoreStatusResponse.java
@@ -1,6 +1,5 @@
 package com.example.solidconnection.score.dto;
 
-
 import java.util.List;
 
 public record LanguageTestScoreStatusResponse(

--- a/src/main/java/com/example/solidconnection/score/service/ScoreService.java
+++ b/src/main/java/com/example/solidconnection/score/service/ScoreService.java
@@ -30,7 +30,7 @@ public class ScoreService {
 
     @Transactional
     public Long submitGpaScore(SiteUser siteUser, GpaScoreRequest gpaScoreRequest) {
-        GpaScore newGpaScore = new GpaScore(gpaScoreRequest.toGpa(), siteUser, gpaScoreRequest.issueDate());
+        GpaScore newGpaScore = new GpaScore(gpaScoreRequest.toGpa(), siteUser);
         newGpaScore.setSiteUser(siteUser);
         GpaScore savedNewGpaScore = gpaScoreRepository.save(newGpaScore);  // 저장 후 반환된 객체
         return savedNewGpaScore.getId();  // 저장된 GPA Score의 ID 반환
@@ -41,7 +41,7 @@ public class ScoreService {
         LanguageTest languageTest = languageTestScoreRequest.toLanguageTest();
 
         LanguageTestScore newScore = new LanguageTestScore(
-                languageTest, languageTestScoreRequest.issueDate(), siteUser);
+                languageTest, siteUser);
         newScore.setSiteUser(siteUser);
         LanguageTestScore savedNewScore = languageTestScoreRepository.save(newScore);  // 새로 저장한 객체
         return savedNewScore.getId();  // 저장된 객체의 ID 반환

--- a/src/main/resources/db/migration/V4__remove_issue_date_columns.sql
+++ b/src/main/resources/db/migration/V4__remove_issue_date_columns.sql
@@ -1,0 +1,5 @@
+ALTER TABLE gpa_score
+    DROP COLUMN issue_date;
+
+ALTER TABLE language_test_score
+    DROP COLUMN issue_date;

--- a/src/test/java/com/example/solidconnection/application/service/ApplicationSubmissionServiceTest.java
+++ b/src/test/java/com/example/solidconnection/application/service/ApplicationSubmissionServiceTest.java
@@ -19,8 +19,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import java.time.LocalDate;
-
 import static com.example.solidconnection.application.service.ApplicationSubmissionService.APPLICATION_UPDATE_COUNT_LIMIT;
 import static com.example.solidconnection.custom.exception.ErrorCode.APPLY_UPDATE_LIMIT_EXCEED;
 import static com.example.solidconnection.custom.exception.ErrorCode.CANT_APPLY_FOR_SAME_UNIVERSITY;
@@ -165,8 +163,7 @@ class ApplicationSubmissionServiceTest extends BaseIntegrationTest {
     private GpaScore createUnapprovedGpaScore(SiteUser siteUser) {
         GpaScore gpaScore = new GpaScore(
                 new Gpa(4.0,  4.5, "/gpa-report.pdf"),
-                siteUser,
-                LocalDate.now()
+                siteUser
         );
         return gpaScoreRepository.save(gpaScore);
     }
@@ -174,8 +171,7 @@ class ApplicationSubmissionServiceTest extends BaseIntegrationTest {
     private GpaScore createApprovedGpaScore(SiteUser siteUser) {
         GpaScore gpaScore = new GpaScore(
                 new Gpa(4.0, 4.5, "/gpa-report.pdf"),
-                siteUser,
-                LocalDate.now()
+                siteUser
         );
         gpaScore.setVerifyStatus(VerifyStatus.APPROVED);
         return gpaScoreRepository.save(gpaScore);
@@ -184,7 +180,6 @@ class ApplicationSubmissionServiceTest extends BaseIntegrationTest {
     private LanguageTestScore createUnapprovedLanguageTestScore(SiteUser siteUser) {
         LanguageTestScore languageTestScore = new LanguageTestScore(
                 new LanguageTest(LanguageTestType.TOEIC, "100", "/gpa-report.pdf"),
-                LocalDate.now(),
                 siteUser
         );
         return languageTestScoreRepository.save(languageTestScore);
@@ -193,7 +188,6 @@ class ApplicationSubmissionServiceTest extends BaseIntegrationTest {
     private LanguageTestScore createApprovedLanguageTestScore(SiteUser siteUser) {
         LanguageTestScore languageTestScore = new LanguageTestScore(
                 new LanguageTest(LanguageTestType.TOEIC, "100", "/gpa-report.pdf"),
-                LocalDate.now(),
                 siteUser
         );
         languageTestScore.setVerifyStatus(VerifyStatus.APPROVED);

--- a/src/test/java/com/example/solidconnection/score/service/ScoreServiceTest.java
+++ b/src/test/java/com/example/solidconnection/score/service/ScoreServiceTest.java
@@ -24,7 +24,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import java.time.LocalDate;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -129,7 +128,6 @@ class ScoreServiceTest extends BaseIntegrationTest {
                 () -> assertThat(savedScore.getId()).isEqualTo(scoreId),
                 () -> assertThat(savedScore.getGpa().getGpa()).isEqualTo(request.gpa()),
                 () -> assertThat(savedScore.getGpa().getGpaCriteria()).isEqualTo(request.gpaCriteria()),
-                () -> assertThat(savedScore.getIssueDate()).isEqualTo(request.issueDate()),
                 () -> assertThat(savedScore.getVerifyStatus()).isEqualTo(VerifyStatus.PENDING)
         );
     }
@@ -149,7 +147,6 @@ class ScoreServiceTest extends BaseIntegrationTest {
                 () -> assertThat(savedScore.getId()).isEqualTo(scoreId),
                 () -> assertThat(savedScore.getLanguageTest().getLanguageTestType()).isEqualTo(request.languageTestType()),
                 () -> assertThat(savedScore.getLanguageTest().getLanguageTestScore()).isEqualTo(request.languageTestScore()),
-                () -> assertThat(savedScore.getIssueDate()).isEqualTo(request.issueDate()),
                 () -> assertThat(savedScore.getVerifyStatus()).isEqualTo(VerifyStatus.PENDING)
         );
     }
@@ -170,8 +167,7 @@ class ScoreServiceTest extends BaseIntegrationTest {
     private GpaScore createGpaScore(SiteUser siteUser, double gpa, double gpaCriteria) {
         GpaScore gpaScore = new GpaScore(
                 new Gpa(gpa, gpaCriteria, "/gpa-report.pdf"),
-                siteUser,
-                LocalDate.now()
+                siteUser
         );
         gpaScore.setSiteUser(siteUser);
         return gpaScoreRepository.save(gpaScore);
@@ -180,7 +176,6 @@ class ScoreServiceTest extends BaseIntegrationTest {
     private LanguageTestScore createLanguageTestScore(SiteUser siteUser, LanguageTestType languageTestType, String score) {
         LanguageTestScore languageTestScore = new LanguageTestScore(
                 new LanguageTest(languageTestType, score, "/gpa-report.pdf"),
-                LocalDate.now(),
                 siteUser
         );
         languageTestScore.setSiteUser(siteUser);
@@ -191,7 +186,6 @@ class ScoreServiceTest extends BaseIntegrationTest {
         return new GpaScoreRequest(
                 3.5,
                 4.5,
-                LocalDate.now(),
                 "/gpa-report.pdf"
         );
     }
@@ -200,7 +194,6 @@ class ScoreServiceTest extends BaseIntegrationTest {
         return new LanguageTestScoreRequest(
                 LanguageTestType.TOEFL_IBT,
                 "100",
-                LocalDate.now(),
                 "/gpa-report.pdf"
         );
     }

--- a/src/test/java/com/example/solidconnection/support/integration/BaseIntegrationTest.java
+++ b/src/test/java/com/example/solidconnection/support/integration/BaseIntegrationTest.java
@@ -39,7 +39,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 
-import java.time.LocalDate;
 import java.util.HashSet;
 import java.util.List;
 
@@ -511,8 +510,7 @@ public abstract class BaseIntegrationTest {
     private GpaScore createApprovedGpaScore(SiteUser siteUser) {
         GpaScore gpaScore = new GpaScore(
                 new Gpa(4.0, 4.5, "/gpa-report.pdf"),
-                siteUser,
-                LocalDate.now()
+                siteUser
         );
         gpaScore.setVerifyStatus(VerifyStatus.APPROVED);
         return gpaScoreRepository.save(gpaScore);
@@ -521,7 +519,6 @@ public abstract class BaseIntegrationTest {
     private LanguageTestScore createApprovedLanguageTestScore(SiteUser siteUser) {
         LanguageTestScore languageTestScore = new LanguageTestScore(
                 new LanguageTest(LanguageTestType.TOEIC, "100", "/gpa-report.pdf"),
-                LocalDate.now(),
                 siteUser
         );
         languageTestScore.setVerifyStatus(VerifyStatus.APPROVED);


### PR DESCRIPTION
## 관련 이슈

- resolves: #180


## 작업 내용

GpaScore 과 LanguageTestScore 의 사용하지 않을 컬럼인 "issueDate"를 없앴습니다.

<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->
Flyway 이용하려고 Hibernate SQL 사용할 때 ddl-auto update로 사용하시나요? 저는 그렇게하면 서버가 안켜지고 create로 하니까 그냥 alter로 issueDate를 드랍하는 게 아니라 그냥 새 테이블 생성 쿼리문 주더라구요..
이번엔 컬럼 드랍하는 간단한 쿼리문이여서 그냥 제가 작성했습니다 @wibaek 
