### PR TITLE
chore: stage, prod docker-compose 파일 분리

### DIFF
--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -33,7 +33,7 @@ jobs:
       run: chmod +x ./gradlew
 
     - name: Build with Gradle
-      run: ./gradlew bootJar -Dspring.profiles.active=prod
+      run: ./gradlew bootJar
       
     - name: Copy jar file to remote
       uses: appleboy/scp-action@master
@@ -59,7 +59,7 @@ jobs:
         host: ${{ secrets.HOST }}
         username: ${{ secrets.USERNAME }}
         key: ${{ secrets.PRIVATE_KEY }}
-        source: "./docker-compose.yml"
+        source: "./docker-compose.prod.yml"
         target: "/home/${{ secrets.USERNAME }}/solid-connect-server/"
         
     - name: Run docker compose
@@ -72,4 +72,4 @@ jobs:
         script: |
           cd /home/${{ secrets.USERNAME }}/solid-connect-server
           docker compose down
-          docker compose up -d --build
+          docker compose -f docker-compose.prod.yml up -d --build

--- a/.github/workflows/stage-cd.yml
+++ b/.github/workflows/stage-cd.yml
@@ -33,7 +33,7 @@ jobs:
         run: chmod +x ./gradlew
 
       - name: Build with Gradle
-        run: ./gradlew bootJar -Dspring.profiles.active=stage
+        run: ./gradlew bootJar
 
       - name: Copy jar file to remote
         uses: appleboy/scp-action@master
@@ -59,7 +59,7 @@ jobs:
           host: ${{ secrets.STAGE_HOST }}
           username: ${{ secrets.STAGE_USERNAME }}
           key: ${{ secrets.STAGE_PRIVATE_KEY }}
-          source: "./docker-compose.yml"
+          source: "./docker-compose.stage.yml"
           target: "/home/${{ secrets.STAGE_USERNAME }}/solid-connect-stage/"
 
       - name: Run docker compose
@@ -72,4 +72,4 @@ jobs:
           script: |
             cd /home/${{ secrets.STAGE_USERNAME }}/solid-connect-stage
             docker compose down
-            docker compose up -d --build
+            docker compose -f docker-compose.stage.yml up -d --build

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG JAR_FILE=./build/libs/solid-connection-0.0.1-SNAPSHOT.jar
 COPY ${JAR_FILE} app.jar
 
 # 시스템 진입점 정의
-ENTRYPOINT ["java", "-jar", "/app.jar", "--spring.profiles.active=prod"]
+ENTRYPOINT ["java", "-jar", "/app.jar"]
 
 # 볼륨 설정
 VOLUME /tmp

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,32 @@
+version: '3.8'
+
+services:
+  redis:
+    image: redis:latest
+    container_name: redis
+    ports:
+      - "6379:6379"
+
+  redis-exporter:
+    image: oliver006/redis_exporter
+    container_name: redis-exporter
+    ports:
+      - "9121:9121"
+    environment:
+      REDIS_ADDR: "redis:6379"
+    depends_on:
+      - redis
+
+  solid-connection-server:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: solid-connection-server
+    ports:
+      - "8080:8080"
+    environment:
+      - SPRING_PROFILES_ACTIVE=prod
+      - SPRING_DATA_REDIS_HOST=redis
+      - SPRING_DATA_REDIS_PORT=6379
+    depends_on:
+      - redis

--- a/docker-compose.stage.yml
+++ b/docker-compose.stage.yml
@@ -6,6 +6,7 @@ services:
     container_name: redis
     ports:
       - "6379:6379"
+    network_mode: host
 
   redis-exporter:
     image: oliver006/redis_exporter
@@ -13,19 +14,20 @@ services:
     ports:
       - "9121:9121"
     environment:
-      REDIS_ADDR: "redis:6379"
+      REDIS_ADDR: "localhost:6379"
     depends_on:
       - redis
+    network_mode: host
 
-  solid-connection-server:
+  solid-connection-stage:
     build:
       context: .
       dockerfile: Dockerfile
-    container_name: solid-connection-server
+    container_name: solid-connection-stage
     ports:
       - "8080:8080"
     environment:
-      - SPRING_DATA_REDIS_HOST=redis
-      - SPRING_DATA_REDIS_PORT=6379
+      - SPRING_PROFILES_ACTIVE=stage
     depends_on:
       - redis
+    network_mode: host


### PR DESCRIPTION
## 작업 내용 1 - spring profile 한 곳에서 설정하기

스테이지 서버에 돌아가는 app 의 profile이 prod 로 지정되는 이슈가 있었습니다.
![image](https://github.com/user-attachments/assets/eded6f73-c7f8-4453-9a31-96267e6ce8f2)

cd 에서 `./gradlew bootJar -Dspring.profiles.active=stage`를 해주었음에도 
prod profile로 실행되는게 이상해서 코드를 더 봐보니, 
docker file 에서 추가적으로 profile을 prod로 지정하고 있었습니다.
이때 profile 이 덮어쓰기되어 prod로 실행되었습니다.

profile 을 한곳에서 지정하도록 Dockerfile에서 지정하는 부분은 없앴습니다.

## 작업 내용 2 - stage의 DB를 docker의 mysql로 설정

stage 서버의 mysql을 처음에는 localhost에 설치했습니다.
그랬더니 [docker위에 동작하는 스프링 어플리케이션] → [host 의 mysql] 로의 통신이 되어서
도커 네트워크 설정이 복잡해지더라고요😓
심지어 커멘트로 직접 설정하는거라, 비슷한 상황에서 적용되기도 힘들 것 같다 생각했습니다.

## 고민한 내용 : docker-compose 분리가 맞을까?

위 이슈에서 보시다시피, stage의 인프라 구성과 prod의 구성이 100%일치하진 않습니다.
그래서 docker-compose 파일을 분리했습니다.

stage 서버는 prod 와 최대한 가은 환경이어야 한다고 생각해서 
처음에는 최대한 docker-compose도 하나로 가려고 했었는데요,
현실적으로 이들이 100% 일치하기는 어려우니까 분리를 하는게 맞다고 생각했습니다.

stage 서버도 prod처럼 그 자체만을 위한 db를 외부에 가지게 하는건 비효율적인 것 같습니다.
"최대한 비슷한 환경이되, 어느 정도 타협을 해야한다"는 생각이 들었습니다.

<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
