### PR TITLE
fix: 유효하지 않은 토큰으로 api 요청 시 500 error 발생 버그 수정

### DIFF
--- a/src/main/java/com/example/solidconnection/config/security/SecurityConfiguration.java
+++ b/src/main/java/com/example/solidconnection/config/security/SecurityConfiguration.java
@@ -1,5 +1,7 @@
 package com.example.solidconnection.config.security;
 
+import com.example.solidconnection.custom.exception.CustomAccessDeniedHandler;
+import com.example.solidconnection.custom.exception.CustomAuthenticationEntryPoint;
 import com.example.solidconnection.custom.security.filter.ExceptionHandlerFilter;
 import com.example.solidconnection.custom.security.filter.JwtAuthenticationFilter;
 import com.example.solidconnection.custom.security.filter.SignOutCheckFilter;
@@ -13,7 +15,6 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.access.ExceptionTranslationFilter;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
@@ -30,6 +31,8 @@ public class SecurityConfiguration {
     private final ExceptionHandlerFilter exceptionHandlerFilter;
     private final SignOutCheckFilter signOutCheckFilter;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
 
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
@@ -62,9 +65,13 @@ public class SecurityConfiguration {
                         .requestMatchers("/admin/**").hasRole(ADMIN.name())
                         .anyRequest().permitAll()
                 )
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint(customAuthenticationEntryPoint)
+                        .accessDeniedHandler(customAccessDeniedHandler)
+                )
                 .addFilterBefore(jwtAuthenticationFilter, BasicAuthenticationFilter.class)
                 .addFilterBefore(signOutCheckFilter, JwtAuthenticationFilter.class)
-                .addFilterAfter(exceptionHandlerFilter, ExceptionTranslationFilter.class)
+                .addFilterBefore(exceptionHandlerFilter, SignOutCheckFilter.class)
                 .build();
     }
 }

--- a/src/main/java/com/example/solidconnection/custom/exception/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/example/solidconnection/custom/exception/CustomAccessDeniedHandler.java
@@ -1,0 +1,31 @@
+package com.example.solidconnection.custom.exception;
+
+import com.example.solidconnection.custom.response.ErrorResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(HttpServletRequest request,
+                       HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException {
+        ErrorResponse errorResponse =
+                new ErrorResponse(ErrorCode.ACCESS_DENIED);
+        response.setStatus(ErrorCode.ACCESS_DENIED.getCode());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}

--- a/src/main/java/com/example/solidconnection/custom/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/solidconnection/custom/exception/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,31 @@
+package com.example.solidconnection.custom.exception;
+
+import com.example.solidconnection.custom.response.ErrorResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+        ErrorResponse errorResponse =
+                new ErrorResponse(ErrorCode.AUTHENTICATION_FAILED);
+        response.setStatus(ErrorCode.AUTHENTICATION_FAILED.getCode());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}

--- a/src/main/java/com/example/solidconnection/custom/response/ErrorResponse.java
+++ b/src/main/java/com/example/solidconnection/custom/response/ErrorResponse.java
@@ -9,6 +9,10 @@ public record ErrorResponse(String message) {
         this(e.getMessage());
     }
 
+    public ErrorResponse(ErrorCode e) {
+        this(e.getMessage());
+    }
+
     public ErrorResponse(ErrorCode e, String detail) {
         this(e.getMessage() + " : " + detail);
     }

--- a/src/main/java/com/example/solidconnection/custom/security/filter/ExceptionHandlerFilter.java
+++ b/src/main/java/com/example/solidconnection/custom/security/filter/ExceptionHandlerFilter.java
@@ -10,16 +10,12 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.AccessDeniedException;
-import org.springframework.security.authentication.AnonymousAuthenticationToken;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
-import static com.example.solidconnection.custom.exception.ErrorCode.ACCESS_DENIED;
 import static com.example.solidconnection.custom.exception.ErrorCode.AUTHENTICATION_FAILED;
 
 @Component
@@ -36,10 +32,6 @@ public class ExceptionHandlerFilter extends OncePerRequestFilter {
             filterChain.doFilter(request, response);
         } catch (CustomException e) {
             customCommence(response, e);
-        } catch (AccessDeniedException e) {
-            Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-            ErrorCode errorCode = auth instanceof AnonymousAuthenticationToken ? AUTHENTICATION_FAILED : ACCESS_DENIED;
-            generalCommence(response, e, errorCode);
         } catch (Exception e) {
             generalCommence(response, e, AUTHENTICATION_FAILED);
         }

--- a/src/test/java/com/example/solidconnection/custom/exception/CustomAccessDeniedHandlerTest.java
+++ b/src/test/java/com/example/solidconnection/custom/exception/CustomAccessDeniedHandlerTest.java
@@ -1,0 +1,51 @@
+package com.example.solidconnection.custom.exception;
+
+import com.example.solidconnection.custom.response.ErrorResponse;
+import com.example.solidconnection.support.TestContainerSpringBootTest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+
+import java.io.IOException;
+
+import static com.example.solidconnection.custom.exception.ErrorCode.ACCESS_DENIED;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestContainerSpringBootTest
+@DisplayName("커스텀 인가 예외 처리 테스트")
+class CustomAccessDeniedHandlerTest {
+
+    @Autowired
+    private CustomAccessDeniedHandler accessDeniedHandler;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private MockHttpServletRequest request;
+    private MockHttpServletResponse response;
+
+    @BeforeEach
+    void setUp() {
+        request = new MockHttpServletRequest();
+        response = new MockHttpServletResponse();
+    }
+
+    @Test
+    void 권한이_없는_사용자_접근시_403_예외_응답을_반환한다() throws IOException {
+        // given
+        AccessDeniedException accessDeniedException = new AccessDeniedException(ACCESS_DENIED.getMessage());
+
+        // when
+        accessDeniedHandler.handle(request, response, accessDeniedException);
+
+        // then
+        ErrorResponse errorResponse = objectMapper.readValue(response.getContentAsString(), ErrorResponse.class);
+        assertThat(response.getStatus()).isEqualTo(ACCESS_DENIED.getCode());
+        assertThat(errorResponse.message()).isEqualTo(ACCESS_DENIED.getMessage());
+    }
+}

