### PR TITLE
feat: 중복 닉네임 검증 api 추가

### DIFF
--- a/src/main/java/com/example/solidconnection/custom/exception/ErrorCode.java
+++ b/src/main/java/com/example/solidconnection/custom/exception/ErrorCode.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 import static com.example.solidconnection.application.service.ApplicationSubmissionService.APPLICATION_UPDATE_COUNT_LIMIT;
-import static com.example.solidconnection.siteuser.service.SiteUserService.MIN_DAYS_BETWEEN_NICKNAME_CHANGES;
+import static com.example.solidconnection.siteuser.service.MyPageService.MIN_DAYS_BETWEEN_NICKNAME_CHANGES;
 
 @Getter
 @AllArgsConstructor

--- a/src/main/java/com/example/solidconnection/siteuser/controller/MyPageController.java
+++ b/src/main/java/com/example/solidconnection/siteuser/controller/MyPageController.java
@@ -3,7 +3,7 @@ package com.example.solidconnection.siteuser.controller;
 import com.example.solidconnection.custom.resolver.AuthorizedUser;
 import com.example.solidconnection.siteuser.domain.SiteUser;
 import com.example.solidconnection.siteuser.dto.MyPageResponse;
-import com.example.solidconnection.siteuser.service.SiteUserService;
+import com.example.solidconnection.siteuser.service.MyPageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -16,15 +16,15 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 @RequestMapping("/my")
 @RestController
