### PR TITLE
refactor: 커뮤니티, 지원, 성적 관련 api 수정

### DIFF
--- a/src/main/java/com/example/solidconnection/application/controller/ApplicationController.java
+++ b/src/main/java/com/example/solidconnection/application/controller/ApplicationController.java
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
-@RequestMapping("/application")
+@RequestMapping("/applications")
 @RestController
 public class ApplicationController {
 
@@ -27,7 +27,7 @@ public class ApplicationController {
     private final ApplicationQueryService applicationQueryService;
 
     // 지원서 제출하기 api
-    @PostMapping()
+    @PostMapping
     public ResponseEntity<ApplicationSubmissionResponse> apply(
             @AuthorizedUser SiteUser siteUser,
             @Valid @RequestBody ApplyRequest applyRequest

--- a/src/main/java/com/example/solidconnection/auth/controller/AuthController.java
+++ b/src/main/java/com/example/solidconnection/auth/controller/AuthController.java
@@ -93,7 +93,8 @@ public class AuthController {
 
     @PostMapping("/sign-out")
     public ResponseEntity<Void> signOut(
-            @ExpiredToken ExpiredTokenAuthentication expiredToken
+            @ExpiredToken ExpiredTokenAuthentication expiredToken,
+            @AuthorizedUser SiteUser siteUser
     ) {
         authService.signOut(expiredToken.getToken());
         return ResponseEntity.ok().build();

--- a/src/main/java/com/example/solidconnection/auth/controller/AuthController.java
+++ b/src/main/java/com/example/solidconnection/auth/controller/AuthController.java
@@ -93,8 +93,7 @@ public class AuthController {
 
     @PostMapping("/sign-out")
     public ResponseEntity<Void> signOut(
-            @ExpiredToken ExpiredTokenAuthentication expiredToken,
-            @AuthorizedUser SiteUser siteUser
+            @ExpiredToken ExpiredTokenAuthentication expiredToken
     ) {
         authService.signOut(expiredToken.getToken());
         return ResponseEntity.ok().build();

--- a/src/main/java/com/example/solidconnection/community/board/controller/BoardController.java
+++ b/src/main/java/com/example/solidconnection/community/board/controller/BoardController.java
@@ -1,10 +1,14 @@
 package com.example.solidconnection.community.board.controller;
 
+import com.example.solidconnection.community.post.dto.PostListResponse;
+import com.example.solidconnection.community.post.service.PostQueryService;
 import com.example.solidconnection.type.BoardCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.ArrayList;
@@ -12,16 +16,27 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/communities")
+@RequestMapping("/boards")
 public class BoardController {
 
+    private final PostQueryService postQueryService;
+
     // todo: 회원별로 접근 가능한 게시판 목록 조회 기능 개발
-    @GetMapping()
+    @GetMapping
     public ResponseEntity<?> findAccessibleCodes() {
         List<String> accessibleCodeList = new ArrayList<>();
         for (BoardCode boardCode : BoardCode.values()) {
             accessibleCodeList.add(String.valueOf(boardCode));
         }
         return ResponseEntity.ok().body(accessibleCodeList);
+    }
+
+    @GetMapping("/{code}")
+    public ResponseEntity<?> findPostsByCodeAndCategory(
+            @PathVariable(value = "code") String code,
+            @RequestParam(value = "category", defaultValue = "전체") String category) {
+        List<PostListResponse> postsByCodeAndPostCategory = postQueryService
+                .findPostsByCodeAndPostCategory(code, category);
+        return ResponseEntity.ok().body(postsByCodeAndPostCategory);
     }
 }

--- a/src/main/java/com/example/solidconnection/community/comment/controller/CommentController.java
+++ b/src/main/java/com/example/solidconnection/community/comment/controller/CommentController.java
@@ -21,39 +21,36 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/posts")
+@RequestMapping("/comments")
 public class CommentController {
 
     private final CommentService commentService;
 
-    @PostMapping("/{post_id}/comments")
+    @PostMapping
     public ResponseEntity<?> createComment(
             @AuthorizedUser SiteUser siteUser,
-            @PathVariable("post_id") Long postId,
             @Valid @RequestBody CommentCreateRequest commentCreateRequest
     ) {
-        CommentCreateResponse response = commentService.createComment(siteUser, postId, commentCreateRequest);
+        CommentCreateResponse response = commentService.createComment(siteUser, commentCreateRequest);
         return ResponseEntity.ok().body(response);
     }
 
-    @PatchMapping("/{post_id}/comments/{comment_id}")
+    @PatchMapping("/{comment_id}")
     public ResponseEntity<?> updateComment(
             @AuthorizedUser SiteUser siteUser,
-            @PathVariable("post_id") Long postId,
             @PathVariable("comment_id") Long commentId,
             @Valid @RequestBody CommentUpdateRequest commentUpdateRequest
     ) {
-        CommentUpdateResponse response = commentService.updateComment(siteUser, postId, commentId, commentUpdateRequest);
+        CommentUpdateResponse response = commentService.updateComment(siteUser, commentId, commentUpdateRequest);
         return ResponseEntity.ok().body(response);
     }
 
-    @DeleteMapping("/{post_id}/comments/{comment_id}")
+    @DeleteMapping("/{comment_id}")
     public ResponseEntity<?> deleteCommentById(
             @AuthorizedUser SiteUser siteUser,
-            @PathVariable("post_id") Long postId,
             @PathVariable("comment_id") Long commentId
     ) {
-        CommentDeleteResponse response = commentService.deleteCommentById(siteUser, postId, commentId);
+        CommentDeleteResponse response = commentService.deleteCommentById(siteUser, commentId);
         return ResponseEntity.ok().body(response);
     }
 }

--- a/src/main/java/com/example/solidconnection/community/comment/dto/CommentCreateRequest.java
+++ b/src/main/java/com/example/solidconnection/community/comment/dto/CommentCreateRequest.java
@@ -4,9 +4,13 @@ import com.example.solidconnection.community.comment.domain.Comment;
 import com.example.solidconnection.community.post.domain.Post;
 import com.example.solidconnection.siteuser.domain.SiteUser;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 public record CommentCreateRequest(
+        @NotNull(message = "게시글 ID를 설정해주세요.")
+        Long postId,
+
         @NotBlank(message = "댓글 내용은 빈 값일 수 없습니다.")
         @Size(min = 1, max = 255, message = "댓글 내용은 최소 1자 이상, 최대 255자 이하여야 합니다.")
         String content,

--- a/src/main/java/com/example/solidconnection/community/comment/service/CommentService.java
+++ b/src/main/java/com/example/solidconnection/community/comment/service/CommentService.java
@@ -8,10 +8,11 @@ import com.example.solidconnection.community.comment.dto.CommentUpdateRequest;
 import com.example.solidconnection.community.comment.dto.CommentUpdateResponse;
 import com.example.solidconnection.community.comment.dto.PostFindCommentResponse;
 import com.example.solidconnection.community.comment.repository.CommentRepository;
-import com.example.solidconnection.custom.exception.CustomException;
 import com.example.solidconnection.community.post.domain.Post;
 import com.example.solidconnection.community.post.repository.PostRepository;
+import com.example.solidconnection.custom.exception.CustomException;
 import com.example.solidconnection.siteuser.domain.SiteUser;
+import com.example.solidconnection.siteuser.repository.SiteUserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,6 +23,7 @@ import java.util.stream.Collectors;
 import static com.example.solidconnection.custom.exception.ErrorCode.CAN_NOT_UPDATE_DEPRECATED_COMMENT;
 import static com.example.solidconnection.custom.exception.ErrorCode.INVALID_COMMENT_LEVEL;
 import static com.example.solidconnection.custom.exception.ErrorCode.INVALID_POST_ACCESS;
+import static com.example.solidconnection.custom.exception.ErrorCode.USER_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
@@ -43,8 +45,8 @@ public class CommentService {
     }
 
     @Transactional
-    public CommentCreateResponse createComment(SiteUser siteUser, Long postId, CommentCreateRequest commentCreateRequest) {
-        Post post = postRepository.getById(postId);
+    public CommentCreateResponse createComment(SiteUser siteUser, CommentCreateRequest commentCreateRequest) {
+        Post post = postRepository.getById(commentCreateRequest.postId());
 
         Comment parentComment = null;
         if (commentCreateRequest.parentId() != null) {
@@ -64,8 +66,7 @@ public class CommentService {
     }
 
     @Transactional
-    public CommentUpdateResponse updateComment(SiteUser siteUser, Long postId, Long commentId, CommentUpdateRequest commentUpdateRequest) {
-        Post post = postRepository.getById(postId);
+    public CommentUpdateResponse updateComment(SiteUser siteUser, Long commentId, CommentUpdateRequest commentUpdateRequest) {
         Comment comment = commentRepository.getById(commentId);
         validateDeprecated(comment);
         validateOwnership(comment, siteUser);
@@ -82,8 +83,7 @@ public class CommentService {
     }
 
     @Transactional
-    public CommentDeleteResponse deleteCommentById(SiteUser siteUser, Long postId, Long commentId) {
-        Post post = postRepository.getById(postId);
+    public CommentDeleteResponse deleteCommentById(SiteUser siteUser, Long commentId) {
         Comment comment = commentRepository.getById(commentId);
         validateOwnership(comment, siteUser);
 

--- a/src/main/java/com/example/solidconnection/community/comment/service/CommentService.java
+++ b/src/main/java/com/example/solidconnection/community/comment/service/CommentService.java
@@ -31,6 +31,7 @@ public class CommentService {
 
     private final CommentRepository commentRepository;
     private final PostRepository postRepository;
+    private final SiteUserRepository siteUserRepository;
 
     @Transactional(readOnly = true)
     public List<PostFindCommentResponse> findCommentsByPostId(SiteUser siteUser, Long postId) {
@@ -53,7 +54,15 @@ public class CommentService {
             parentComment = commentRepository.getById(commentCreateRequest.parentId());
             validateCommentDepth(parentComment);
         }
-        Comment createdComment = commentRepository.save(commentCreateRequest.toEntity(siteUser, post, parentComment));
+
+        /*
+         * todo: siteUser를 영속 상태로 만들 수 있도록 컨트롤러에서 siteUserId 를 넘겨줄 것인지,
+         *  siteUser 에 postList 를 FetchType.EAGER 로 설정할 것인지,
+         *  post 와 siteUser 사이의 양방향을 끊을 것인지 생각해봐야한다.
+         */
+        SiteUser siteUser1 = siteUserRepository.findById(siteUser.getId()).orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+        Comment comment = commentCreateRequest.toEntity(siteUser1, post, parentComment);
+        Comment createdComment = commentRepository.save(comment);
 
         return CommentCreateResponse.from(createdComment);
     }

--- a/src/main/java/com/example/solidconnection/community/post/controller/PostController.java
+++ b/src/main/java/com/example/solidconnection/community/post/controller/PostController.java
@@ -1,7 +1,5 @@
 package com.example.solidconnection.community.post.controller;
 
-import com.example.solidconnection.community.post.dto.PostListResponse;
-import com.example.solidconnection.custom.resolver.AuthorizedUser;
 import com.example.solidconnection.community.post.dto.PostCreateRequest;
 import com.example.solidconnection.community.post.dto.PostCreateResponse;
 import com.example.solidconnection.community.post.dto.PostDeleteResponse;
@@ -13,6 +11,7 @@ import com.example.solidconnection.community.post.dto.PostUpdateResponse;
 import com.example.solidconnection.community.post.service.PostCommandService;
 import com.example.solidconnection.community.post.service.PostLikeService;
 import com.example.solidconnection.community.post.service.PostQueryService;
+import com.example.solidconnection.custom.resolver.AuthorizedUser;
 import com.example.solidconnection.siteuser.domain.SiteUser;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -39,16 +38,6 @@ public class PostController {
     private final PostQueryService postQueryService;
     private final PostCommandService postCommandService;
     private final PostLikeService postLikeService;
-
-    @GetMapping("/{code}")
-    public ResponseEntity<?> findPostsByCodeAndCategory(
-            @PathVariable(value = "code") String code,
-            @RequestParam(value = "category", defaultValue = "전체") String category) {
-
-        List<PostListResponse> postsByCodeAndPostCategory = postQueryService
-                .findPostsByCodeAndPostCategory(code, category);
-        return ResponseEntity.ok().body(postsByCodeAndPostCategory);
-    }
 
     @PostMapping(value = "/{code}/posts")
     public ResponseEntity<?> createPost(

--- a/src/main/java/com/example/solidconnection/community/post/controller/PostController.java
+++ b/src/main/java/com/example/solidconnection/community/post/controller/PostController.java
@@ -32,31 +32,29 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/communities")
+@RequestMapping("/posts")
 public class PostController {
 
     private final PostQueryService postQueryService;
     private final PostCommandService postCommandService;
     private final PostLikeService postLikeService;
 
-    @PostMapping(value = "/{code}/posts")
+    @PostMapping
     public ResponseEntity<?> createPost(
             @AuthorizedUser SiteUser siteUser,
-            @PathVariable("code") String code,
             @Valid @RequestPart("postCreateRequest") PostCreateRequest postCreateRequest,
             @RequestParam(value = "file", required = false) List<MultipartFile> imageFile
     ) {
         if (imageFile == null) {
             imageFile = Collections.emptyList();
         }
-        PostCreateResponse post = postCommandService.createPost(siteUser, code, postCreateRequest, imageFile);
+        PostCreateResponse post = postCommandService.createPost(siteUser, postCreateRequest, imageFile);
         return ResponseEntity.ok().body(post);
     }
 
-    @PatchMapping(value = "/{code}/posts/{post_id}")
+    @PatchMapping(value = "/{post_id}")
     public ResponseEntity<?> updatePost(
             @AuthorizedUser SiteUser siteUser,
-            @PathVariable("code") String code,
             @PathVariable("post_id") Long postId,
             @Valid @RequestPart("postUpdateRequest") PostUpdateRequest postUpdateRequest,
             @RequestParam(value = "file", required = false) List<MultipartFile> imageFile
@@ -65,48 +63,44 @@ public class PostController {
             imageFile = Collections.emptyList();
         }
         PostUpdateResponse postUpdateResponse = postCommandService.updatePost(
-                siteUser, code, postId, postUpdateRequest, imageFile
+                siteUser, postId, postUpdateRequest, imageFile
         );
         return ResponseEntity.ok().body(postUpdateResponse);
     }
 
-    @GetMapping("/{code}/posts/{post_id}")
+    @GetMapping("/{post_id}")
     public ResponseEntity<?> findPostById(
             @AuthorizedUser SiteUser siteUser,
-            @PathVariable("code") String code,
             @PathVariable("post_id") Long postId
     ) {
-        PostFindResponse postFindResponse = postQueryService.findPostById(siteUser, code, postId);
+        PostFindResponse postFindResponse = postQueryService.findPostById(siteUser, postId);
         return ResponseEntity.ok().body(postFindResponse);
     }
 
-    @DeleteMapping(value = "/{code}/posts/{post_id}")
+    @DeleteMapping(value = "/{post_id}")
     public ResponseEntity<?> deletePostById(
             @AuthorizedUser SiteUser siteUser,
-            @PathVariable("code") String code,
             @PathVariable("post_id") Long postId
     ) {
-        PostDeleteResponse postDeleteResponse = postCommandService.deletePostById(siteUser, code, postId);
+        PostDeleteResponse postDeleteResponse = postCommandService.deletePostById(siteUser, postId);
         return ResponseEntity.ok().body(postDeleteResponse);
     }
 
-    @PostMapping(value = "/{code}/posts/{post_id}/like")
+    @PostMapping(value = "/{post_id}/like")
     public ResponseEntity<?> likePost(
             @AuthorizedUser SiteUser siteUser,
-            @PathVariable("code") String code,
             @PathVariable("post_id") Long postId
     ) {
-        PostLikeResponse postLikeResponse = postLikeService.likePost(siteUser, code, postId);
+        PostLikeResponse postLikeResponse = postLikeService.likePost(siteUser, postId);
         return ResponseEntity.ok().body(postLikeResponse);
     }
 
-    @DeleteMapping(value = "/{code}/posts/{post_id}/like")
+    @DeleteMapping(value = "/{post_id}/like")
     public ResponseEntity<?> dislikePost(
             @AuthorizedUser SiteUser siteUser,
-            @PathVariable("code") String code,
             @PathVariable("post_id") Long postId
     ) {
-        PostDislikeResponse postDislikeResponse = postLikeService.dislikePost(siteUser, code, postId);
+        PostDislikeResponse postDislikeResponse = postLikeService.dislikePost(siteUser, postId);
         return ResponseEntity.ok().body(postDislikeResponse);
     }
 }

--- a/src/main/java/com/example/solidconnection/community/post/dto/PostCreateRequest.java
+++ b/src/main/java/com/example/solidconnection/community/post/dto/PostCreateRequest.java
@@ -10,6 +10,9 @@ import jakarta.validation.constraints.Size;
 
 public record PostCreateRequest(
         @NotNull(message = "게시글 카테고리를 설정해주세요.")
+        String boardCode,
+
+        @NotNull(message = "게시글 카테고리를 설정해주세요.")
         String postCategory,
 
         @NotBlank(message = "게시글 제목은 빈 값일 수 없습니다.")

--- a/src/main/java/com/example/solidconnection/community/post/service/PostLikeService.java
+++ b/src/main/java/com/example/solidconnection/community/post/service/PostLikeService.java
@@ -8,12 +8,14 @@ import com.example.solidconnection.community.post.repository.PostLikeRepository;
 import com.example.solidconnection.community.post.repository.PostRepository;
 import com.example.solidconnection.custom.exception.CustomException;
 import com.example.solidconnection.siteuser.domain.SiteUser;
+import com.example.solidconnection.siteuser.repository.SiteUserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 import static com.example.solidconnection.custom.exception.ErrorCode.DUPLICATE_POST_LIKE;
+import static com.example.solidconnection.custom.exception.ErrorCode.USER_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
@@ -21,14 +23,21 @@ public class PostLikeService {
 
     private final PostRepository postRepository;
     private final PostLikeRepository postLikeRepository;
+    private final SiteUserRepository siteUserRepository;
 
     @Transactional(isolation = Isolation.READ_COMMITTED)
     public PostLikeResponse likePost(SiteUser siteUser, Long postId) {
         Post post = postRepository.getById(postId);
         validateDuplicatePostLike(post, siteUser);
-
         PostLike postLike = new PostLike();
-        postLike.setPostAndSiteUser(post, siteUser);
+
+        /*
+         * todo: siteUser를 영속 상태로 만들 수 있도록 컨트롤러에서 siteUserId 를 넘겨줄 것인지,
+         *  siteUser 에 postList 를 FetchType.EAGER 로 설정할 것인지,
+         *  post 와 siteUser 사이의 양방향을 끊을 것인지 생각해봐야한다.
+         */
+        SiteUser siteUser1 = siteUserRepository.findById(siteUser.getId()).orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+        postLike.setPostAndSiteUser(post, siteUser1);
         postLikeRepository.save(postLike);
         postRepository.increaseLikeCount(post.getId());
 

--- a/src/main/java/com/example/solidconnection/community/post/service/PostLikeService.java
+++ b/src/main/java/com/example/solidconnection/community/post/service/PostLikeService.java
@@ -1,21 +1,19 @@
 package com.example.solidconnection.community.post.service;
 
-import com.example.solidconnection.custom.exception.CustomException;
 import com.example.solidconnection.community.post.domain.Post;
 import com.example.solidconnection.community.post.domain.PostLike;
 import com.example.solidconnection.community.post.dto.PostDislikeResponse;
 import com.example.solidconnection.community.post.dto.PostLikeResponse;
 import com.example.solidconnection.community.post.repository.PostLikeRepository;
 import com.example.solidconnection.community.post.repository.PostRepository;
+import com.example.solidconnection.custom.exception.CustomException;
 import com.example.solidconnection.siteuser.domain.SiteUser;
-import com.example.solidconnection.type.BoardCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 import static com.example.solidconnection.custom.exception.ErrorCode.DUPLICATE_POST_LIKE;
-import static com.example.solidconnection.custom.exception.ErrorCode.INVALID_BOARD_CODE;
 
 @Service
 @RequiredArgsConstructor
@@ -25,8 +23,7 @@ public class PostLikeService {
     private final PostLikeRepository postLikeRepository;
 
     @Transactional(isolation = Isolation.READ_COMMITTED)
-    public PostLikeResponse likePost(SiteUser siteUser, String code, Long postId) {
-        String boardCode = validateCode(code);
+    public PostLikeResponse likePost(SiteUser siteUser, Long postId) {
         Post post = postRepository.getById(postId);
         validateDuplicatePostLike(post, siteUser);
 
@@ -39,8 +36,7 @@ public class PostLikeService {
     }
 
     @Transactional(isolation = Isolation.READ_COMMITTED)
-    public PostDislikeResponse dislikePost(SiteUser siteUser, String code, Long postId) {
-        String boardCode = validateCode(code);
+    public PostDislikeResponse dislikePost(SiteUser siteUser, Long postId) {
         Post post = postRepository.getById(postId);
 
         PostLike postLike = postLikeRepository.getByPostAndSiteUser(post, siteUser);
@@ -49,14 +45,6 @@ public class PostLikeService {
         postRepository.decreaseLikeCount(post.getId());
 
         return PostDislikeResponse.from(postRepository.getById(postId)); // 실시간성을 위한 재조회
-    }
-
-    private String validateCode(String code) {
-        try {
-            return String.valueOf(BoardCode.valueOf(code));
-        } catch (IllegalArgumentException ex) {
-            throw new CustomException(INVALID_BOARD_CODE);
-        }
     }
 
     private void validateDuplicatePostLike(Post post, SiteUser siteUser) {

--- a/src/main/java/com/example/solidconnection/community/post/service/PostQueryService.java
+++ b/src/main/java/com/example/solidconnection/community/post/service/PostQueryService.java
@@ -53,9 +53,7 @@ public class PostQueryService {
     }
 
     @Transactional(readOnly = true)
-    public PostFindResponse findPostById(SiteUser siteUser, String code, Long postId) {
-        String boardCode = validateCode(code);
-
+    public PostFindResponse findPostById(SiteUser siteUser, Long postId) {
         Post post = postRepository.getByIdUsingEntityGraph(postId);
         Boolean isOwner = getIsOwner(post, siteUser);
         Boolean isLiked = getIsLiked(post, siteUser);

--- a/src/main/java/com/example/solidconnection/score/controller/ScoreController.java
+++ b/src/main/java/com/example/solidconnection/score/controller/ScoreController.java
@@ -12,39 +12,43 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
-@RequestMapping("/score")
+@RequestMapping("/scores")
 @RequiredArgsConstructor
 public class ScoreController {
 
     private final ScoreService scoreService;
 
     // 학점을 등록하는 api
-    @PostMapping("/gpa")
+    @PostMapping("/gpas")
     public ResponseEntity<Long> submitGpaScore(
             @AuthorizedUser SiteUser siteUser,
-            @Valid @RequestBody GpaScoreRequest gpaScoreRequest
+            @Valid @RequestPart("gpaScoreRequest") GpaScoreRequest gpaScoreRequest,
+            @RequestParam("file") MultipartFile file
     ) {
-        Long id = scoreService.submitGpaScore(siteUser, gpaScoreRequest);
+        Long id = scoreService.submitGpaScore(siteUser, gpaScoreRequest, file);
         return ResponseEntity.ok(id);
     }
 
     // 어학성적을 등록하는 api
-    @PostMapping("/languageTest")
+    @PostMapping("/language-tests")
     public ResponseEntity<Long> submitLanguageTestScore(
             @AuthorizedUser SiteUser siteUser,
-            @Valid @RequestBody LanguageTestScoreRequest languageTestScoreRequest
+            @Valid @RequestPart("languageTestScoreRequest") LanguageTestScoreRequest languageTestScoreRequest,
+            @RequestParam("file") MultipartFile file
     ) {
-        Long id = scoreService.submitLanguageTestScore(siteUser, languageTestScoreRequest);
+        Long id = scoreService.submitLanguageTestScore(siteUser, languageTestScoreRequest, file);
         return ResponseEntity.ok(id);
     }
 
     // 학점 상태를 확인하는 api
-    @GetMapping("/gpa")
+    @GetMapping("/gpas")
     public ResponseEntity<GpaScoreStatusResponse> getGpaScoreStatus(
             @AuthorizedUser SiteUser siteUser
     ) {
@@ -53,7 +57,7 @@ public class ScoreController {
     }
 
     // 어학 성적 상태를 확인하는 api
-    @GetMapping("/languageTest")
+    @GetMapping("/language-tests")
     public ResponseEntity<LanguageTestScoreStatusResponse> getLanguageTestScoreStatus(
             @AuthorizedUser SiteUser siteUser
     ) {

--- a/src/main/java/com/example/solidconnection/score/dto/GpaScoreRequest.java
+++ b/src/main/java/com/example/solidconnection/score/dto/GpaScoreRequest.java
@@ -1,7 +1,5 @@
 package com.example.solidconnection.score.dto;
 
-import com.example.solidconnection.application.domain.Gpa;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record GpaScoreRequest(
@@ -9,15 +7,6 @@ public record GpaScoreRequest(
         Double gpa,
 
         @NotNull(message = "학점 기준을 입력해주세요.")
-        Double gpaCriteria,
-
-        @NotBlank(message = "대학 성적 증명서를 첨부해주세요.")
-        String gpaReportUrl) {
-
-    public Gpa toGpa() {
-        return new Gpa(
-                this.gpa,
-                this.gpaCriteria,
-                this.gpaReportUrl);
-    }
+        Double gpaCriteria
+) {
 }

--- a/src/main/java/com/example/solidconnection/score/dto/LanguageTestScoreRequest.java
+++ b/src/main/java/com/example/solidconnection/score/dto/LanguageTestScoreRequest.java
@@ -1,6 +1,5 @@
 package com.example.solidconnection.score.dto;
 
-import com.example.solidconnection.application.domain.LanguageTest;
 import com.example.solidconnection.type.LanguageTestType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -10,16 +9,6 @@ public record LanguageTestScoreRequest(
         LanguageTestType languageTestType,
 
         @NotBlank(message = "어학 점수를 입력해주세요.")
-        String languageTestScore,
-
-        @NotBlank(message = "어학 증명서를 첨부해주세요.")
-        String languageTestReportUrl) {
-
-    public LanguageTest toLanguageTest() {
-        return new LanguageTest(
-                this.languageTestType,
-                this.languageTestScore,
-                this.languageTestReportUrl
-        );
-    }
+        String languageTestScore
+) {
 }

--- a/src/main/java/com/example/solidconnection/score/service/ScoreService.java
+++ b/src/main/java/com/example/solidconnection/score/service/ScoreService.java
@@ -1,6 +1,9 @@
 package com.example.solidconnection.score.service;
 
+import com.example.solidconnection.application.domain.Gpa;
 import com.example.solidconnection.application.domain.LanguageTest;
+import com.example.solidconnection.s3.S3Service;
+import com.example.solidconnection.s3.UploadedFileUrlResponse;
 import com.example.solidconnection.score.domain.GpaScore;
 import com.example.solidconnection.score.domain.LanguageTestScore;
 import com.example.solidconnection.score.dto.GpaScoreRequest;
@@ -12,9 +15,11 @@ import com.example.solidconnection.score.dto.LanguageTestScoreStatusResponse;
 import com.example.solidconnection.score.repository.GpaScoreRepository;
 import com.example.solidconnection.score.repository.LanguageTestScoreRepository;
 import com.example.solidconnection.siteuser.domain.SiteUser;
+import com.example.solidconnection.type.ImgType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.Collections;
 import java.util.List;
@@ -26,22 +31,25 @@ import java.util.stream.Collectors;
 public class ScoreService {
 
     private final GpaScoreRepository gpaScoreRepository;
+    private final S3Service s3Service;
     private final LanguageTestScoreRepository languageTestScoreRepository;
 
     @Transactional
-    public Long submitGpaScore(SiteUser siteUser, GpaScoreRequest gpaScoreRequest) {
-        GpaScore newGpaScore = new GpaScore(gpaScoreRequest.toGpa(), siteUser);
+    public Long submitGpaScore(SiteUser siteUser, GpaScoreRequest gpaScoreRequest, MultipartFile file) {
+        UploadedFileUrlResponse uploadedFile = s3Service.uploadFile(file, ImgType.GPA);
+        Gpa gpa = new Gpa(gpaScoreRequest.gpa(), gpaScoreRequest.gpaCriteria(), uploadedFile.fileUrl());
+        GpaScore newGpaScore = new GpaScore(gpa, siteUser);
         newGpaScore.setSiteUser(siteUser);
         GpaScore savedNewGpaScore = gpaScoreRepository.save(newGpaScore);  // 저장 후 반환된 객체
         return savedNewGpaScore.getId();  // 저장된 GPA Score의 ID 반환
     }
 
     @Transactional
-    public Long submitLanguageTestScore(SiteUser siteUser, LanguageTestScoreRequest languageTestScoreRequest) {
-        LanguageTest languageTest = languageTestScoreRequest.toLanguageTest();
-
-        LanguageTestScore newScore = new LanguageTestScore(
-                languageTest, siteUser);
+    public Long submitLanguageTestScore(SiteUser siteUser, LanguageTestScoreRequest languageTestScoreRequest, MultipartFile file) {
+        UploadedFileUrlResponse uploadedFile = s3Service.uploadFile(file, ImgType.LANGUAGE_TEST);
+        LanguageTest languageTest = new LanguageTest(languageTestScoreRequest.languageTestType(),
+                languageTestScoreRequest.languageTestScore(), uploadedFile.fileUrl());
+        LanguageTestScore newScore = new LanguageTestScore(languageTest, siteUser);
         newScore.setSiteUser(siteUser);
         LanguageTestScore savedNewScore = languageTestScoreRepository.save(newScore);  // 새로 저장한 객체
         return savedNewScore.getId();  // 저장된 객체의 ID 반환

--- a/src/main/java/com/example/solidconnection/score/service/ScoreService.java
+++ b/src/main/java/com/example/solidconnection/score/service/ScoreService.java
@@ -2,6 +2,7 @@ package com.example.solidconnection.score.service;
 
 import com.example.solidconnection.application.domain.Gpa;
 import com.example.solidconnection.application.domain.LanguageTest;
+import com.example.solidconnection.custom.exception.CustomException;
 import com.example.solidconnection.s3.S3Service;
 import com.example.solidconnection.s3.UploadedFileUrlResponse;
 import com.example.solidconnection.score.domain.GpaScore;
@@ -15,6 +16,7 @@ import com.example.solidconnection.score.dto.LanguageTestScoreStatusResponse;
 import com.example.solidconnection.score.repository.GpaScoreRepository;
 import com.example.solidconnection.score.repository.LanguageTestScoreRepository;
 import com.example.solidconnection.siteuser.domain.SiteUser;
+import com.example.solidconnection.siteuser.repository.SiteUserRepository;
 import com.example.solidconnection.type.ImgType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -26,6 +28,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static com.example.solidconnection.custom.exception.ErrorCode.USER_NOT_FOUND;
+
 @Service
 @RequiredArgsConstructor
 public class ScoreService {
@@ -33,13 +37,21 @@ public class ScoreService {
     private final GpaScoreRepository gpaScoreRepository;
     private final S3Service s3Service;
     private final LanguageTestScoreRepository languageTestScoreRepository;
+    private final SiteUserRepository siteUserRepository;
 
     @Transactional
     public Long submitGpaScore(SiteUser siteUser, GpaScoreRequest gpaScoreRequest, MultipartFile file) {
         UploadedFileUrlResponse uploadedFile = s3Service.uploadFile(file, ImgType.GPA);
         Gpa gpa = new Gpa(gpaScoreRequest.gpa(), gpaScoreRequest.gpaCriteria(), uploadedFile.fileUrl());
-        GpaScore newGpaScore = new GpaScore(gpa, siteUser);
-        newGpaScore.setSiteUser(siteUser);
+
+        /*
+         * todo: siteUser를 영속 상태로 만들 수 있도록 컨트롤러에서 siteUserId 를 넘겨줄 것인지,
+         *  siteUser 에 gpaScoreList 를 FetchType.EAGER 로 설정할 것인지,
+         *  gpa 와 siteUser 사이의 양방향을 끊을 것인지 생각해봐야한다.
+         */
+        SiteUser siteUser1 = siteUserRepository.findById(siteUser.getId()).orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+        GpaScore newGpaScore = new GpaScore(gpa, siteUser1);
+        newGpaScore.setSiteUser(siteUser1);
         GpaScore savedNewGpaScore = gpaScoreRepository.save(newGpaScore);  // 저장 후 반환된 객체
         return savedNewGpaScore.getId();  // 저장된 GPA Score의 ID 반환
     }
@@ -49,16 +61,25 @@ public class ScoreService {
         UploadedFileUrlResponse uploadedFile = s3Service.uploadFile(file, ImgType.LANGUAGE_TEST);
         LanguageTest languageTest = new LanguageTest(languageTestScoreRequest.languageTestType(),
                 languageTestScoreRequest.languageTestScore(), uploadedFile.fileUrl());
-        LanguageTestScore newScore = new LanguageTestScore(languageTest, siteUser);
-        newScore.setSiteUser(siteUser);
+
+        /*
+         * todo: siteUser를 영속 상태로 만들 수 있도록 컨트롤러에서 siteUserId 를 넘겨줄 것인지,
+         *  siteUser 에 languageTestScoreList 를 FetchType.EAGER 로 설정할 것인지,
+         *  languageTest 와 siteUser 사이의 양방향을 끊을 것인지 생각해봐야한다.
+         */
+        SiteUser siteUser1 = siteUserRepository.findById(siteUser.getId()).orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+        LanguageTestScore newScore = new LanguageTestScore(languageTest, siteUser1);
+        newScore.setSiteUser(siteUser1);
         LanguageTestScore savedNewScore = languageTestScoreRepository.save(newScore);  // 새로 저장한 객체
         return savedNewScore.getId();  // 저장된 객체의 ID 반환
     }
 
     @Transactional(readOnly = true)
     public GpaScoreStatusResponse getGpaScoreStatus(SiteUser siteUser) {
+        // todo: ditto
+        SiteUser siteUser1 = siteUserRepository.findById(siteUser.getId()).orElseThrow(() -> new CustomException(USER_NOT_FOUND));
         List<GpaScoreStatus> gpaScoreStatusList =
-                Optional.ofNullable(siteUser.getGpaScoreList())
+                Optional.ofNullable(siteUser1.getGpaScoreList())
                         .map(scores -> scores.stream()
                                 .map(GpaScoreStatus::from)
                                 .collect(Collectors.toList()))
@@ -68,8 +89,10 @@ public class ScoreService {
 
     @Transactional(readOnly = true)
     public LanguageTestScoreStatusResponse getLanguageTestScoreStatus(SiteUser siteUser) {
+        // todo: ditto
+        SiteUser siteUser1 = siteUserRepository.findById(siteUser.getId()).orElseThrow(() -> new CustomException(USER_NOT_FOUND));
         List<LanguageTestScoreStatus> languageTestScoreStatusList =
-                Optional.ofNullable(siteUser.getLanguageTestScoreList())
+                Optional.ofNullable(siteUser1.getLanguageTestScoreList())
                         .map(scores -> scores.stream()
                                 .map(LanguageTestScoreStatus::from)
                                 .collect(Collectors.toList()))

--- a/src/test/java/com/example/solidconnection/community/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/example/solidconnection/community/comment/service/CommentServiceTest.java
@@ -9,9 +9,9 @@ import com.example.solidconnection.community.comment.dto.CommentUpdateRequest;
 import com.example.solidconnection.community.comment.dto.CommentUpdateResponse;
 import com.example.solidconnection.community.comment.dto.PostFindCommentResponse;
 import com.example.solidconnection.community.comment.repository.CommentRepository;
-import com.example.solidconnection.custom.exception.CustomException;
 import com.example.solidconnection.community.post.domain.Post;
 import com.example.solidconnection.community.post.repository.PostRepository;
+import com.example.solidconnection.custom.exception.CustomException;
 import com.example.solidconnection.siteuser.domain.SiteUser;
 import com.example.solidconnection.support.integration.BaseIntegrationTest;
 import com.example.solidconnection.type.PostCategory;
@@ -110,12 +110,11 @@ class CommentServiceTest extends BaseIntegrationTest {
         void 댓글을_성공적으로_생성한다() {
             // given
             Post testPost = createPost(자유게시판, 테스트유저_1);
-            CommentCreateRequest request = new CommentCreateRequest("테스트 댓글", null);
+            CommentCreateRequest request = new CommentCreateRequest(testPost.getId(), "테스트 댓글", null);
 
             // when
             CommentCreateResponse response = commentService.createComment(
                     테스트유저_1,
-                    testPost.getId(),
                     request
             );
 
@@ -135,12 +134,11 @@ class CommentServiceTest extends BaseIntegrationTest {
             // given
             Post testPost = createPost(자유게시판, 테스트유저_1);
             Comment parentComment = createComment(testPost, 테스트유저_1, "부모 댓글");
-            CommentCreateRequest request = new CommentCreateRequest("테스트 대댓글", parentComment.getId());
+            CommentCreateRequest request = new CommentCreateRequest(testPost.getId(), "테스트 대댓글", parentComment.getId());
 
             // when
             CommentCreateResponse response = commentService.createComment(
                     테스트유저_2,
-                    testPost.getId(),
                     request
             );
 
@@ -161,13 +159,12 @@ class CommentServiceTest extends BaseIntegrationTest {
             Post testPost = createPost(자유게시판, 테스트유저_1);
             Comment parentComment = createComment(testPost, 테스트유저_1, "부모 댓글");
             Comment childComment = createChildComment(testPost, 테스트유저_2, parentComment, "자식 댓글");
-            CommentCreateRequest request = new CommentCreateRequest("테스트 대대댓글", childComment.getId());
+            CommentCreateRequest request = new CommentCreateRequest(testPost.getId(), "테스트 대대댓글", childComment.getId());
 
             // when & then
             assertThatThrownBy(() ->
                     commentService.createComment(
                             테스트유저_1,
-                            testPost.getId(),
                             request
                     ))
                     .isInstanceOf(CustomException.class)
@@ -179,13 +176,12 @@ class CommentServiceTest extends BaseIntegrationTest {
             // given
             Post testPost = createPost(자유게시판, 테스트유저_1);
             long invalidCommentId = 9999L;
-            CommentCreateRequest request = new CommentCreateRequest("테스트 대댓글", invalidCommentId);
+            CommentCreateRequest request = new CommentCreateRequest(testPost.getId(), "테스트 대댓글", invalidCommentId);
 
             // when & then
             assertThatThrownBy(() ->
                     commentService.createComment(
                             테스트유저_1,
-                            testPost.getId(),
                             request
                     ))
                     .isInstanceOf(CustomException.class)
@@ -206,7 +202,6 @@ class CommentServiceTest extends BaseIntegrationTest {
             // when
             CommentUpdateResponse response = commentService.updateComment(
                     테스트유저_1,
-                    testPost.getId(),
                     comment.getId(),
                     request
             );
@@ -233,7 +228,6 @@ class CommentServiceTest extends BaseIntegrationTest {
             assertThatThrownBy(() ->
                     commentService.updateComment(
                             테스트유저_2,
-                            testPost.getId(),
                             comment.getId(),
                             request
                     ))
@@ -252,7 +246,6 @@ class CommentServiceTest extends BaseIntegrationTest {
             assertThatThrownBy(() ->
                     commentService.updateComment(
                             테스트유저_1,
-                            testPost.getId(),
                             comment.getId(),
                             request
                     ))
@@ -276,7 +269,6 @@ class CommentServiceTest extends BaseIntegrationTest {
             // when
             CommentDeleteResponse response = commentService.deleteCommentById(
                     테스트유저_1,
-                    testPost.getId(),
                     comment.getId()
             );
 
@@ -301,7 +293,6 @@ class CommentServiceTest extends BaseIntegrationTest {
             // when
             CommentDeleteResponse response = commentService.deleteCommentById(
                     테스트유저_1,
-                    testPost.getId(),
                     parentComment.getId()
             );
 
@@ -331,7 +322,6 @@ class CommentServiceTest extends BaseIntegrationTest {
             // when
             CommentDeleteResponse response = commentService.deleteCommentById(
                     테스트유저_2,
-                    testPost.getId(),
                     childComment1.getId()
             );
 
@@ -362,7 +352,6 @@ class CommentServiceTest extends BaseIntegrationTest {
             // when
             CommentDeleteResponse response = commentService.deleteCommentById(
                     테스트유저_2,
-                    testPost.getId(),
                     childComment.getId()
             );
 
@@ -384,7 +373,6 @@ class CommentServiceTest extends BaseIntegrationTest {
             assertThatThrownBy(() ->
                     commentService.deleteCommentById(
                             테스트유저_2,
-                            testPost.getId(),
                             comment.getId()
                     ))
                     .isInstanceOf(CustomException.class)

--- a/src/test/java/com/example/solidconnection/community/post/service/PostCommandServiceTest.java
+++ b/src/test/java/com/example/solidconnection/community/post/service/PostCommandServiceTest.java
@@ -1,16 +1,16 @@
 package com.example.solidconnection.community.post.service;
 
 import com.example.solidconnection.community.board.domain.Board;
-import com.example.solidconnection.custom.exception.CustomException;
-import com.example.solidconnection.community.post.domain.PostImage;
 import com.example.solidconnection.community.post.domain.Post;
+import com.example.solidconnection.community.post.domain.PostImage;
 import com.example.solidconnection.community.post.dto.PostCreateRequest;
 import com.example.solidconnection.community.post.dto.PostCreateResponse;
 import com.example.solidconnection.community.post.dto.PostDeleteResponse;
 import com.example.solidconnection.community.post.dto.PostUpdateRequest;
 import com.example.solidconnection.community.post.dto.PostUpdateResponse;
-import com.example.solidconnection.community.post.repository.PostRepository;
 import com.example.solidconnection.community.post.repository.PostImageRepository;
+import com.example.solidconnection.community.post.repository.PostRepository;
+import com.example.solidconnection.custom.exception.CustomException;
 import com.example.solidconnection.s3.S3Service;
 import com.example.solidconnection.s3.UploadedFileUrlResponse;
 import com.example.solidconnection.service.RedisService;
@@ -37,9 +37,9 @@ import static com.example.solidconnection.custom.exception.ErrorCode.INVALID_POS
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.any;
 import static org.mockito.BDDMockito.eq;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
 @DisplayName("게시글 생성/수정/삭제 서비스 테스트")
@@ -79,7 +79,6 @@ class PostCommandServiceTest extends BaseIntegrationTest {
             // when
             PostCreateResponse response = postCommandService.createPost(
                     테스트유저_1,
-                    자유게시판.getCode(),
                     request,
                     imageFiles
             );
@@ -108,7 +107,7 @@ class PostCommandServiceTest extends BaseIntegrationTest {
 
             // when & then
             assertThatThrownBy(() ->
-                    postCommandService.createPost(테스트유저_1, 자유게시판.getCode(), request, imageFiles))
+                    postCommandService.createPost(테스트유저_1, request, imageFiles))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(INVALID_POST_CATEGORY.getMessage());
         }
@@ -121,7 +120,7 @@ class PostCommandServiceTest extends BaseIntegrationTest {
 
             // when & then
             assertThatThrownBy(() ->
-                    postCommandService.createPost(테스트유저_1, 자유게시판.getCode(), request, imageFiles))
+                    postCommandService.createPost(테스트유저_1, request, imageFiles))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(INVALID_POST_CATEGORY.getMessage());
         }
@@ -134,7 +133,7 @@ class PostCommandServiceTest extends BaseIntegrationTest {
 
             // when & then
             assertThatThrownBy(() ->
-                    postCommandService.createPost(테스트유저_1, 자유게시판.getCode(), request, imageFiles))
+                    postCommandService.createPost(테스트유저_1, request, imageFiles))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(CAN_NOT_UPLOAD_MORE_THAN_FIVE_IMAGES.getMessage());
         }
@@ -159,7 +158,6 @@ class PostCommandServiceTest extends BaseIntegrationTest {
             // when
             PostUpdateResponse response = postCommandService.updatePost(
                     테스트유저_1,
-                    자유게시판.getCode(),
                     testPost.getId(),
                     request,
                     imageFiles
@@ -190,7 +188,6 @@ class PostCommandServiceTest extends BaseIntegrationTest {
             assertThatThrownBy(() ->
                     postCommandService.updatePost(
                             테스트유저_2,
-                            자유게시판.getCode(),
                             testPost.getId(),
                             request,
                             imageFiles
@@ -210,7 +207,6 @@ class PostCommandServiceTest extends BaseIntegrationTest {
             assertThatThrownBy(() ->
                     postCommandService.updatePost(
                             테스트유저_1,
-                            자유게시판.getCode(),
                             testPost.getId(),
                             request,
                             imageFiles
@@ -230,7 +226,6 @@ class PostCommandServiceTest extends BaseIntegrationTest {
             assertThatThrownBy(() ->
                     postCommandService.updatePost(
                             테스트유저_1,
-                            자유게시판.getCode(),
                             testPost.getId(),
                             request,
                             imageFiles
@@ -254,7 +249,6 @@ class PostCommandServiceTest extends BaseIntegrationTest {
             // when
             PostDeleteResponse response = postCommandService.deletePostById(
                     테스트유저_1,
-                    자유게시판.getCode(),
                     testPost.getId()
             );
 
@@ -276,7 +270,6 @@ class PostCommandServiceTest extends BaseIntegrationTest {
             assertThatThrownBy(() ->
                     postCommandService.deletePostById(
                             테스트유저_2,
-                            자유게시판.getCode(),
                             testPost.getId()
                     ))
                     .isInstanceOf(CustomException.class)
@@ -292,7 +285,6 @@ class PostCommandServiceTest extends BaseIntegrationTest {
             assertThatThrownBy(() ->
                     postCommandService.deletePostById(
                             테스트유저_1,
-                            자유게시판.getCode(),
                             testPost.getId()
                     ))
                     .isInstanceOf(CustomException.class)
@@ -302,6 +294,7 @@ class PostCommandServiceTest extends BaseIntegrationTest {
 
     private PostCreateRequest createPostCreateRequest(String category) {
         return new PostCreateRequest(
+                자유게시판.getCode(),
                 category,
                 "테스트 제목",
                 "테스트 내용",

--- a/src/test/java/com/example/solidconnection/community/post/service/PostLikeServiceTest.java
+++ b/src/test/java/com/example/solidconnection/community/post/service/PostLikeServiceTest.java
@@ -45,7 +45,6 @@ class PostLikeServiceTest extends BaseIntegrationTest {
             // when
             PostLikeResponse response = postLikeService.likePost(
                     테스트유저_1,
-                    자유게시판.getCode(),
                     testPost.getId()
             );
 
@@ -63,13 +62,12 @@ class PostLikeServiceTest extends BaseIntegrationTest {
         void 이미_좋아요한_게시글을_다시_좋아요하면_예외_응답을_반환한다() {
             // given
             Post testPost = createPost(자유게시판, 테스트유저_1);
-            postLikeService.likePost(테스트유저_1, 자유게시판.getCode(), testPost.getId());
+            postLikeService.likePost(테스트유저_1,  testPost.getId());
 
             // when & then
             assertThatThrownBy(() ->
                     postLikeService.likePost(
                             테스트유저_1,
-                            자유게시판.getCode(),
                             testPost.getId()
                     ))
                     .isInstanceOf(CustomException.class)
@@ -84,13 +82,12 @@ class PostLikeServiceTest extends BaseIntegrationTest {
         void 게시글_좋아요를_성공적으로_취소한다() {
             // given
             Post testPost = createPost(자유게시판, 테스트유저_1);
-            PostLikeResponse beforeResponse = postLikeService.likePost(테스트유저_1, 자유게시판.getCode(), testPost.getId());
+            PostLikeResponse beforeResponse = postLikeService.likePost(테스트유저_1,  testPost.getId());
             long beforeLikeCount = beforeResponse.likeCount();
 
             // when
             PostDislikeResponse response = postLikeService.dislikePost(
                     테스트유저_1,
-                    자유게시판.getCode(),
                     testPost.getId()
             );
 
@@ -113,7 +110,6 @@ class PostLikeServiceTest extends BaseIntegrationTest {
             assertThatThrownBy(() ->
                     postLikeService.dislikePost(
                             테스트유저_1,
-                            자유게시판.getCode(),
                             testPost.getId()
                     ))
                     .isInstanceOf(CustomException.class)

--- a/src/test/java/com/example/solidconnection/community/post/service/PostQueryServiceTest.java
+++ b/src/test/java/com/example/solidconnection/community/post/service/PostQueryServiceTest.java
@@ -112,7 +112,6 @@ class PostQueryServiceTest extends BaseIntegrationTest {
         // when
         PostFindResponse response = postQueryService.findPostById(
                 테스트유저_1,
-                자유게시판.getCode(),
                 testPost.getId()
         );
 

--- a/src/test/java/com/example/solidconnection/concurrency/PostLikeCountConcurrencyTest.java
+++ b/src/test/java/com/example/solidconnection/concurrency/PostLikeCountConcurrencyTest.java
@@ -103,8 +103,8 @@ class PostLikeCountConcurrencyTest {
             SiteUser tmpSiteUser = siteUserRepository.save(createSiteUserByEmail(email));
             executorService.submit(() -> {
                 try {
-                    postLikeService.likePost(tmpSiteUser, board.getCode(), post.getId());
-                    postLikeService.dislikePost(tmpSiteUser, board.getCode(), post.getId());
+                    postLikeService.likePost(tmpSiteUser, post.getId());
+                    postLikeService.dislikePost(tmpSiteUser, post.getId());
                 } finally {
                     doneSignal.countDown();
                 }

--- a/src/test/java/com/example/solidconnection/e2e/ApplicantsQueryTest.java
+++ b/src/test/java/com/example/solidconnection/e2e/ApplicantsQueryTest.java
@@ -105,7 +105,7 @@ class ApplicantsQueryTest extends UniversityDataSetUpEndToEndTest {
         ApplicationsResponse response = RestAssured.given().log().all()
                 .header("Authorization", "Bearer " + accessToken)
                 .when().log().all()
-                .get("/application")
+                .get("/applications")
                 .then().log().all()
                 .statusCode(200)
                 .extract().as(ApplicationsResponse.class);
@@ -151,7 +151,7 @@ class ApplicantsQueryTest extends UniversityDataSetUpEndToEndTest {
         ApplicationsResponse response = RestAssured.given().log().all()
                 .header("Authorization", "Bearer " + accessToken)
                 .when().log().all()
-                .get("/application?region=" + 영미권.getCode())
+                .get("/applications?region=" + 영미권.getCode())
                 .then().log().all()
                 .statusCode(200)
                 .extract().as(ApplicationsResponse.class);
@@ -178,7 +178,7 @@ class ApplicantsQueryTest extends UniversityDataSetUpEndToEndTest {
         ApplicationsResponse response = RestAssured.given().log().all()
                 .header("Authorization", "Bearer " + accessToken)
                 .when().log().all()
-                .get("/application?keyword=라")
+                .get("/applications?keyword=라")
                 .then().log().all()
                 .statusCode(200)
                 .extract().as(ApplicationsResponse.class);
@@ -204,7 +204,7 @@ class ApplicantsQueryTest extends UniversityDataSetUpEndToEndTest {
         ApplicationsResponse response = RestAssured.given().log().all()
                 .header("Authorization", "Bearer " + accessToken)
                 .when().log().all()
-                .get("/application?keyword=일본")
+                .get("/applications?keyword=일본")
                 .then().log().all()
                 .statusCode(200)
                 .extract().as(ApplicationsResponse.class);
@@ -224,7 +224,7 @@ class ApplicantsQueryTest extends UniversityDataSetUpEndToEndTest {
         ApplicationsResponse response = RestAssured.given().log().all()
                 .header("Authorization", "Bearer " + accessToken)
                 .when().log().all()
-                .get("/application")
+                .get("/applications")
                 .then().log().all()
                 .statusCode(200)
                 .extract().as(ApplicationsResponse.class);
@@ -253,7 +253,7 @@ class ApplicantsQueryTest extends UniversityDataSetUpEndToEndTest {
         ApplicationsResponse response = RestAssured.given().log().all()
                 .header("Authorization", "Bearer " + accessToken)
                 .when().log().all()
-                .get("/application/competitors")
+                .get("/applications/competitors")
                 .then().log().all()
                 .statusCode(200)
                 .extract().as(ApplicationsResponse.class);
@@ -295,7 +295,7 @@ class ApplicantsQueryTest extends UniversityDataSetUpEndToEndTest {
         ApplicationsResponse response = RestAssured.given().log().all()
                 .header("Authorization", "Bearer " + user6AccessToken)
                 .when().log().all()
-                .get("/application/competitors")
+                .get("/applications/competitors")
                 .then().log().all()
                 .statusCode(200)
                 .extract().as(ApplicationsResponse.class);
@@ -316,7 +316,7 @@ class ApplicantsQueryTest extends UniversityDataSetUpEndToEndTest {
         ApplicationsResponse response = RestAssured.given().log().all()
                 .header("Authorization", "Bearer " + adminAccessToken)
                 .when().log().all()
-                .get("/application/competitors")
+                .get("/applications/competitors")
                 .then().log().all()
                 .statusCode(200)
                 .extract().as(ApplicationsResponse.class);


### PR DESCRIPTION
## 관련 이슈

- resolves: #181 

## 작업 내용

회의에 나온 내용들을 반영했습니다😊

## 특이 사항

**URI 복수형 사용**
- 게시판 관련 uri를 `/communites/**` 에서 `/boards/**`로 변경
- 지원 관련 uri를 `/application/**` 에서 `/applications/**`로 변경
- 어학 성적 관련 uri를 `/score/languageTest/**`에서 `scores/language-tests/**`로 변경
- 학점 관련 uri를 `/score/gpa/**`에서 `/scores/gpas/**`로 변경

**request, response 변경**
- gpa 성적 등록, 어학 성적 등록 시 [파일 업로드 → url 제출]이 아니라 바로 파일을 업로드하도록 변경
- 댓글 작성 시 postId 함께 제출하도록 변경
- 게시글 작성 시 boardCode 함께 제출하도록 변경
- 게시판 조회(PostFindResponse)시 boardCode 함께 응답하도록 변경

## 리뷰 요구사항 (선택)

**❗️조금 치명적인 이슈가 있습니다🥲❗️**
컨트롤러에서 SiteUser 를 인자로 받기 이전에는,
서비스 코드에서 직접 SiteUser 를 조회해와서, 다른 비지니스 로직들과 동일한 영속성 컨텍스트에 적재되었습니다.
그래서 Lazy Loading 을 사용할 수 있었어요.

하지만 지금은 컨트롤러에서 SiteUser를 가져오기 때문에, 
서비스 코드에서 이 SiteUser 는 영속 상태가 아니라 Lazy Loading이 적용되지 않습니다.
이 PR에서는 가장 간편한 해결방법으로 해결하긴 했는데, 추가로 논의가 필요할 것 같습니다.

이건 오늘 회의 끝나고 이야기해봐도 좋을 것 같습니다.

**❗️api 변경 사항❗️**
https://github.com/solid-connection/api-docs/pull/5