--- a/src/test/java/com/example/solidconnection/custom/exception/CustomAuthenticationEntryPointTest.java
+++ b/src/test/java/com/example/solidconnection/custom/exception/CustomAuthenticationEntryPointTest.java
@@ -1,0 +1,52 @@
+package com.example.solidconnection.custom.exception;
+
+import com.example.solidconnection.custom.response.ErrorResponse;
+import com.example.solidconnection.support.TestContainerSpringBootTest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.AuthenticationServiceException;
+import org.springframework.security.core.AuthenticationException;
+
+import java.io.IOException;
+
+import static com.example.solidconnection.custom.exception.ErrorCode.AUTHENTICATION_FAILED;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestContainerSpringBootTest
+@DisplayName("커스텀 인증 예외 처리 테스트")
+class CustomAuthenticationEntryPointTest {
+
+    @Autowired
+    private CustomAuthenticationEntryPoint authenticationEntryPoint;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private MockHttpServletRequest request;
+    private MockHttpServletResponse response;
+
+    @BeforeEach
+    void setUp() {
+        request = new MockHttpServletRequest();
+        response = new MockHttpServletResponse();
+    }
+
+    @Test
+    void 인증되지_않은_사용자_접근시_401_예외_응답을_반환한다() throws IOException {
+        // given
+        AuthenticationException authException = new AuthenticationServiceException(AUTHENTICATION_FAILED.getMessage());
+
+        // when
+        authenticationEntryPoint.commence(request, response, authException);
+
+        // then
+        ErrorResponse errorResponse = objectMapper.readValue(response.getContentAsString(), ErrorResponse.class);
+        assertThat(response.getStatus()).isEqualTo(AUTHENTICATION_FAILED.getCode());
+        assertThat(errorResponse.message()).isEqualTo(AUTHENTICATION_FAILED.getMessage());
+    }
+}

--- a/src/test/java/com/example/solidconnection/custom/security/filter/ExceptionHandlerFilterTest.java
+++ b/src/test/java/com/example/solidconnection/custom/security/filter/ExceptionHandlerFilterTest.java
@@ -85,34 +85,6 @@ class ExceptionHandlerFilterTest {
         assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_UNAUTHORIZED);
     }
 
-    @Test
-    void 익명_사용자의_접근_거부시_401_예외_응답을_반환한다() throws Exception {
-        // given
-        Authentication anonymousAuth = getAnonymousAuth();
-        SecurityContextHolder.getContext().setAuthentication(anonymousAuth);
-        willThrow(new AccessDeniedException("Access Denied")).given(filterChain).doFilter(request, response);
-
-        // when
-        exceptionHandlerFilter.doFilterInternal(request, response, filterChain);
-
-        // then
-        assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_UNAUTHORIZED);
-    }
-
-    @Test
-    void 인증된_사용자의_접근_거부하면_403_예외_응답을_반환한다() throws Exception {
-        // given
-        Authentication auth = new TestingAuthenticationToken("user", "password", "ROLE_USER");
-        SecurityContextHolder.getContext().setAuthentication(auth);
-        willThrow(new AccessDeniedException("Access Denied")).given(filterChain).doFilter(request, response);
-
-        // when
-        exceptionHandlerFilter.doFilterInternal(request, response, filterChain);
-
-        // then
-        assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_FORBIDDEN);
-    }
-
     private static Stream<Throwable> provideException() {
         return Stream.of(
                 new RuntimeException(),


### PR DESCRIPTION
## 관련 이슈

- resolves: #208

## 작업 내용

###  문제 내용
유효하지 않은 토큰으로 API 요청 시 JwtAuthenticationFilter에서 발생한 예외(CustomException 등)가 ExceptionHandlerFilter에서 잡히지 않고, WAS 기본 예외 처리로 넘어가면서 500 에러가 발생하는 문제가 있었습니다.

###  문제 원인
<img width="1016" alt="참고사진" src="https://github.com/user-attachments/assets/5ddd1aed-ae50-4a93-87a0-1a98074e1fa3" />
지난번 #192 pr에서 인증/인가 관련 예외처리를 잡지 못해 필터순서를 조정하니 jwtAuthenticationFilter 발생한 예외를 잡아줄 exceptionHandlerFilter가 jwtAuthenticationFilter보다 훨씬 뒤인 ExceptionTranslationFilter 뒤에 있어서 잡지 못하는 것이었습니다.


###  문제 해결

필터 순서를 원복하고, Spring Security의 기본 제공 기능인 AccessDeniedHandler와 AuthenticationEntryPoint를 활용해 인증/인가 예외를 처리하도록 변경했습니다.
CustomAuthenticationEntryPoint, CustomAccessDeniedHandler를 구현하여 예외 발생 시 일관된 JSON 응답이 내려가도록 했습니다.


## 리뷰 요구사항 (선택)

일단 필터 순서변경만으로 인가 관련 예외 잡는 것과 jwtAuthenticationFilter 예외를 잡는 것을 동시에 해결하는 것이 어려울 거 같아 이 방식으로 구현을 했는데 추후 더 나은 해결책을 찾으면 그거로 적용해보도록 하겠습니다 🥲

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
