### PR TITLE
refactor: 입력 형식과 관련된 검증은 Dto 내부에서 하게 한다.

### DIFF
--- a/src/main/java/com/example/solidconnection/application/dto/ApplyRequest.java
+++ b/src/main/java/com/example/solidconnection/application/dto/ApplyRequest.java
@@ -1,14 +1,17 @@
 package com.example.solidconnection.application.dto;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 
 public record ApplyRequest(
+
         @NotNull(message = "gpa score id를 입력해주세요.")
         Long gpaScoreId,
 
         @NotNull(message = "language test score id를 입력해주세요.")
         Long languageTestScoreId,
 
+        @Valid
         UniversityChoiceRequest universityChoiceRequest
 ) {
 }

--- a/src/main/java/com/example/solidconnection/application/dto/UniversityChoiceRequest.java
+++ b/src/main/java/com/example/solidconnection/application/dto/UniversityChoiceRequest.java
@@ -1,11 +1,12 @@
 package com.example.solidconnection.application.dto;
 
+import com.example.solidconnection.custom.validation.annotation.ValidUniversityChoice;
 import jakarta.validation.constraints.NotNull;
 
+@ValidUniversityChoice
 public record UniversityChoiceRequest(
         @NotNull(message = "1지망 대학교를 입력해주세요.")
         Long firstChoiceUniversityId,
-
         Long secondChoiceUniversityId,
         Long thirdChoiceUniversityId) {
 }

--- a/src/main/java/com/example/solidconnection/application/dto/UniversityChoiceRequest.java
+++ b/src/main/java/com/example/solidconnection/application/dto/UniversityChoiceRequest.java
@@ -1,11 +1,9 @@
 package com.example.solidconnection.application.dto;
 
 import com.example.solidconnection.custom.validation.annotation.ValidUniversityChoice;
