### PR TITLE
fix: 인증과 관련되어 리졸버와 컨트롤러 인자에서 발생한 이슈 해결

### DIFF
--- a/src/main/java/com/example/solidconnection/auth/controller/AuthController.java
+++ b/src/main/java/com/example/solidconnection/auth/controller/AuthController.java
@@ -16,14 +16,15 @@ import com.example.solidconnection.auth.service.EmailSignUpTokenProvider;
 import com.example.solidconnection.auth.service.oauth.AppleOAuthService;
 import com.example.solidconnection.auth.service.oauth.KakaoOAuthService;
 import com.example.solidconnection.auth.service.oauth.OAuthSignUpService;
+import com.example.solidconnection.custom.exception.CustomException;
+import com.example.solidconnection.custom.exception.ErrorCode;
 import com.example.solidconnection.custom.resolver.AuthorizedUser;
-import com.example.solidconnection.custom.resolver.ExpiredToken;
-import com.example.solidconnection.custom.security.authentication.ExpiredTokenAuthentication;
 import com.example.solidconnection.siteuser.domain.AuthType;
 import com.example.solidconnection.siteuser.domain.SiteUser;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -93,9 +94,13 @@ public class AuthController {
 
     @PostMapping("/sign-out")
     public ResponseEntity<Void> signOut(
-            @ExpiredToken ExpiredTokenAuthentication expiredToken
+            Authentication authentication
     ) {
-        authService.signOut(expiredToken.getToken());
+        String token = authentication.getCredentials().toString();
+        if (token == null) {
+            throw new CustomException(ErrorCode.AUTHENTICATION_FAILED, "토큰이 없습니다.");
+        }
+        authService.signOut(token);
         return ResponseEntity.ok().build();
     }
 
@@ -109,9 +114,13 @@ public class AuthController {
 
     @PostMapping("/reissue")
     public ResponseEntity<ReissueResponse> reissueToken(
-            @ExpiredToken ExpiredTokenAuthentication expiredToken
+            Authentication authentication
     ) {
-        ReissueResponse reissueResponse = authService.reissue(expiredToken.getSubject());
+        String token = authentication.getCredentials().toString();
+        if (token == null) {
+            throw new CustomException(ErrorCode.AUTHENTICATION_FAILED, "토큰이 없습니다.");
+        }
+        ReissueResponse reissueResponse = authService.reissue(token);
         return ResponseEntity.ok(reissueResponse);
     }
 }

--- a/src/main/java/com/example/solidconnection/custom/resolver/AuthorizedUser.java
+++ b/src/main/java/com/example/solidconnection/custom/resolver/AuthorizedUser.java
@@ -8,4 +8,5 @@ import java.lang.annotation.Target;
 @Target({ElementType.PARAMETER})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface AuthorizedUser {
+    boolean required() default true;
 }

--- a/src/main/java/com/example/solidconnection/custom/resolver/AuthorizedUserResolver.java
+++ b/src/main/java/com/example/solidconnection/custom/resolver/AuthorizedUserResolver.java
@@ -1,15 +1,19 @@
 package com.example.solidconnection.custom.resolver;
 
+import com.example.solidconnection.custom.exception.CustomException;
 import com.example.solidconnection.custom.security.userdetails.SiteUserDetails;
 import com.example.solidconnection.siteuser.domain.SiteUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
+
+import static com.example.solidconnection.custom.exception.ErrorCode.AUTHENTICATION_FAILED;
 
 @Component
 @RequiredArgsConstructor
@@ -25,11 +29,19 @@ public class AuthorizedUserResolver implements HandlerMethodArgumentResolver {
     public Object resolveArgument(MethodParameter parameter,
                                   ModelAndViewContainer mavContainer,
                                   NativeWebRequest webRequest,
-                                  WebDataBinderFactory binderFactory) throws Exception {
+                                  WebDataBinderFactory binderFactory) {
+        SiteUser siteUser = extractSiteUserFromAuthentication();
+        if (parameter.getParameterAnnotation(AuthorizedUser.class).required() && siteUser == null) {
+            throw new CustomException(AUTHENTICATION_FAILED, "로그인 상태가 아닙니다.");
+        }
+
+        return siteUser;
+    }
+
+    private SiteUser extractSiteUserFromAuthentication() {
         try {
-            SiteUserDetails principal = (SiteUserDetails) SecurityContextHolder.getContext()
-                    .getAuthentication()
-                    .getPrincipal();
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+            SiteUserDetails principal = (SiteUserDetails) authentication.getPrincipal();
             return principal.getSiteUser();
         } catch (Exception e) {
             return null;

--- a/src/main/java/com/example/solidconnection/custom/resolver/ExpiredToken.java
+++ b/src/main/java/com/example/solidconnection/custom/resolver/ExpiredToken.java
@@ -5,6 +5,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+// todo: 사용되지 않음, 다른 PR에서 삭제하고 더 효율적인 구조를 고민해봐야 함
 @Target({ElementType.PARAMETER})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ExpiredToken {

--- a/src/main/java/com/example/solidconnection/custom/resolver/ExpiredTokenResolver.java
+++ b/src/main/java/com/example/solidconnection/custom/resolver/ExpiredTokenResolver.java
@@ -10,6 +10,7 @@ import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
+// todo: 사용되지 않음, 다른 PR에서 삭제하고 더 효율적인 구조를 고민해봐야 함
 @Component
 @RequiredArgsConstructor
 public class ExpiredTokenResolver implements HandlerMethodArgumentResolver {

--- a/src/main/java/com/example/solidconnection/custom/security/authentication/ExpiredTokenAuthentication.java
+++ b/src/main/java/com/example/solidconnection/custom/security/authentication/ExpiredTokenAuthentication.java
@@ -1,5 +1,6 @@
 package com.example.solidconnection.custom.security.authentication;
 
+// todo: 사용되지 않음, 다른 PR에서 삭제하고 더 효율적인 구조를 고민해봐야 함
 public class ExpiredTokenAuthentication extends JwtAuthentication {
 
     public ExpiredTokenAuthentication(String token) {

--- a/src/main/java/com/example/solidconnection/custom/security/provider/ExpiredTokenAuthenticationProvider.java
+++ b/src/main/java/com/example/solidconnection/custom/security/provider/ExpiredTokenAuthenticationProvider.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Component;
 
 import static com.example.solidconnection.util.JwtUtils.parseSubjectIgnoringExpiration;
 
+// todo: 사용되지 않음, 다른 PR에서 삭제하고 더 효율적인 구조를 고민해봐야 함
 @Component
 @RequiredArgsConstructor
 public class ExpiredTokenAuthenticationProvider implements AuthenticationProvider {

--- a/src/main/java/com/example/solidconnection/university/controller/UniversityController.java
+++ b/src/main/java/com/example/solidconnection/university/controller/UniversityController.java
@@ -36,7 +36,7 @@ public class UniversityController {
 
     @GetMapping("/recommend")
     public ResponseEntity<UniversityRecommendsResponse> getUniversityRecommends(
-            @AuthorizedUser SiteUser siteUser
+            @AuthorizedUser(required = false) SiteUser siteUser
     ) {
         if (siteUser == null) {
             return ResponseEntity.ok(universityRecommendService.getGeneralRecommends());

--- a/src/test/java/com/example/solidconnection/custom/resolver/AuthorizedUserResolverTest.java
+++ b/src/test/java/com/example/solidconnection/custom/resolver/AuthorizedUserResolverTest.java
@@ -1,6 +1,7 @@
 package com.example.solidconnection.custom.resolver;
 
 
+import com.example.solidconnection.custom.exception.CustomException;
 import com.example.solidconnection.custom.security.authentication.SiteUserAuthentication;
 import com.example.solidconnection.custom.security.userdetails.SiteUserDetails;
 import com.example.solidconnection.siteuser.domain.SiteUser;
@@ -11,11 +12,18 @@ import com.example.solidconnection.type.PreparationStatus;
 import com.example.solidconnection.type.Role;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
+import static com.example.solidconnection.custom.exception.ErrorCode.AUTHENTICATION_FAILED;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 @TestContainerSpringBootTest
 @DisplayName("인증된 사용자 argument resolver 테스트")
@@ -33,28 +41,58 @@ class AuthorizedUserResolverTest {
     }
 
     @Test
-    void security_context_에_저장된_인증된_사용자를_반환한다() throws Exception {
+    void security_context_에_저장된_인증된_사용자를_반환한다() {
         // given
-        SiteUser siteUser = siteUserRepository.save(createSiteUser());
-        SiteUserDetails userDetails = new SiteUserDetails(siteUser);
-        SiteUserAuthentication authentication = new SiteUserAuthentication("token", userDetails);
+        SiteUser siteUser = createAndSaveSiteUser();
+        Authentication authentication = createAuthenticationWithUser(siteUser);
         SecurityContextHolder.getContext().setAuthentication(authentication);
 
+        MethodParameter parameter = mock(MethodParameter.class);
+        AuthorizedUser authorizedUser = mock(AuthorizedUser.class);
+        given(parameter.getParameterAnnotation(AuthorizedUser.class)).willReturn(authorizedUser);
+        given(authorizedUser.required()).willReturn(false);
+
         // when
-        SiteUser resolveSiteUser = (SiteUser) authorizedUserResolver.resolveArgument(null, null, null, null);
+        SiteUser resolveSiteUser = (SiteUser) authorizedUserResolver.resolveArgument(parameter, null, null, null);
 
         // then
         assertThat(resolveSiteUser).isEqualTo(siteUser);
     }
 
-    @Test
-    void security_context_에_저장된_사용자가_없으면_null_을_반환한다() throws Exception {
-        // when, then
-        assertThat(authorizedUserResolver.resolveArgument(null, null, null, null)).isNull();
+    @Nested
+    class security_context_에_저장된_사용자가_없는_경우 {
+
+        @Test
+        void required_가_true_이면_예외_응답을_반환한다() {
+            // given
+            MethodParameter parameter = mock(MethodParameter.class);
+            AuthorizedUser authorizedUser = mock(AuthorizedUser.class);
+            given(parameter.getParameterAnnotation(AuthorizedUser.class)).willReturn(authorizedUser);
+            given(authorizedUser.required()).willReturn(true);
+
+            // when, then
+            assertThatCode(() -> authorizedUserResolver.resolveArgument(parameter, null, null, null))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(AUTHENTICATION_FAILED.getMessage());
+        }
+
+        @Test
+        void required_가_false_이면_null_을_반환한다() {
+            // given
+            MethodParameter parameter = mock(MethodParameter.class);
+            AuthorizedUser authorizedUser = mock(AuthorizedUser.class);
+            given(parameter.getParameterAnnotation(AuthorizedUser.class)).willReturn(authorizedUser);
+            given(authorizedUser.required()).willReturn(false);
+
+            // when, then
+            assertThat(
+                    authorizedUserResolver.resolveArgument(parameter, null, null, null)
+            ).isNull();
+        }
     }
 
-    private SiteUser createSiteUser() {
-        return new SiteUser(
+    private SiteUser createAndSaveSiteUser() {
+        SiteUser siteUser = new SiteUser(
                 "test@example.com",
                 "nickname",
                 "profileImageUrl",
@@ -63,5 +101,11 @@ class AuthorizedUserResolverTest {
                 Role.MENTEE,
                 Gender.MALE
         );
+        return siteUserRepository.save(siteUser);
+    }
+
+    private SiteUserAuthentication createAuthenticationWithUser(SiteUser siteUser) {
+        SiteUserDetails userDetails = new SiteUserDetails(siteUser);
+        return new SiteUserAuthentication("token", userDetails);
     }
 }


### PR DESCRIPTION
## 관련 이슈

- resolves: #201

## 작업 내용

<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

### 문제 내용

로그아웃에서 예외가 발생했습니다.

```
argument type mismatch
Controller [com.example.solidconnection.auth.controller.AuthController]
Method [public org.springframework.http.ResponseEntity<java.lang.Void> 
com.example.solidconnection.auth.controller.AuthController.signOut(com.example.solidconnection.custom.security.authentication.ExpiredTokenAuthentication)] with argument values:

 [0] [type=com.example.solidconnection.custom.security.authentication.SiteUserAuthentication] 
[value=SiteUserAuthentication 
[Principal=com.example.solidconnection.custom.security.userdetails.SiteUserDetails@16a8d604, Credentials=
[PROTECTED], Authenticated=true, Details=null, Granted Authorities=[ROLE_MENTEE]]]

```

로그아웃 컨트롤러에서 ExpiredTokenAuthentication 을 기대했는데 그건 없고,
SiteUserAuthentication 가 있다는 내용의 예외입니다.

### 문제 원인

제가 시큐리티를 구성할 때, 잘못 생각했던 부분이 있었습니다.
저는 로그아웃 api 엑세스 토큰 재발급 api 에 있는
**토큰이 만료되었더라도 요청을 받아야 한다, 그리고 서비스 코드까지 토큰을 넘겨줘야 한다**
라는 특수한 요구사항을 만족시키기 위해서, ExpiredToken 이라는 개념을 만들어줬습니다.

그런데 코드 상에서 문제가 되었던 부분은,
- JwtFilter에서 만료된 토큰이면 ExpiredTokenAuthentication 를 context에 저장하고
- 로그아웃 api 와 엑세스 토큰 재발급 api의 컨트롤러에서 ExpiredTokenAuthentication 을 인자로 받았던 부분

입니다.

이렇게 하니 “로그인했으며, 토큰이 만료되지 않은 사용자”는 가 저 api 를 호출할 때 문제가 발생했습니다.
토큰이 만료되지 않았으니 JwtFilter에서 ExpiredTokenAuthentication가 아니라 SiteUserAuthentication 을 발급했고,
그랬기 때문에 컨트롤러의 인자로 ExpiredTokenAuthentication 를 받지 못했습니다…

### 문제 해결

그래서 ExpiredTokenAuthentication 이라는 개념을 없애고, 
당장 컨트롤러에서는 Authentication 으로부터 바로 토큰을 받아오도록 수정해뒀습니다.
ExpiredTokenAuthentication 을 변경하고 시큐리티 구조를 다시 생각하는건 더 시간이 걸릴 것 같아 fix 용도의 PR 만 따로 올립니다.

---

### 문제 내용

미인증 상태로 마이페이지 접근시 예외가 발생했습니다

```
Cannot invoke "com.example.solidconnection.siteuser.domain.SiteUser.getId()" because "siteUser" is null
```

### 문제 원인

기존에는 리졸버에서 일치하는 정보가 없으면 null 을 반환하게 했습니다.
받아서 사용하는 쪽에서 예외를 발생시키는게 맞다고 생각했습니다.
하지만 이렇게 처리하니 SiteUser 에서 바로 값을 꺼내오기 위해 getter 함수를 호출할 경우 NPE 가 발생하는 문제가 발생했습니다.

### 문제 해결

이를 어노테이션의 required 를 통해 해결했습니다. 
기본적으로 required = true 로 하고 리졸버 단에서 required = true 임에도 정보가 없으면 401 예외가 발생하게 구현했습니다.
회원/비회원이 모두 사용할 수 있는 맞춤 대학 추천은 required = false 를 걸어줬습니다.

## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
