### PR TITLE
feat: 관리자 role 추가

### DIFF
--- a/src/main/java/com/example/solidconnection/config/security/SecurityConfiguration.java
+++ b/src/main/java/com/example/solidconnection/config/security/SecurityConfiguration.java
@@ -13,6 +13,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.ExceptionTranslationFilter;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
@@ -63,7 +64,7 @@ public class SecurityConfiguration {
                 )
                 .addFilterBefore(jwtAuthenticationFilter, BasicAuthenticationFilter.class)
                 .addFilterBefore(signOutCheckFilter, JwtAuthenticationFilter.class)
-                .addFilterBefore(exceptionHandlerFilter, SignOutCheckFilter.class)
+                .addFilterAfter(exceptionHandlerFilter, ExceptionTranslationFilter.class)
                 .build();
     }
 }

--- a/src/main/java/com/example/solidconnection/config/security/SecurityConfiguration.java
+++ b/src/main/java/com/example/solidconnection/config/security/SecurityConfiguration.java
@@ -18,6 +18,8 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import static com.example.solidconnection.type.Role.ADMIN;
+
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
@@ -55,7 +57,10 @@ public class SecurityConfiguration {
                 .formLogin(AbstractHttpConfigurer::disable)
                 .cors(corsConfigurer -> corsConfigurer.configurationSource(corsConfigurationSource()))
                 .sessionManagement((session) -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/admin/**").hasRole(ADMIN.name())
+                        .anyRequest().permitAll()
+                )
                 .addFilterBefore(jwtAuthenticationFilter, BasicAuthenticationFilter.class)
                 .addFilterBefore(signOutCheckFilter, JwtAuthenticationFilter.class)
                 .addFilterBefore(exceptionHandlerFilter, SignOutCheckFilter.class)

--- a/src/main/java/com/example/solidconnection/custom/exception/ErrorCode.java
+++ b/src/main/java/com/example/solidconnection/custom/exception/ErrorCode.java
@@ -48,6 +48,7 @@ public enum ErrorCode {
     AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED.value(), "인증이 필요한 접근입니다."),
     ACCESS_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED.value(), "액세스 토큰이 만료되었습니다. 재발급 api를 호출해주세요."),
     REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED.value(), "리프레시 토큰이 만료되었습니다. 다시 로그인을 진행해주세요."),
+    ACCESS_DENIED(HttpStatus.FORBIDDEN.value(), "접근 권한이 없습니다."),
 
     // s3
     S3_SERVICE_EXCEPTION(HttpStatus.BAD_REQUEST.value(), "S3 서비스 에러 발생"),

--- a/src/main/java/com/example/solidconnection/custom/security/authentication/JwtAuthentication.java
+++ b/src/main/java/com/example/solidconnection/custom/security/authentication/JwtAuthentication.java
@@ -12,7 +12,9 @@ public abstract class JwtAuthentication extends AbstractAuthenticationToken {
     private final Object principal;
 
     public JwtAuthentication(String token, Object principal) {
-        super(principal != null ? ((UserDetails)principal).getAuthorities() : Collections.emptyList());
+        super(principal instanceof UserDetails ?
+                ((UserDetails)principal).getAuthorities() :
+                Collections.emptyList());
         this.credentials = token;
         this.principal = principal;
     }

--- a/src/main/java/com/example/solidconnection/custom/security/authentication/JwtAuthentication.java
+++ b/src/main/java/com/example/solidconnection/custom/security/authentication/JwtAuthentication.java
@@ -1,6 +1,9 @@
 package com.example.solidconnection.custom.security.authentication;
 
 import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collections;
 
 public abstract class JwtAuthentication extends AbstractAuthenticationToken {
 
@@ -9,7 +12,7 @@ public abstract class JwtAuthentication extends AbstractAuthenticationToken {
     private final Object principal;
 
     public JwtAuthentication(String token, Object principal) {
-        super(null);
+        super(principal != null ? ((UserDetails)principal).getAuthorities() : Collections.emptyList());
         this.credentials = token;
         this.principal = principal;
     }

--- a/src/main/java/com/example/solidconnection/custom/security/authentication/JwtAuthentication.java
+++ b/src/main/java/com/example/solidconnection/custom/security/authentication/JwtAuthentication.java
@@ -13,7 +13,7 @@ public abstract class JwtAuthentication extends AbstractAuthenticationToken {
 
     public JwtAuthentication(String token, Object principal) {
         super(principal instanceof UserDetails ?
-                ((UserDetails)principal).getAuthorities() :
+                ((UserDetails) principal).getAuthorities() :
                 Collections.emptyList());
         this.credentials = token;
         this.principal = principal;

--- a/src/main/java/com/example/solidconnection/custom/security/filter/ExceptionHandlerFilter.java
+++ b/src/main/java/com/example/solidconnection/custom/security/filter/ExceptionHandlerFilter.java
@@ -49,18 +49,17 @@ public class ExceptionHandlerFilter extends OncePerRequestFilter {
     }
 
     public void customCommence(HttpServletResponse response, CustomException customException) throws IOException {
-        SecurityContextHolder.clearContext();
         ErrorResponse errorResponse = new ErrorResponse(customException);
         writeResponse(response, errorResponse, customException.getCode());
     }
 
     public void generalCommence(HttpServletResponse response, Exception exception, ErrorCode errorCode) throws IOException {
-        SecurityContextHolder.clearContext();
         ErrorResponse errorResponse = new ErrorResponse(errorCode, exception.getMessage());
         writeResponse(response, errorResponse, errorCode.getCode());
     }
 
     private void writeResponse(HttpServletResponse response, ErrorResponse errorResponse, int statusCode) throws IOException {
+        SecurityContextHolder.clearContext();
         response.setStatus(statusCode);
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");

--- a/src/main/java/com/example/solidconnection/custom/security/filter/ExceptionHandlerFilter.java
+++ b/src/main/java/com/example/solidconnection/custom/security/filter/ExceptionHandlerFilter.java
@@ -35,7 +35,7 @@ public class ExceptionHandlerFilter extends OncePerRequestFilter {
         try {
             filterChain.doFilter(request, response);
         } catch (CustomException e) {
-            customCommence(response, e, e.getCode());
+            customCommence(response, e);
         } catch (AccessDeniedException e) {
             Authentication auth = SecurityContextHolder.getContext().getAuthentication();
             if (auth instanceof AnonymousAuthenticationToken) {
@@ -48,10 +48,10 @@ public class ExceptionHandlerFilter extends OncePerRequestFilter {
         }
     }
 
-    public void customCommence(HttpServletResponse response, CustomException customException, int statusCode) throws IOException {
+    public void customCommence(HttpServletResponse response, CustomException customException) throws IOException {
         SecurityContextHolder.clearContext();
         ErrorResponse errorResponse = new ErrorResponse(customException);
-        writeResponse(response, errorResponse, statusCode);
+        writeResponse(response, errorResponse, customException.getCode());
     }
 
     public void generalCommence(HttpServletResponse response, Exception exception, ErrorCode errorCode) throws IOException {

--- a/src/main/java/com/example/solidconnection/custom/security/filter/ExceptionHandlerFilter.java
+++ b/src/main/java/com/example/solidconnection/custom/security/filter/ExceptionHandlerFilter.java
@@ -38,11 +38,8 @@ public class ExceptionHandlerFilter extends OncePerRequestFilter {
             customCommence(response, e);
         } catch (AccessDeniedException e) {
             Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-            if (auth instanceof AnonymousAuthenticationToken) {
-                generalCommence(response, e, AUTHENTICATION_FAILED);
-            } else {
-                generalCommence(response, e, ACCESS_DENIED);
-            }
+            ErrorCode errorCode = auth instanceof AnonymousAuthenticationToken ? AUTHENTICATION_FAILED : ACCESS_DENIED;
+            generalCommence(response, e, errorCode);
         } catch (Exception e) {
             generalCommence(response, e, AUTHENTICATION_FAILED);
         }

--- a/src/main/java/com/example/solidconnection/custom/security/filter/ExceptionHandlerFilter.java
+++ b/src/main/java/com/example/solidconnection/custom/security/filter/ExceptionHandlerFilter.java
@@ -1,6 +1,7 @@
 package com.example.solidconnection.custom.security.filter;
 
 import com.example.solidconnection.custom.exception.CustomException;
+import com.example.solidconnection.custom.exception.ErrorCode;
 import com.example.solidconnection.custom.response.ErrorResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.FilterChain;
@@ -9,12 +10,16 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
+import static com.example.solidconnection.custom.exception.ErrorCode.ACCESS_DENIED;
 import static com.example.solidconnection.custom.exception.ErrorCode.AUTHENTICATION_FAILED;
 
 @Component
@@ -30,26 +35,33 @@ public class ExceptionHandlerFilter extends OncePerRequestFilter {
         try {
             filterChain.doFilter(request, response);
         } catch (CustomException e) {
-            customCommence(response, e);
+            customCommence(response, e, e.getCode());
+        } catch (AccessDeniedException e) {
+            Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+            if (auth instanceof AnonymousAuthenticationToken) {
+                generalCommence(response, e, AUTHENTICATION_FAILED);
+            } else {
+                generalCommence(response, e, ACCESS_DENIED);
+            }
         } catch (Exception e) {
-            generalCommence(response, e);
+            generalCommence(response, e, AUTHENTICATION_FAILED);
         }
     }
 
-    public void customCommence(HttpServletResponse response, CustomException customException) throws IOException {
+    public void customCommence(HttpServletResponse response, CustomException customException, int statusCode) throws IOException {
         SecurityContextHolder.clearContext();
         ErrorResponse errorResponse = new ErrorResponse(customException);
-        writeResponse(response, errorResponse);
+        writeResponse(response, errorResponse, statusCode);
     }
 
-    public void generalCommence(HttpServletResponse response, Exception exception) throws IOException {
+    public void generalCommence(HttpServletResponse response, Exception exception, ErrorCode errorCode) throws IOException {
         SecurityContextHolder.clearContext();
-        ErrorResponse errorResponse = new ErrorResponse(AUTHENTICATION_FAILED, exception.getMessage());
-        writeResponse(response, errorResponse);
+        ErrorResponse errorResponse = new ErrorResponse(errorCode, exception.getMessage());
+        writeResponse(response, errorResponse, errorCode.getCode());
     }
 
-    private void writeResponse(HttpServletResponse response, ErrorResponse errorResponse) throws IOException {
-        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+    private void writeResponse(HttpServletResponse response, ErrorResponse errorResponse, int statusCode) throws IOException {
+        response.setStatus(statusCode);
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
         response.getWriter().write(objectMapper.writeValueAsString(errorResponse));

--- a/src/main/java/com/example/solidconnection/custom/security/mapper/SecurityRoleMapper.java
+++ b/src/main/java/com/example/solidconnection/custom/security/mapper/SecurityRoleMapper.java
@@ -1,0 +1,18 @@
+package com.example.solidconnection.custom.security.mapper;
+
+import com.example.solidconnection.type.Role;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.List;
+
+public class SecurityRoleMapper {
+
+    private static final String ROLE_PREFIX = "ROLE_";
+
+    private SecurityRoleMapper() {
+    }
+
+    public static List<SimpleGrantedAuthority> mapRoleToAuthorities(Role role) {
+        return List.of(new SimpleGrantedAuthority(ROLE_PREFIX + role.name()));
+    }
+}

--- a/src/main/java/com/example/solidconnection/custom/security/userdetails/SecurityRoleMapper.java
+++ b/src/main/java/com/example/solidconnection/custom/security/userdetails/SecurityRoleMapper.java
@@ -1,4 +1,4 @@
-package com.example.solidconnection.custom.security.mapper;
+package com.example.solidconnection.custom.security.userdetails;
 
 import com.example.solidconnection.type.Role;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;

--- a/src/main/java/com/example/solidconnection/custom/security/userdetails/SiteUserDetails.java
+++ b/src/main/java/com/example/solidconnection/custom/security/userdetails/SiteUserDetails.java
@@ -27,7 +27,7 @@ public class SiteUserDetails implements UserDetails {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return null;
+        return siteUser.getRole().getAuthorities();
     }
 
     @Override

--- a/src/main/java/com/example/solidconnection/custom/security/userdetails/SiteUserDetails.java
+++ b/src/main/java/com/example/solidconnection/custom/security/userdetails/SiteUserDetails.java
@@ -1,5 +1,6 @@
 package com.example.solidconnection.custom.security.userdetails;
 
+import com.example.solidconnection.custom.security.mapper.SecurityRoleMapper;
 import com.example.solidconnection.siteuser.domain.SiteUser;
 import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
@@ -27,7 +28,7 @@ public class SiteUserDetails implements UserDetails {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return siteUser.getRole().getAuthorities();
+        return SecurityRoleMapper.mapRoleToAuthorities(siteUser.getRole());
     }
 
     @Override

--- a/src/main/java/com/example/solidconnection/custom/security/userdetails/SiteUserDetails.java
+++ b/src/main/java/com/example/solidconnection/custom/security/userdetails/SiteUserDetails.java
@@ -1,6 +1,5 @@
 package com.example.solidconnection.custom.security.userdetails;
 
-import com.example.solidconnection.custom.security.mapper.SecurityRoleMapper;
 import com.example.solidconnection.siteuser.domain.SiteUser;
 import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;

--- a/src/main/java/com/example/solidconnection/type/Role.java
+++ b/src/main/java/com/example/solidconnection/type/Role.java
@@ -1,6 +1,18 @@
 package com.example.solidconnection.type;
 
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.List;
+
 public enum Role {
+
+    ADMIN,
     MENTOR,
-    MENTEE
+    MENTEE;
+
+    private static final String ROLE_PREFIX = "ROLE_";
+
+    public List<SimpleGrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority(ROLE_PREFIX + name()));
+    }
 }

--- a/src/main/java/com/example/solidconnection/type/Role.java
+++ b/src/main/java/com/example/solidconnection/type/Role.java
@@ -1,18 +1,8 @@
 package com.example.solidconnection.type;
 
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-
-import java.util.List;
-
 public enum Role {
 
     ADMIN,
     MENTOR,
     MENTEE;
-
-    private static final String ROLE_PREFIX = "ROLE_";
-
-    public List<SimpleGrantedAuthority> getAuthorities() {
-        return List.of(new SimpleGrantedAuthority(ROLE_PREFIX + name()));
-    }
 }

--- a/src/main/resources/db/migration/V6__add_admin_to_role_enum.sql
+++ b/src/main/resources/db/migration/V6__add_admin_to_role_enum.sql
@@ -1,0 +1,2 @@
+ALTER TABLE site_user
+    modify ROLE enum ('MENTEE', 'MENTOR', 'ADMIN') NOT NULL;

--- a/src/test/java/com/example/solidconnection/custom/security/userdetails/SiteUserDetailsServiceTest.java
+++ b/src/test/java/com/example/solidconnection/custom/security/userdetails/SiteUserDetailsServiceTest.java
@@ -46,6 +46,21 @@ class SiteUserDetailsServiceTest {
         );
     }
 
+    @Test
+    void 사용자_권한_정보를_정상적으로_반환한다() {
+        // given
+        SiteUser siteUser = siteUserRepository.save(createSiteUser());
+        String username = getUserName(siteUser);
+
+        // when
+        SiteUserDetails userDetails = (SiteUserDetails) userDetailsService.loadUserByUsername(username);
+
+        // then
+        assertThat(userDetails.getAuthorities())
+                .extracting("authority")
+                .containsExactly("ROLE_" + siteUser.getRole().name());
+    }
+
     @Nested
     class 예외_응답을_반환한다 {
 

--- a/src/test/java/com/example/solidconnection/custom/security/userdetails/SiteUserDetailsServiceTest.java
+++ b/src/test/java/com/example/solidconnection/custom/security/userdetails/SiteUserDetailsServiceTest.java
@@ -18,7 +18,7 @@ import static com.example.solidconnection.custom.exception.ErrorCode.AUTHENTICAT
 import static com.example.solidconnection.custom.exception.ErrorCode.INVALID_TOKEN;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 @DisplayName("사용자 인증 정보 서비스 테스트")
 @TestContainerSpringBootTest
@@ -44,21 +44,6 @@ class SiteUserDetailsServiceTest {
                 () -> assertThat(userDetails.getUsername()).isEqualTo(username),
                 () -> assertThat(userDetails.getSiteUser()).extracting("id").isEqualTo(siteUser.getId())
         );
-    }
-
-    @Test
-    void 사용자_권한_정보를_정상적으로_반환한다() {
-        // given
-        SiteUser siteUser = siteUserRepository.save(createSiteUser());
-        String username = getUserName(siteUser);
-
-        // when
-        SiteUserDetails userDetails = (SiteUserDetails) userDetailsService.loadUserByUsername(username);
-
-        // then
-        assertThat(userDetails.getAuthorities())
-                .extracting("authority")
-                .containsExactly("ROLE_" + siteUser.getRole().name());
     }
 
     @Nested

--- a/src/test/java/com/example/solidconnection/custom/security/userdetails/SiteUserDetailsTest.java
+++ b/src/test/java/com/example/solidconnection/custom/security/userdetails/SiteUserDetailsTest.java
@@ -1,0 +1,51 @@
+package com.example.solidconnection.custom.security.userdetails;
+
+import com.example.solidconnection.siteuser.domain.SiteUser;
+import com.example.solidconnection.siteuser.repository.SiteUserRepository;
+import com.example.solidconnection.support.TestContainerSpringBootTest;
+import com.example.solidconnection.type.Gender;
+import com.example.solidconnection.type.PreparationStatus;
+import com.example.solidconnection.type.Role;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("사용자 인증 정보 테스트")
+@TestContainerSpringBootTest
+class SiteUserDetailsTest {
+
+    @Autowired
+    private SiteUserRepository siteUserRepository;
+
+    @Test
+    void 사용자_권한을_정상적으로_반환한다() {
+        // given
+        SiteUser siteUser = siteUserRepository.save(createSiteUser());
+        SiteUserDetails siteUserDetails = new SiteUserDetails(siteUser);
+
+        // when
+        Collection<? extends GrantedAuthority> authorities = siteUserDetails.getAuthorities();
+
+        // then
+        assertThat(authorities)
+                .extracting("authority")
+                .containsExactly("ROLE_" + siteUser.getRole().name());
+    }
+
+    private SiteUser createSiteUser() {
+        return new SiteUser(
+                "test@example.com",
+                "nickname",
+                "profileImageUrl",
+                "1999-01-01",
+                PreparationStatus.CONSIDERING,
+                Role.MENTEE,
+                Gender.MALE
+        );
+    }
+}


### PR DESCRIPTION
## 관련 이슈

- resolves: #190 

## 작업 내용

1. Role에 ADMIN 추가 및 Spring Security 권한 처리 추가하였습니다.

2. Security 필터 체인 실행 순서를 조정하였습니다.

3. 인증되지 않은 사용자가 관리자 api 호출 시 401, 권한 없는 사용자가 관리자 api 호출 시 403 에러를 반환하도록 하였습니다.

## 특이 사항

<img width="791" alt="참고자료" src="https://github.com/user-attachments/assets/37caa148-5804-49ce-b1a6-f8d3d4004b81" />

어드민 인가 관련 예외처리를 SecurityFilterChain에서 한 번에 하도록 하였는데 이 처리를 하는 필터인 ExceptionTranslationFilter는 커스텀으로 정의한 ExceptionHandlerFilter 필터보다 뒤에 있어 ExceptionHandlerFilter에서 예외를 처리할 수 없었습니다. 그래서 

`.addFilterAfter(exceptionHandlerFilter, ExceptionTranslationFilter.class)`

필터 순서를 ExceptionTranslationFilter 이후로 조정하였습니다.

## 참고자료

[Security Filters](https://docs.spring.io/spring-security/reference/5.7/servlet/architecture.html#servlet-exceptiontranslationfilter)