-class SiteUserController {
+class MyPageController {
 
-    private final SiteUserService siteUserService;
+    private final MyPageService myPageService;
 
     @GetMapping
     public ResponseEntity<MyPageResponse> getMyPageInfo(
             @AuthorizedUser SiteUser siteUser
     ) {
-        MyPageResponse myPageResponse = siteUserService.getMyPageInfo(siteUser);
+        MyPageResponse myPageResponse = myPageService.getMyPageInfo(siteUser);
         return ResponseEntity.ok(myPageResponse);
     }
 
@@ -34,7 +34,7 @@ class SiteUserController {
             @RequestParam("file") MultipartFile imageFile,
             @RequestParam("nickname") String nickname
     ) {
-        siteUserService.updateMyPageInfo(siteUser, imageFile, nickname);
+        myPageService.updateMyPageInfo(siteUser, imageFile, nickname);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/example/solidconnection/siteuser/controller/SiteUserController.java
+++ b/src/main/java/com/example/solidconnection/siteuser/controller/SiteUserController.java
@@ -1,0 +1,24 @@
+package com.example.solidconnection.siteuser.controller;
+
+import com.example.solidconnection.siteuser.dto.NicknameExistsResponse;
+import com.example.solidconnection.siteuser.service.SiteUserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/users")
+@RestController
+public class SiteUserController {
+
+    private final SiteUserService siteUserService;
+
+    @GetMapping("/exists")
+    public ResponseEntity<NicknameExistsResponse> existsByNickname(@RequestParam("nickname") String nickname) {
+        NicknameExistsResponse nicknameExistsResponse = siteUserService.existsByNickname(nickname);
+        return ResponseEntity.ok(nicknameExistsResponse);
+    }
+}

--- a/src/main/java/com/example/solidconnection/siteuser/controller/SiteUserController.java
+++ b/src/main/java/com/example/solidconnection/siteuser/controller/SiteUserController.java
@@ -17,10 +17,10 @@ public class SiteUserController {
     private final SiteUserService siteUserService;
 
     @GetMapping("/exists")
-    public ResponseEntity<NicknameExistsResponse> existsByNickname(
+    public ResponseEntity<NicknameExistsResponse> checkNicknameExists(
             @RequestParam("nickname") String nickname
     ) {
-        NicknameExistsResponse nicknameExistsResponse = siteUserService.existsByNickname(nickname);
+        NicknameExistsResponse nicknameExistsResponse = siteUserService.checkNicknameExists(nickname);
         return ResponseEntity.ok(nicknameExistsResponse);
     }
 }

--- a/src/main/java/com/example/solidconnection/siteuser/controller/SiteUserController.java
+++ b/src/main/java/com/example/solidconnection/siteuser/controller/SiteUserController.java
@@ -17,7 +17,9 @@ public class SiteUserController {
     private final SiteUserService siteUserService;
 
     @GetMapping("/exists")
-    public ResponseEntity<NicknameExistsResponse> existsByNickname(@RequestParam("nickname") String nickname) {
+    public ResponseEntity<NicknameExistsResponse> existsByNickname(
+            @RequestParam("nickname") String nickname
+    ) {
         NicknameExistsResponse nicknameExistsResponse = siteUserService.existsByNickname(nickname);
         return ResponseEntity.ok(nicknameExistsResponse);
     }

--- a/src/main/java/com/example/solidconnection/siteuser/dto/NicknameExistsResponse.java
+++ b/src/main/java/com/example/solidconnection/siteuser/dto/NicknameExistsResponse.java
@@ -1,0 +1,9 @@
+package com.example.solidconnection.siteuser.dto;
+
+public record NicknameExistsResponse(
+        boolean exists
+) {
+    public static NicknameExistsResponse from(boolean exists) {
+        return new NicknameExistsResponse(exists);
+    }
+}

--- a/src/main/java/com/example/solidconnection/siteuser/service/MyPageService.java
+++ b/src/main/java/com/example/solidconnection/siteuser/service/MyPageService.java
@@ -25,7 +25,7 @@ import static com.example.solidconnection.custom.exception.ErrorCode.PROFILE_IMA
 
 @RequiredArgsConstructor
 @Service
-public class SiteUserService {
+public class MyPageService {
 
     public static final int MIN_DAYS_BETWEEN_NICKNAME_CHANGES = 7;
     public static final DateTimeFormatter NICKNAME_LAST_CHANGE_DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");

--- a/src/main/java/com/example/solidconnection/siteuser/service/SiteUserService.java
+++ b/src/main/java/com/example/solidconnection/siteuser/service/SiteUserService.java
@@ -11,7 +11,7 @@ public class SiteUserService {
 
     private final SiteUserRepository siteUserRepository;
 
-    public NicknameExistsResponse existsByNickname(String nickname) {
+    public NicknameExistsResponse checkNicknameExists(String nickname) {
         boolean exists = siteUserRepository.existsByNickname(nickname);
         return NicknameExistsResponse.from(exists);
     }

--- a/src/main/java/com/example/solidconnection/siteuser/service/SiteUserService.java
+++ b/src/main/java/com/example/solidconnection/siteuser/service/SiteUserService.java
@@ -1,0 +1,18 @@
+package com.example.solidconnection.siteuser.service;
+
+import com.example.solidconnection.siteuser.dto.NicknameExistsResponse;
+import com.example.solidconnection.siteuser.repository.SiteUserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class SiteUserService {
+
+    private final SiteUserRepository siteUserRepository;
+
+    public NicknameExistsResponse existsByNickname(String nickname) {
+        boolean exists = siteUserRepository.existsByNickname(nickname);
+        return NicknameExistsResponse.from(exists);
+    }
+}

--- a/src/main/java/com/example/solidconnection/university/controller/UniversityController.java
+++ b/src/main/java/com/example/solidconnection/university/controller/UniversityController.java
@@ -2,7 +2,7 @@ package com.example.solidconnection.university.controller;
 
 import com.example.solidconnection.custom.resolver.AuthorizedUser;
 import com.example.solidconnection.siteuser.domain.SiteUser;
-import com.example.solidconnection.siteuser.service.SiteUserService;
+import com.example.solidconnection.siteuser.service.MyPageService;
 import com.example.solidconnection.type.LanguageTestType;
 import com.example.solidconnection.university.dto.IsLikeResponse;
 import com.example.solidconnection.university.dto.LikeResultResponse;
@@ -32,7 +32,7 @@ public class UniversityController {
     private final UniversityQueryService universityQueryService;
     private final UniversityLikeService universityLikeService;
     private final UniversityRecommendService universityRecommendService;
-    private final SiteUserService siteUserService;
+    private final MyPageService myPageService;
 
     @GetMapping("/recommend")
     public ResponseEntity<UniversityRecommendsResponse> getUniversityRecommends(
@@ -49,7 +49,7 @@ public class UniversityController {
     public ResponseEntity<List<UniversityInfoForApplyPreviewResponse>> getMyWishUniversity(
             @AuthorizedUser SiteUser siteUser
     ) {
-        List<UniversityInfoForApplyPreviewResponse> wishUniversities = siteUserService.getWishUniversity(siteUser);
+        List<UniversityInfoForApplyPreviewResponse> wishUniversities = myPageService.getWishUniversity(siteUser);
         return ResponseEntity.ok(wishUniversities);
     }
 

--- a/src/test/java/com/example/solidconnection/siteuser/service/MyPageServiceTest.java
+++ b/src/test/java/com/example/solidconnection/siteuser/service/MyPageServiceTest.java
@@ -30,8 +30,8 @@ import java.util.List;
 import static com.example.solidconnection.custom.exception.ErrorCode.CAN_NOT_CHANGE_NICKNAME_YET;
 import static com.example.solidconnection.custom.exception.ErrorCode.NICKNAME_ALREADY_EXISTED;
 import static com.example.solidconnection.custom.exception.ErrorCode.PROFILE_IMAGE_NEEDED;
-import static com.example.solidconnection.siteuser.service.SiteUserService.MIN_DAYS_BETWEEN_NICKNAME_CHANGES;
-import static com.example.solidconnection.siteuser.service.SiteUserService.NICKNAME_LAST_CHANGE_DATE_FORMAT;
+import static com.example.solidconnection.siteuser.service.MyPageService.MIN_DAYS_BETWEEN_NICKNAME_CHANGES;
+import static com.example.solidconnection.siteuser.service.MyPageService.NICKNAME_LAST_CHANGE_DATE_FORMAT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
 import static org.mockito.BDDMockito.any;
@@ -40,11 +40,11 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.never;
 import static org.mockito.BDDMockito.then;
 
-@DisplayName("유저 서비스 테스트")
-class SiteUserServiceTest extends BaseIntegrationTest {
+@DisplayName("마이페이지 서비스 테스트")
+class MyPageServiceTest extends BaseIntegrationTest {
 
     @Autowired
-    private SiteUserService siteUserService;
+    private MyPageService myPageService;
 
     @MockBean
     private S3Service s3Service;
@@ -62,7 +62,7 @@ class SiteUserServiceTest extends BaseIntegrationTest {
         int likedUniversityCount = createLikedUniversities(testUser);
 
         // when
-        MyPageResponse response = siteUserService.getMyPageInfo(testUser);
+        MyPageResponse response = myPageService.getMyPageInfo(testUser);
 
         // then
         Assertions.assertAll(
@@ -83,7 +83,7 @@ class SiteUserServiceTest extends BaseIntegrationTest {
         int likedUniversityCount = createLikedUniversities(testUser);
 
         // when
-        List<UniversityInfoForApplyPreviewResponse> response = siteUserService.getWishUniversity(testUser);
+        List<UniversityInfoForApplyPreviewResponse> response = myPageService.getWishUniversity(testUser);
 
         // then
         assertThat(response)
@@ -109,7 +109,7 @@ class SiteUserServiceTest extends BaseIntegrationTest {
                     .willReturn(new UploadedFileUrlResponse(expectedUrl));
 
             // when
-            siteUserService.updateMyPageInfo(testUser, imageFile, "newNickname");
+            myPageService.updateMyPageInfo(testUser, imageFile, "newNickname");
 
             // then
             assertThat(testUser.getProfileImageUrl()).isEqualTo(expectedUrl);
@@ -124,7 +124,7 @@ class SiteUserServiceTest extends BaseIntegrationTest {
                     .willReturn(new UploadedFileUrlResponse("newProfileImageUrl"));
 
             // when
-            siteUserService.updateMyPageInfo(testUser, imageFile, "newNickname");
+            myPageService.updateMyPageInfo(testUser, imageFile, "newNickname");
 
             // then
             then(s3Service).should(never()).deleteExProfile(any());
@@ -139,7 +139,7 @@ class SiteUserServiceTest extends BaseIntegrationTest {
                     .willReturn(new UploadedFileUrlResponse("newProfileImageUrl"));
 
             // when
-            siteUserService.updateMyPageInfo(testUser, imageFile, "newNickname");
+            myPageService.updateMyPageInfo(testUser, imageFile, "newNickname");
 
             // then
             then(s3Service).should().deleteExProfile(testUser);
@@ -152,7 +152,7 @@ class SiteUserServiceTest extends BaseIntegrationTest {
             MockMultipartFile emptyFile = createEmptyImageFile();
 
             // when & then
-            assertThatCode(() -> siteUserService.updateMyPageInfo(testUser, emptyFile, "newNickname"))
+            assertThatCode(() -> myPageService.updateMyPageInfo(testUser, emptyFile, "newNickname"))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(PROFILE_IMAGE_NEEDED.getMessage());
         }
@@ -175,7 +175,7 @@ class SiteUserServiceTest extends BaseIntegrationTest {
             String newNickname = "newNickname";
 
             // when
-            siteUserService.updateMyPageInfo(testUser, imageFile, newNickname);
+            myPageService.updateMyPageInfo(testUser, imageFile, newNickname);
 
             // then
             SiteUser updatedUser = siteUserRepository.findById(testUser.getId()).get();
@@ -191,7 +191,7 @@ class SiteUserServiceTest extends BaseIntegrationTest {
             MockMultipartFile imageFile = createValidImageFile();
 
             // when & then
-            assertThatCode(() -> siteUserService.updateMyPageInfo(testUser, imageFile, "duplicatedNickname"))
+            assertThatCode(() -> myPageService.updateMyPageInfo(testUser, imageFile, "duplicatedNickname"))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(NICKNAME_ALREADY_EXISTED.getMessage());
         }
@@ -208,7 +208,7 @@ class SiteUserServiceTest extends BaseIntegrationTest {
             NicknameUpdateRequest request = new NicknameUpdateRequest("newNickname");
 
             // when & then
-            assertThatCode(() -> siteUserService.updateMyPageInfo(testUser, imageFile, "nickname12"))
+            assertThatCode(() -> myPageService.updateMyPageInfo(testUser, imageFile, "nickname12"))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(createExpectedErrorMessage(modifiedAt));
         }

--- a/src/test/java/com/example/solidconnection/siteuser/service/SiteUserServiceTest.java
+++ b/src/test/java/com/example/solidconnection/siteuser/service/SiteUserServiceTest.java
@@ -1,0 +1,68 @@
+package com.example.solidconnection.siteuser.service;
+
+import com.example.solidconnection.siteuser.domain.SiteUser;
+import com.example.solidconnection.siteuser.dto.NicknameExistsResponse;
+import com.example.solidconnection.siteuser.repository.SiteUserRepository;
+import com.example.solidconnection.support.integration.BaseIntegrationTest;
+import com.example.solidconnection.type.Gender;
+import com.example.solidconnection.type.PreparationStatus;
+import com.example.solidconnection.type.Role;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("유저 서비스 테스트")
+class SiteUserServiceTest extends BaseIntegrationTest {
+
+    @Autowired
+    private SiteUserService siteUserService;
+
+    @Autowired
+    private SiteUserRepository siteUserRepository;
+
+    private SiteUser siteUser;
+
+    @BeforeEach
+    void setUp() {
+        siteUser = createSiteUser();
+    }
+
+    @Nested
+    class 닉네임_중복_검사 {
+
+        @Test
+        void 존재하는_닉네임이면_true를_반환한다() {
+            // when
+            NicknameExistsResponse response = siteUserService.existsByNickname(siteUser.getNickname());
+
+            // then
+            assertThat(response.exists()).isTrue();
+        }
+
+        @Test
+        void 존재하지_않는_닉네임이면_false를_반환한다() {
+            // when
+            NicknameExistsResponse response = siteUserService.existsByNickname("nonExistingNickname");
+
+            // then
+            assertThat(response.exists()).isFalse();
+        }
+    }
+
+    private SiteUser createSiteUser() {
+        SiteUser siteUser = new SiteUser(
+                "test@example.com",
+                "nickname",
+                "profileImageUrl",
+                "1999-01-01",
+                PreparationStatus.CONSIDERING,
+                Role.MENTEE,
+                Gender.MALE
+        );
+        return siteUserRepository.save(siteUser);
+    }
+}

--- a/src/test/java/com/example/solidconnection/siteuser/service/SiteUserServiceTest.java
+++ b/src/test/java/com/example/solidconnection/siteuser/service/SiteUserServiceTest.java
@@ -37,7 +37,7 @@ class SiteUserServiceTest extends BaseIntegrationTest {
         @Test
         void 존재하는_닉네임이면_true를_반환한다() {
             // when
-            NicknameExistsResponse response = siteUserService.existsByNickname(siteUser.getNickname());
+            NicknameExistsResponse response = siteUserService.checkNicknameExists(siteUser.getNickname());
 
             // then
             assertThat(response.exists()).isTrue();
@@ -46,7 +46,7 @@ class SiteUserServiceTest extends BaseIntegrationTest {
         @Test
         void 존재하지_않는_닉네임이면_false를_반환한다() {
             // when
-            NicknameExistsResponse response = siteUserService.existsByNickname("nonExistingNickname");
+            NicknameExistsResponse response = siteUserService.checkNicknameExists("nonExistingNickname");
 
             // then
             assertThat(response.exists()).isFalse();


### PR DESCRIPTION
## 관련 이슈

- resolves: #189

## 작업 내용

1. 기존 SiteUserController 및 SiteUserService를 MyPageController 및 MyPageService로 변경하였습니다.
2. 중복 닉네임 검증 api를 추가하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new profile management section allowing users to view and update their personal details, including profile images and nicknames.
  - Added a nickname availability check to quickly verify if your chosen nickname is unique.

- **Refactor**
  - Streamlined and reorganized profile management endpoints for a more consistent and user-friendly experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->