### PR TITLE
feat: university_info_for_apply 테이블 details 컬럼 길이 증가

### DIFF
--- a/src/main/java/com/example/solidconnection/university/domain/UniversityInfoForApply.java
+++ b/src/main/java/com/example/solidconnection/university/domain/UniversityInfoForApply.java
@@ -73,7 +73,7 @@ public class UniversityInfoForApply {
     @Column(length = 1000)
     private String detailsForEnglishCourse;
 
-    @Column(length = 500)
+    @Column(length = 1000)
     private String details;
 
     @OneToMany(mappedBy = "universityInfoForApply", fetch = FetchType.EAGER)

--- a/src/main/resources/db/migration/V7__expand_details_column_length.sql
+++ b/src/main/resources/db/migration/V7__expand_details_column_length.sql
@@ -1,0 +1,2 @@
+ALTER TABLE university_info_for_apply
+    modify details VARCHAR(1000) NULL;


### PR DESCRIPTION
## 관련 이슈

- resolves: #211

## 작업 내용

이번에 2025-2 시즌 파견대학을 추가하던중에 university_info_for_apply.details 필드의 기본값인 500을 초과하는 데이터가 있어 컬럼 길이 500 -> 1000으로 증가시켰습니다.