### PR TITLE
fix: 프로필 수정 API에서 닉네임, 이미지 부분 업데이트 가능하도록 수정

### DIFF
--- a/src/main/java/com/example/solidconnection/siteuser/controller/SiteUserController.java
+++ b/src/main/java/com/example/solidconnection/siteuser/controller/SiteUserController.java
@@ -31,8 +31,8 @@ class SiteUserController {
     @PatchMapping
     public ResponseEntity<Void> updateMyPageInfo(
             @AuthorizedUser SiteUser siteUser,
-            @RequestParam("file") MultipartFile imageFile,
-            @RequestParam("nickname") String nickname
+            @RequestParam(value = "file", required = false) MultipartFile imageFile,
+            @RequestParam(value = "nickname", required = false) String nickname
     ) {
         siteUserService.updateMyPageInfo(siteUser, imageFile, nickname);
         return ResponseEntity.ok().build();

--- a/src/main/java/com/example/solidconnection/siteuser/service/SiteUserService.java
+++ b/src/main/java/com/example/solidconnection/siteuser/service/SiteUserService.java
@@ -56,10 +56,10 @@ public class SiteUserService {
         }
 
         if (imageFile != null && !imageFile.isEmpty()) {
+            UploadedFileUrlResponse uploadedFile = s3Service.uploadFile(imageFile, ImgType.PROFILE);
             if (!isDefaultProfileImage(siteUser.getProfileImageUrl())) {
                 s3Service.deleteExProfile(siteUser);
             }
-            UploadedFileUrlResponse uploadedFile = s3Service.uploadFile(imageFile, ImgType.PROFILE);
             String profileImageUrl = uploadedFile.fileUrl();
             siteUser.setProfileImageUrl(profileImageUrl);
         }

--- a/src/main/java/com/example/solidconnection/siteuser/service/SiteUserService.java
+++ b/src/main/java/com/example/solidconnection/siteuser/service/SiteUserService.java
@@ -48,19 +48,21 @@ public class SiteUserService {
      * */
     @Transactional
     public void updateMyPageInfo(SiteUser siteUser, MultipartFile imageFile, String nickname) {
-        validateNicknameUnique(nickname);
-        validateNicknameNotChangedRecently(siteUser.getNicknameModifiedAt());
-        validateProfileImageNotEmpty(imageFile);
-
-        if (!isDefaultProfileImage(siteUser.getProfileImageUrl())) {
-            s3Service.deleteExProfile(siteUser);
+        if (nickname != null) {
+            validateNicknameUnique(nickname);
+            validateNicknameNotChangedRecently(siteUser.getNicknameModifiedAt());
+            siteUser.setNickname(nickname);
+            siteUser.setNicknameModifiedAt(LocalDateTime.now());
         }
-        UploadedFileUrlResponse uploadedFile = s3Service.uploadFile(imageFile, ImgType.PROFILE);
-        String profileImageUrl = uploadedFile.fileUrl();
 
-        siteUser.setProfileImageUrl(profileImageUrl);
-        siteUser.setNickname(nickname);
-        siteUser.setNicknameModifiedAt(LocalDateTime.now());
+        if (imageFile != null && !imageFile.isEmpty()) {
+            if (!isDefaultProfileImage(siteUser.getProfileImageUrl())) {
+                s3Service.deleteExProfile(siteUser);
+            }
+            UploadedFileUrlResponse uploadedFile = s3Service.uploadFile(imageFile, ImgType.PROFILE);
+            String profileImageUrl = uploadedFile.fileUrl();
+            siteUser.setProfileImageUrl(profileImageUrl);
+        }
         siteUserRepository.save(siteUser);
     }
 
@@ -78,12 +80,6 @@ public class SiteUserService {
             String formatLastModifiedAt
                     = String.format("(마지막 수정 시간 : %s)", NICKNAME_LAST_CHANGE_DATE_FORMAT.format(lastModifiedAt));
             throw new CustomException(CAN_NOT_CHANGE_NICKNAME_YET, formatLastModifiedAt);
-        }
-    }
-
-    private void validateProfileImageNotEmpty(MultipartFile imageFile) {
-        if (imageFile == null || imageFile.isEmpty()) {
-            throw new CustomException(PROFILE_IMAGE_NEEDED);
         }
     }
 

--- a/src/test/java/com/example/solidconnection/siteuser/service/SiteUserServiceTest.java
+++ b/src/test/java/com/example/solidconnection/siteuser/service/SiteUserServiceTest.java
@@ -145,18 +145,6 @@ class SiteUserServiceTest extends BaseIntegrationTest {
             // then
             then(s3Service).should().deleteExProfile(testUser);
         }
-
-        @Test
-        void 빈_이미지_파일로_프로필을_수정하면_예외_응답을_반환한다() {
-            // given
-            SiteUser testUser = createSiteUser();
-            MockMultipartFile emptyFile = createEmptyImageFile();
-
-            // when & then
-            assertThatCode(() -> siteUserService.updateMyPageInfo(testUser, emptyFile, "newNickname"))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(PROFILE_IMAGE_NEEDED.getMessage());
-        }
     }
 
     @Nested
@@ -271,15 +259,6 @@ class SiteUserServiceTest extends BaseIntegrationTest {
                 "test.jpg",
                 "image/jpeg",
                 "test image content".getBytes()
-        );
-    }
-
-    private MockMultipartFile createEmptyImageFile() {
-        return new MockMultipartFile(
-                "image",
-                "empty.jpg",
-                "image/jpeg",
-                new byte[0]
         );
     }
 

--- a/src/test/java/com/example/solidconnection/siteuser/service/SiteUserServiceTest.java
+++ b/src/test/java/com/example/solidconnection/siteuser/service/SiteUserServiceTest.java
@@ -29,7 +29,6 @@ import java.util.List;
 
 import static com.example.solidconnection.custom.exception.ErrorCode.CAN_NOT_CHANGE_NICKNAME_YET;
 import static com.example.solidconnection.custom.exception.ErrorCode.NICKNAME_ALREADY_EXISTED;
-import static com.example.solidconnection.custom.exception.ErrorCode.PROFILE_IMAGE_NEEDED;
 import static com.example.solidconnection.siteuser.service.SiteUserService.MIN_DAYS_BETWEEN_NICKNAME_CHANGES;
 import static com.example.solidconnection.siteuser.service.SiteUserService.NICKNAME_LAST_CHANGE_DATE_FORMAT;
 import static org.assertj.core.api.Assertions.assertThat;


### PR DESCRIPTION
## 관련 이슈

- resolves: #226

## 작업 내용

PATCH 메서드에 따라 전송한 리소스만 변경되게 수정하였습니다.

## 리뷰 요구사항 (선택)

파일이 empty인 상태일 때 굳이 예외를 던지기보단 변경을 안하는 게 클라이언트 입장에서 더 좋은 거 같아서 validateProfileImageNotEmpty 메서드는 그냥 지웠는데 괜찮을까요?