-import jakarta.validation.constraints.NotNull;
 
 @ValidUniversityChoice
 public record UniversityChoiceRequest(
-        @NotNull(message = "1지망 대학교를 입력해주세요.")
         Long firstChoiceUniversityId,
         Long secondChoiceUniversityId,
         Long thirdChoiceUniversityId) {

--- a/src/main/java/com/example/solidconnection/application/service/ApplicationSubmissionService.java
+++ b/src/main/java/com/example/solidconnection/application/service/ApplicationSubmissionService.java
@@ -19,7 +19,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -49,7 +51,6 @@ public class ApplicationSubmissionService {
     @Transactional
     public boolean apply(SiteUser siteUser, ApplyRequest applyRequest) {
         UniversityChoiceRequest universityChoiceRequest = applyRequest.universityChoiceRequest();
-        validateUniversityChoices(universityChoiceRequest);
 
         Long gpaScoreId = applyRequest.gpaScoreId();
         Long languageTestScoreId = applyRequest.languageTestScoreId();
@@ -115,25 +116,6 @@ public class ApplicationSubmissionService {
     private void validateUpdateLimitNotExceed(Application application) {
         if (application.getUpdateCount() >= APPLICATION_UPDATE_COUNT_LIMIT) {
             throw new CustomException(APPLY_UPDATE_LIMIT_EXCEED);
-        }
-    }
-
-    // 입력값 유효성 검증
-    private void validateUniversityChoices(UniversityChoiceRequest universityChoiceRequest) {
-        Set<Long> uniqueUniversityIds = new HashSet<>();
-        uniqueUniversityIds.add(universityChoiceRequest.firstChoiceUniversityId());
-        if (universityChoiceRequest.secondChoiceUniversityId() != null) {
-            addUniversityChoice(uniqueUniversityIds, universityChoiceRequest.secondChoiceUniversityId());
-        }
-        if (universityChoiceRequest.thirdChoiceUniversityId() != null) {
-            addUniversityChoice(uniqueUniversityIds, universityChoiceRequest.thirdChoiceUniversityId());
-        }
-    }
-
-    private void addUniversityChoice(Set<Long> uniqueUniversityIds, Long universityId) {
-        boolean notAdded = !uniqueUniversityIds.add(universityId);
-        if (notAdded) {
-            throw new CustomException(CANT_APPLY_FOR_SAME_UNIVERSITY);
         }
     }
 }

--- a/src/main/java/com/example/solidconnection/custom/exception/ErrorCode.java
+++ b/src/main/java/com/example/solidconnection/custom/exception/ErrorCode.java
@@ -52,6 +52,9 @@ public enum ErrorCode {
     CANT_APPLY_FOR_SAME_UNIVERSITY(HttpStatus.BAD_REQUEST.value(), "1, 2, 3지망에 동일한 대학교를 입력할 수 없습니다."),
     CAN_NOT_CHANGE_NICKNAME_YET(HttpStatus.BAD_REQUEST.value(), "마지막 닉네임 변경으로부터 " + MIN_DAYS_BETWEEN_NICKNAME_CHANGES + "일이 지나지 않았습니다."),
     PROFILE_IMAGE_NEEDED(HttpStatus.BAD_REQUEST.value(), "프로필 이미지가 필요합니다."),
+    FIRST_CHOICE_REQUIRED(HttpStatus.BAD_REQUEST.value(), "1지망 대학교를 입력해주세요."),
+    THIRD_CHOICE_REQUIRES_SECOND(HttpStatus.BAD_REQUEST.value(), "2지망 없이 3지망을 선택할 수 없습니다."),
+    DUPLICATE_UNIVERSITY_CHOICE(HttpStatus.BAD_REQUEST.value(), "지망 선택이 중복되었습니다."),
 
     // community
     INVALID_POST_CATEGORY(HttpStatus.BAD_REQUEST.value(), "잘못된 카테고리명입니다."),

--- a/src/main/java/com/example/solidconnection/custom/validation/annotation/ValidUniversityChoice.java
+++ b/src/main/java/com/example/solidconnection/custom/validation/annotation/ValidUniversityChoice.java
@@ -1,0 +1,20 @@
+package com.example.solidconnection.custom.validation.annotation;
+
+import com.example.solidconnection.custom.validation.validator.ValidUniversityChoiceValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = ValidUniversityChoiceValidator.class)
+public @interface ValidUniversityChoice {
+
+    String message() default "2지망 없이 3지망을 선택할 수 없습니다";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/example/solidconnection/custom/validation/annotation/ValidUniversityChoice.java
+++ b/src/main/java/com/example/solidconnection/custom/validation/annotation/ValidUniversityChoice.java
@@ -14,7 +14,7 @@ import java.lang.annotation.Target;
 @Constraint(validatedBy = ValidUniversityChoiceValidator.class)
 public @interface ValidUniversityChoice {
 
-    String message() default "2지망 없이 3지망을 선택할 수 없습니다";
+    String message() default "유효하지 않은 지망 대학 선택입니다.";
     Class<?>[] groups() default {};
     Class<? extends Payload>[] payload() default {};
 }

--- a/src/main/java/com/example/solidconnection/custom/validation/validator/ValidUniversityChoiceValidator.java
+++ b/src/main/java/com/example/solidconnection/custom/validation/validator/ValidUniversityChoiceValidator.java
@@ -1,0 +1,41 @@
+package com.example.solidconnection.custom.validation.validator;
+
+import com.example.solidconnection.application.dto.UniversityChoiceRequest;
+import com.example.solidconnection.custom.validation.annotation.ValidUniversityChoice;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class ValidUniversityChoiceValidator implements ConstraintValidator<ValidUniversityChoice, UniversityChoiceRequest> {
+
+    @Override
+    public boolean isValid(UniversityChoiceRequest request, ConstraintValidatorContext context) {
+        if (request.thirdChoiceUniversityId() != null && request.secondChoiceUniversityId() == null) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate("2지망 없이 3지망을 선택할 수 없습니다")
+                    .addConstraintViolation();
+            return false;
+        }
+
+        Set<Long> uniqueUniversityIds = new HashSet<>();
+        uniqueUniversityIds.add(request.firstChoiceUniversityId());
+
+        return isValidChoice(request.secondChoiceUniversityId(), uniqueUniversityIds, context) &&
+                isValidChoice(request.thirdChoiceUniversityId(), uniqueUniversityIds, context);
+    }
+
+    private boolean isValidChoice(Long choiceId, Set<Long> uniqueIds, ConstraintValidatorContext context) {
+        if (choiceId == null)
+            return true;
+
+        if (!uniqueIds.add(choiceId)) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate("지망 선택이 중복되었습니다")
+                    .addConstraintViolation();
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/example/solidconnection/custom/validation/validator/ValidUniversityChoiceValidator.java
+++ b/src/main/java/com/example/solidconnection/custom/validation/validator/ValidUniversityChoiceValidator.java
@@ -8,16 +8,16 @@ import jakarta.validation.ConstraintValidatorContext;
 import java.util.HashSet;
 import java.util.Set;
 
-public class ValidUniversityChoiceValidator implements ConstraintValidator<ValidUniversityChoice, UniversityChoiceRequest> {
+import static com.example.solidconnection.custom.exception.ErrorCode.DUPLICATE_UNIVERSITY_CHOICE;
+import static com.example.solidconnection.custom.exception.ErrorCode.THIRD_CHOICE_REQUIRES_SECOND;
 
-    public static final String ERROR_THIRD_CHOICE_WITHOUT_SECOND = "2지망 없이 3지망을 선택할 수 없습니다.";
-    public static final String ERROR_DUPLICATE_CHOICE = "지망 선택이 중복되었습니다";
+public class ValidUniversityChoiceValidator implements ConstraintValidator<ValidUniversityChoice, UniversityChoiceRequest> {
 
     @Override
     public boolean isValid(UniversityChoiceRequest request, ConstraintValidatorContext context) {
         if (request.thirdChoiceUniversityId() != null && request.secondChoiceUniversityId() == null) {
             context.disableDefaultConstraintViolation();
-            context.buildConstraintViolationWithTemplate(ERROR_THIRD_CHOICE_WITHOUT_SECOND)
+            context.buildConstraintViolationWithTemplate(THIRD_CHOICE_REQUIRES_SECOND.getMessage())
                     .addConstraintViolation();
             return false;
         }
@@ -35,7 +35,7 @@ public class ValidUniversityChoiceValidator implements ConstraintValidator<Valid
 
         if (!uniqueIds.add(choiceId)) {
             context.disableDefaultConstraintViolation();
-            context.buildConstraintViolationWithTemplate(ERROR_DUPLICATE_CHOICE)
+            context.buildConstraintViolationWithTemplate(DUPLICATE_UNIVERSITY_CHOICE.getMessage())
                     .addConstraintViolation();
             return false;
         }

--- a/src/main/java/com/example/solidconnection/custom/validation/validator/ValidUniversityChoiceValidator.java
+++ b/src/main/java/com/example/solidconnection/custom/validation/validator/ValidUniversityChoiceValidator.java
@@ -9,14 +9,21 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static com.example.solidconnection.custom.exception.ErrorCode.DUPLICATE_UNIVERSITY_CHOICE;
+import static com.example.solidconnection.custom.exception.ErrorCode.FIRST_CHOICE_REQUIRED;
 import static com.example.solidconnection.custom.exception.ErrorCode.THIRD_CHOICE_REQUIRES_SECOND;
 
 public class ValidUniversityChoiceValidator implements ConstraintValidator<ValidUniversityChoice, UniversityChoiceRequest> {
-
     @Override
     public boolean isValid(UniversityChoiceRequest request, ConstraintValidatorContext context) {
+        context.disableDefaultConstraintViolation();
+
+        if (request.firstChoiceUniversityId() == null) {
+            context.buildConstraintViolationWithTemplate(FIRST_CHOICE_REQUIRED.getMessage())
+                    .addConstraintViolation();
+            return false;
+        }
+
         if (request.thirdChoiceUniversityId() != null && request.secondChoiceUniversityId() == null) {
-            context.disableDefaultConstraintViolation();
             context.buildConstraintViolationWithTemplate(THIRD_CHOICE_REQUIRES_SECOND.getMessage())
                     .addConstraintViolation();
             return false;
@@ -24,17 +31,13 @@ public class ValidUniversityChoiceValidator implements ConstraintValidator<Valid
 
         Set<Long> uniqueUniversityIds = new HashSet<>();
         uniqueUniversityIds.add(request.firstChoiceUniversityId());
-
         return isValidChoice(request.secondChoiceUniversityId(), uniqueUniversityIds, context) &&
                 isValidChoice(request.thirdChoiceUniversityId(), uniqueUniversityIds, context);
     }
 
     private boolean isValidChoice(Long choiceId, Set<Long> uniqueIds, ConstraintValidatorContext context) {
-        if (choiceId == null)
-            return true;
-
+        if (choiceId == null) return true;
         if (!uniqueIds.add(choiceId)) {
-            context.disableDefaultConstraintViolation();
             context.buildConstraintViolationWithTemplate(DUPLICATE_UNIVERSITY_CHOICE.getMessage())
                     .addConstraintViolation();
             return false;

--- a/src/main/java/com/example/solidconnection/custom/validation/validator/ValidUniversityChoiceValidator.java
+++ b/src/main/java/com/example/solidconnection/custom/validation/validator/ValidUniversityChoiceValidator.java
@@ -10,11 +10,14 @@ import java.util.Set;
 
 public class ValidUniversityChoiceValidator implements ConstraintValidator<ValidUniversityChoice, UniversityChoiceRequest> {
 
+    public static final String ERROR_THIRD_CHOICE_WITHOUT_SECOND = "2지망 없이 3지망을 선택할 수 없습니다.";
+    public static final String ERROR_DUPLICATE_CHOICE = "지망 선택이 중복되었습니다";
+
     @Override
     public boolean isValid(UniversityChoiceRequest request, ConstraintValidatorContext context) {
         if (request.thirdChoiceUniversityId() != null && request.secondChoiceUniversityId() == null) {
             context.disableDefaultConstraintViolation();
-            context.buildConstraintViolationWithTemplate("2지망 없이 3지망을 선택할 수 없습니다")
+            context.buildConstraintViolationWithTemplate(ERROR_THIRD_CHOICE_WITHOUT_SECOND)
                     .addConstraintViolation();
             return false;
         }
@@ -32,7 +35,7 @@ public class ValidUniversityChoiceValidator implements ConstraintValidator<Valid
 
         if (!uniqueIds.add(choiceId)) {
             context.disableDefaultConstraintViolation();
-            context.buildConstraintViolationWithTemplate("지망 선택이 중복되었습니다")
+            context.buildConstraintViolationWithTemplate(ERROR_DUPLICATE_CHOICE)
                     .addConstraintViolation();
             return false;
         }

--- a/src/test/java/com/example/solidconnection/application/service/ApplicationSubmissionServiceTest.java
+++ b/src/test/java/com/example/solidconnection/application/service/ApplicationSubmissionServiceTest.java
@@ -119,26 +119,6 @@ class ApplicationSubmissionServiceTest extends BaseIntegrationTest {
     }
 
     @Test
-    void 동일한_대학을_중복_선택하면_예외_응답을_반환한다() {
-        // given
-        GpaScore gpaScore = createApprovedGpaScore(테스트유저_1);
-        LanguageTestScore languageTestScore = createUnapprovedLanguageTestScore(테스트유저_1);
-        UniversityChoiceRequest universityChoiceRequest = new UniversityChoiceRequest(
-                괌대학_A_지원_정보.getId(),
-                괌대학_A_지원_정보.getId(),
-                메모리얼대학_세인트존스_A_지원_정보.getId()
-        );
-        ApplyRequest request = new ApplyRequest(gpaScore.getId(), languageTestScore.getId(), universityChoiceRequest);
-
-        // when & then
-        assertThatCode(() ->
-                applicationSubmissionService.apply(테스트유저_1, request)
-        )
-                .isInstanceOf(CustomException.class)
-                .hasMessage(CANT_APPLY_FOR_SAME_UNIVERSITY.getMessage());
-    }
-
-    @Test
     void 지원서_수정_횟수를_초과하면_예외_응답을_반환한다() {
         // given
         GpaScore gpaScore = createApprovedGpaScore(테스트유저_1);

--- a/src/test/java/com/example/solidconnection/custom/validation/validator/ValidUniversityChoiceValidatorTest.java
+++ b/src/test/java/com/example/solidconnection/custom/validation/validator/ValidUniversityChoiceValidatorTest.java
@@ -76,7 +76,6 @@ class ValidUniversityChoiceValidatorTest {
         Set<ConstraintViolation<UniversityChoiceRequest>> violations = validator.validate(request);
 
         // then
-
         assertThat(violations)
                 .isNotEmpty()
                 .extracting(MESSAGE)

--- a/src/test/java/com/example/solidconnection/custom/validation/validator/ValidUniversityChoiceValidatorTest.java
+++ b/src/test/java/com/example/solidconnection/custom/validation/validator/ValidUniversityChoiceValidatorTest.java
@@ -11,15 +11,15 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Set;
 
-import static com.example.solidconnection.custom.validation.validator.ValidUniversityChoiceValidator.ERROR_DUPLICATE_CHOICE;
-import static com.example.solidconnection.custom.validation.validator.ValidUniversityChoiceValidator.ERROR_THIRD_CHOICE_WITHOUT_SECOND;
+import static com.example.solidconnection.custom.exception.ErrorCode.DUPLICATE_UNIVERSITY_CHOICE;
+import static com.example.solidconnection.custom.exception.ErrorCode.FIRST_CHOICE_REQUIRED;
+import static com.example.solidconnection.custom.exception.ErrorCode.THIRD_CHOICE_REQUIRES_SECOND;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("대학 선택 유효성 검사 테스트")
 class ValidUniversityChoiceValidatorTest {
 
     private static final String MESSAGE = "message";
-    private static final String ERROR_FIRST_CHOICE_IS_NULL = "1지망 대학교를 입력해주세요.";
 
     private Validator validator;
 
@@ -64,7 +64,7 @@ class ValidUniversityChoiceValidatorTest {
         // then
         assertThat(violations)
                 .extracting(MESSAGE)
-                .contains(ERROR_THIRD_CHOICE_WITHOUT_SECOND);
+                .contains(THIRD_CHOICE_REQUIRES_SECOND.getMessage());
     }
 
     @Test
@@ -80,7 +80,7 @@ class ValidUniversityChoiceValidatorTest {
         assertThat(violations)
                 .isNotEmpty()
                 .extracting(MESSAGE)
-                .contains(ERROR_FIRST_CHOICE_IS_NULL);
+                .contains(FIRST_CHOICE_REQUIRED.getMessage());
     }
 
     @Test
@@ -95,6 +95,6 @@ class ValidUniversityChoiceValidatorTest {
         assertThat(violations)
                 .isNotEmpty()
                 .extracting(MESSAGE)
-                .contains(ERROR_DUPLICATE_CHOICE);
+                .contains(DUPLICATE_UNIVERSITY_CHOICE.getMessage());
     }
 }

--- a/src/test/java/com/example/solidconnection/custom/validation/validator/ValidUniversityChoiceValidatorTest.java
+++ b/src/test/java/com/example/solidconnection/custom/validation/validator/ValidUniversityChoiceValidatorTest.java
@@ -1,0 +1,100 @@
+package com.example.solidconnection.custom.validation.validator;
+
+import com.example.solidconnection.application.dto.UniversityChoiceRequest;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static com.example.solidconnection.custom.validation.validator.ValidUniversityChoiceValidator.ERROR_DUPLICATE_CHOICE;
+import static com.example.solidconnection.custom.validation.validator.ValidUniversityChoiceValidator.ERROR_THIRD_CHOICE_WITHOUT_SECOND;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("대학 선택 유효성 검사 테스트")
+class ValidUniversityChoiceValidatorTest {
+
+    private static final String MESSAGE = "message";
+    private static final String ERROR_FIRST_CHOICE_IS_NULL = "1지망 대학교를 입력해주세요.";
+
+    private Validator validator;
+
+    @BeforeEach
+    void setUp() {
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    @Test
+    void 정상적인_지망_선택은_유효하다() {
+        // given
+        UniversityChoiceRequest request = new UniversityChoiceRequest(1L, 2L, 3L);
+
+        // when
+        Set<ConstraintViolation<UniversityChoiceRequest>> violations = validator.validate(request);
+
+        // then
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    void 첫_번째_지망만_선택하는_것은_유효하다() {
+        // given
+        UniversityChoiceRequest request = new UniversityChoiceRequest(1L, null, null);
+
+        // when
+        Set<ConstraintViolation<UniversityChoiceRequest>> violations = validator.validate(request);
+
+        // then
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    void 두_번째_지망_없이_세_번째_지망을_선택하면_예외_응답을_반환한다() {
+        // given
+        UniversityChoiceRequest request = new UniversityChoiceRequest(1L, null, 3L);
+
+        // when
+        Set<ConstraintViolation<UniversityChoiceRequest>> violations = validator.validate(request);
+
+        // then
+        assertThat(violations)
+                .extracting(MESSAGE)
+                .contains(ERROR_THIRD_CHOICE_WITHOUT_SECOND);
+    }
+
+    @Test
+    void 첫_번째_지망을_선택하지_않으면_예외_응답을_반환한다() {
+        // given
+        UniversityChoiceRequest request = new UniversityChoiceRequest(null, 2L, 3L);
+
+        // when
+        Set<ConstraintViolation<UniversityChoiceRequest>> violations = validator.validate(request);
+
+        // then
+
+        assertThat(violations)
+                .isNotEmpty()
+                .extracting(MESSAGE)
+                .contains(ERROR_FIRST_CHOICE_IS_NULL);
+    }
+
+    @Test
+    void 대학을_중복_선택하면_예외_응답을_반환한다() {
+        // given
+        UniversityChoiceRequest request = new UniversityChoiceRequest(1L, 1L, 2L);
+
+        // when
+        Set<ConstraintViolation<UniversityChoiceRequest>> violations = validator.validate(request);
+
+        // then
+        assertThat(violations)
+                .isNotEmpty()
+                .extracting(MESSAGE)
+                .contains(ERROR_DUPLICATE_CHOICE);
+    }
+}


### PR DESCRIPTION
## 관련 이슈

- resolves: #182 

## 작업 내용

기존 서비스 로직에 있던 대학 중복 선택 검증을 지우고 ConstraintValidator를 활용하여 DTO에서 검증하도록 변경하였습니다.

추가로 기존에 검증하지 않던 2지망 없이 1, 3지망만 선택하는 case의 예외처리도 ConstraintValidator에 추가하였습니다.

## 특이 사항

기존 코드가 잘 동작하는지 확인하고 있었는데 UniversityChoiceRequest의 1지망 @NotNull 어노테이션이 아예 동작하지 않는 것을 발견했었습니다. 왜그런지 구글링을 해보니 중첩 DTO일 때 저런 검증 어노테이션이 동작하려면

```
@Valid
UniversityChoiceRequest universityChoiceRequest
```
이런식으로 첫 DTO에 @Valid를 붙여야하는 것을 확인했습니다. 그동안 @Valid와 @Validated의 차이를 몰랐는데 이참에 알게되었네요. 이건 @Valid로만 적용가능하다고 합니다.
[중첩 DTO 관련 참고 자료](https://www.baeldung.com/spring-valid-vs-validated#using-valid-annotation-to-mark-nested-objects)

## 리뷰 요구사항 (선택)

이 커스텀Validator 테스트 코드 작성방법을 몰라서 구글링을 해봤는데 자료가 잘 나오질 않네요. 혹시 다른 더 좋은 방안이 있다면 참고하겠습니다.
저는 [커스텀Validator 테스트 코드 관련 참고 자료](https://stackoverflow.com/questions/28768577/how-to-test-a-validator-which-implements-constraintvalidator-in-java) 여기서 참고했습니다. 여기 제시 방안은 3가지가 있었는데 ValidatorFactory 사용하는 게 실제 환경과 제일 비슷하게 검증하는 것 같아 ValidatorFactory를 사용해서 테스트코드 작성하였습니다.
