### PR TITLE
fix: 최신 지원서만 조회되도록 수정

### DIFF
--- a/src/main/java/com/example/solidconnection/application/repository/ApplicationRepository.java
+++ b/src/main/java/com/example/solidconnection/application/repository/ApplicationRepository.java
@@ -20,13 +20,13 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
 
     boolean existsByNicknameForApply(String nicknameForApply);
 
-    List<Application> findAllByFirstChoiceUniversityAndVerifyStatusAndTerm(
+    List<Application> findAllByFirstChoiceUniversityAndVerifyStatusAndTermAndIsDeleteFalse(
             UniversityInfoForApply firstChoiceUniversity, VerifyStatus verifyStatus, String term);
 
-    List<Application> findAllBySecondChoiceUniversityAndVerifyStatusAndTerm(
+    List<Application> findAllBySecondChoiceUniversityAndVerifyStatusAndTermAndIsDeleteFalse(
             UniversityInfoForApply secondChoiceUniversity, VerifyStatus verifyStatus, String term);
 
-    List<Application> findAllByThirdChoiceUniversityAndVerifyStatusAndTerm(
+    List<Application> findAllByThirdChoiceUniversityAndVerifyStatusAndTermAndIsDeleteFalse(
             UniversityInfoForApply thirdChoiceUniversity, VerifyStatus verifyStatus, String term);
 
     @Query("""

--- a/src/main/java/com/example/solidconnection/application/service/ApplicationQueryService.java
+++ b/src/main/java/com/example/solidconnection/application/service/ApplicationQueryService.java
@@ -97,7 +97,7 @@ public class ApplicationQueryService {
         return getApplicantsByChoice(
                 universities,
                 siteUser,
-                uia -> applicationRepository.findAllByFirstChoiceUniversityAndVerifyStatusAndTerm(uia, VerifyStatus.APPROVED, term)
+                uia -> applicationRepository.findAllByFirstChoiceUniversityAndVerifyStatusAndTermAndIsDeleteFalse(uia, VerifyStatus.APPROVED, term)
         );
     }
 
@@ -105,7 +105,7 @@ public class ApplicationQueryService {
         return getApplicantsByChoice(
                 universities,
                 siteUser,
-                uia -> applicationRepository.findAllBySecondChoiceUniversityAndVerifyStatusAndTerm(uia, VerifyStatus.APPROVED, term)
+                uia -> applicationRepository.findAllBySecondChoiceUniversityAndVerifyStatusAndTermAndIsDeleteFalse(uia, VerifyStatus.APPROVED, term)
         );
     }
 
@@ -113,7 +113,7 @@ public class ApplicationQueryService {
         return getApplicantsByChoice(
                 universities,
                 siteUser,
-                uia -> applicationRepository.findAllByThirdChoiceUniversityAndVerifyStatusAndTerm(uia, VerifyStatus.APPROVED, term)
+                uia -> applicationRepository.findAllByThirdChoiceUniversityAndVerifyStatusAndTermAndIsDeleteFalse(uia, VerifyStatus.APPROVED, term)
         );
     }
 


### PR DESCRIPTION
## 관련 이슈

- resolves: #229

## 작업 내용

GET /applications API에서 유저의 이전 지원서까지 조회되는 오류가 있었습니다.

isDelete가 false인 것만 조회되도록 하여 최신 지원서만 조회되도록 수정하였습니다.