### PR TITLE
fix: 지원 내역 조회 시 캐시 갱신 문제 임시 해결

### DIFF
--- a/src/main/java/com/example/solidconnection/application/service/ApplicationQueryService.java
+++ b/src/main/java/com/example/solidconnection/application/service/ApplicationQueryService.java
@@ -46,7 +46,8 @@ public class ApplicationQueryService {
      * - 1지망, 2지망 지원자들을 조회한다.
      * */
     @Transactional(readOnly = true)
-    @ThunderingHerdCaching(key = "application:query:{1}:{2}", cacheManager = "customCacheManager", ttlSec = 86400)
+    // todo: 임시로 단일 키로 캐시 적용. 추후 캐싱 전략 재검토 필요.
+    @ThunderingHerdCaching(key = "applications:all", cacheManager = "customCacheManager", ttlSec = 86400)
     public ApplicationsResponse getApplicants(SiteUser siteUser, String regionCode, String keyword) {
         // 국가와 키워드와 지역을 통해 대학을 필터링한다.
         List<University> universities

--- a/src/main/java/com/example/solidconnection/application/service/ApplicationSubmissionService.java
+++ b/src/main/java/com/example/solidconnection/application/service/ApplicationSubmissionService.java
@@ -4,6 +4,7 @@ import com.example.solidconnection.application.domain.Application;
 import com.example.solidconnection.application.dto.ApplyRequest;
 import com.example.solidconnection.application.dto.UniversityChoiceRequest;
 import com.example.solidconnection.application.repository.ApplicationRepository;
+import com.example.solidconnection.cache.annotation.DefaultCacheOut;
 import com.example.solidconnection.custom.exception.CustomException;
 import com.example.solidconnection.score.domain.GpaScore;
 import com.example.solidconnection.score.domain.LanguageTestScore;
@@ -18,14 +19,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 import static com.example.solidconnection.custom.exception.ErrorCode.APPLY_UPDATE_LIMIT_EXCEED;
-import static com.example.solidconnection.custom.exception.ErrorCode.CANT_APPLY_FOR_SAME_UNIVERSITY;
 import static com.example.solidconnection.custom.exception.ErrorCode.INVALID_GPA_SCORE;
 import static com.example.solidconnection.custom.exception.ErrorCode.INVALID_GPA_SCORE_STATUS;
 import static com.example.solidconnection.custom.exception.ErrorCode.INVALID_LANGUAGE_TEST_SCORE;
@@ -48,6 +44,11 @@ public class ApplicationSubmissionService {
     // 학점 및 어학성적이 모두 유효한 경우에만 지원서 등록이 가능하다.
     // 기존에 있던 status field 우선 APRROVED로 입력시킨다.
     @Transactional
+    // todo: 임시로 새로운 신청 생성 시 기존 캐싱 데이터를 삭제한다. 추후 수정 필요
+    @DefaultCacheOut(
+            key = {"applications:all"},
+            cacheManager = "customCacheManager"
+    )
     public boolean apply(SiteUser siteUser, ApplyRequest applyRequest) {
         UniversityChoiceRequest universityChoiceRequest = applyRequest.universityChoiceRequest();
 


### PR DESCRIPTION
## 관련 이슈

- resolves: #219

## 작업 내용

### 문제 상황
지원서 등록 후 조회 시 이전 데이터가 계속 캐싱되어 있는 현상이 발생하였습니다.

### 임시 해결 방법
1. 캐시 키를 단일화 (`applications:all`)하여 관리
2. `@DefaultCacheOut` 적용하여 지원서 등록 시 캐시 자동 삭제
3. region/keyword 검색 및 isMine 표시는 당장 사용하지 않으므로 무시

### 추후 개선 사항
- 캐싱 전략 재검토 필요 (TTL 조정, 검색 기능 추가 등)

## 특이 사항
임시조치로 해결한 것이어서 이에 대한 테스트코드는 일단 작성하지 않았는데 필요하면 추가하겠습니다!