### PR TITLE
feat: 지원 시 지원 횟수 응답값 추가

### DIFF
--- a/src/main/java/com/example/solidconnection/application/controller/ApplicationController.java
+++ b/src/main/java/com/example/solidconnection/application/controller/ApplicationController.java
@@ -32,10 +32,10 @@ public class ApplicationController {
             @AuthorizedUser SiteUser siteUser,
             @Valid @RequestBody ApplyRequest applyRequest
     ) {
-        boolean result = applicationSubmissionService.apply(siteUser, applyRequest);
+        ApplicationSubmissionResponse applicationSubmissionResponse = applicationSubmissionService.apply(siteUser, applyRequest);
         return ResponseEntity
                 .status(HttpStatus.OK)
-                .body(new ApplicationSubmissionResponse(result));
+                .body(applicationSubmissionResponse);
     }
 
     @GetMapping

--- a/src/main/java/com/example/solidconnection/application/domain/Application.java
+++ b/src/main/java/com/example/solidconnection/application/domain/Application.java
@@ -46,7 +46,7 @@ public class Application {
     @Column(length = 100)
     private String nicknameForApply;
 
-    @Column(columnDefinition = "int not null default 0")
+    @Column(columnDefinition = "int not null default 1")
     private Integer updateCount;
 
     @Column(length = 50, nullable = false)
@@ -76,7 +76,7 @@ public class Application {
         this.gpa = gpa;
         this.languageTest = languageTest;
         this.term = term;
-        this.updateCount = 0;
+        this.updateCount = 1;
         this.verifyStatus = PENDING;
     }
 
@@ -115,7 +115,7 @@ public class Application {
         this.gpa = gpa;
         this.languageTest = languageTest;
         this.term = term;
-        this.updateCount = 0;
+        this.updateCount = 1;
         this.firstChoiceUniversity = firstChoiceUniversity;
         this.secondChoiceUniversity = secondChoiceUniversity;
         this.thirdChoiceUniversity = thirdChoiceUniversity;

--- a/src/main/java/com/example/solidconnection/application/dto/ApplicationSubmissionResponse.java
+++ b/src/main/java/com/example/solidconnection/application/dto/ApplicationSubmissionResponse.java
@@ -1,5 +1,12 @@
 package com.example.solidconnection.application.dto;
 
+import com.example.solidconnection.application.domain.Application;
+
 public record ApplicationSubmissionResponse(
-        boolean isSuccess) {
+        int applyCount
+) {
+    // 지원횟수는 1회부터 시작하므로 1을 더해줌
+    public static ApplicationSubmissionResponse from(Application application) {
+        return new ApplicationSubmissionResponse(application.getUpdateCount() + 1);
+    }
 }

--- a/src/main/java/com/example/solidconnection/application/dto/ApplicationSubmissionResponse.java
+++ b/src/main/java/com/example/solidconnection/application/dto/ApplicationSubmissionResponse.java
@@ -5,8 +5,7 @@ import com.example.solidconnection.application.domain.Application;
 public record ApplicationSubmissionResponse(
         int applyCount
 ) {
-    // 지원횟수는 1회부터 시작하므로 1을 더해줌
     public static ApplicationSubmissionResponse from(Application application) {
-        return new ApplicationSubmissionResponse(application.getUpdateCount() + 1);
+        return new ApplicationSubmissionResponse(application.getUpdateCount());
     }
 }

--- a/src/main/java/com/example/solidconnection/application/service/ApplicationSubmissionService.java
+++ b/src/main/java/com/example/solidconnection/application/service/ApplicationSubmissionService.java
@@ -1,6 +1,7 @@
 package com.example.solidconnection.application.service;
 
 import com.example.solidconnection.application.domain.Application;
+import com.example.solidconnection.application.dto.ApplicationSubmissionResponse;
 import com.example.solidconnection.application.dto.ApplyRequest;
 import com.example.solidconnection.application.dto.UniversityChoiceRequest;
 import com.example.solidconnection.application.repository.ApplicationRepository;
@@ -49,7 +50,7 @@ public class ApplicationSubmissionService {
             key = {"applications:all"},
             cacheManager = "customCacheManager"
     )
-    public boolean apply(SiteUser siteUser, ApplyRequest applyRequest) {
+    public ApplicationSubmissionResponse apply(SiteUser siteUser, ApplyRequest applyRequest) {
         UniversityChoiceRequest universityChoiceRequest = applyRequest.universityChoiceRequest();
 
         Long gpaScoreId = applyRequest.gpaScoreId();
@@ -73,6 +74,7 @@ public class ApplicationSubmissionService {
                     term, firstChoiceUniversity, secondChoiceUniversity, thirdChoiceUniversity, getRandomNickname());
             newApplication.setVerifyStatus(VerifyStatus.APPROVED);
             applicationRepository.save(newApplication);
+            return ApplicationSubmissionResponse.from(newApplication);
         } else {
             Application before = application.get();
             validateUpdateLimitNotExceed(before);
@@ -82,8 +84,8 @@ public class ApplicationSubmissionService {
                     term, before.getUpdateCount() + 1, firstChoiceUniversity, secondChoiceUniversity, thirdChoiceUniversity, getRandomNickname());
             newApplication.setVerifyStatus(VerifyStatus.APPROVED);
             applicationRepository.save(newApplication);
+            return ApplicationSubmissionResponse.from(newApplication);
         }
-        return true;
     }
 
     private GpaScore getValidGpaScore(SiteUser siteUser, Long gpaScoreId) {

--- a/src/main/resources/db/migration/V8__change_update_count_default_value.sql
+++ b/src/main/resources/db/migration/V8__change_update_count_default_value.sql
@@ -1,0 +1,2 @@
+ALTER TABLE application
+    ALTER COLUMN update_count SET DEFAULT 1;

--- a/src/test/java/com/example/solidconnection/application/service/ApplicationSubmissionServiceTest.java
+++ b/src/test/java/com/example/solidconnection/application/service/ApplicationSubmissionServiceTest.java
@@ -61,12 +61,11 @@ class ApplicationSubmissionServiceTest extends BaseIntegrationTest {
         // then
         Application savedApplication = applicationRepository.findBySiteUserAndTerm(테스트유저_1, term).orElseThrow();
         assertAll(
-                () -> assertThat(response.applyCount()).isEqualTo(savedApplication.getUpdateCount() + 1),
+                () -> assertThat(response.applyCount()).isEqualTo(savedApplication.getUpdateCount()),
                 () -> assertThat(savedApplication.getGpa()).isEqualTo(gpaScore.getGpa()),
                 () -> assertThat(savedApplication.getLanguageTest()).isEqualTo(languageTestScore.getLanguageTest()),
                 () -> assertThat(savedApplication.getVerifyStatus()).isEqualTo(VerifyStatus.APPROVED),
                 () -> assertThat(savedApplication.getNicknameForApply()).isNotNull(),
-                () -> assertThat(savedApplication.getUpdateCount()).isZero(),
                 () -> assertThat(savedApplication.getTerm()).isEqualTo(term),
                 () -> assertThat(savedApplication.isDelete()).isFalse(),
                 () -> assertThat(savedApplication.getFirstChoiceUniversity().getId()).isEqualTo(괌대학_A_지원_정보.getId()),
@@ -128,7 +127,7 @@ class ApplicationSubmissionServiceTest extends BaseIntegrationTest {
         );
         ApplyRequest request = new ApplyRequest(gpaScore.getId(), languageTestScore.getId(), universityChoiceRequest);
 
-        for (int i = 0; i < APPLICATION_UPDATE_COUNT_LIMIT + 1; i++) {
+        for (int i = 0; i < APPLICATION_UPDATE_COUNT_LIMIT; i++) {
             applicationSubmissionService.apply(테스트유저_1, request);
         }
 

--- a/src/test/java/com/example/solidconnection/application/service/ApplicationSubmissionServiceTest.java
+++ b/src/test/java/com/example/solidconnection/application/service/ApplicationSubmissionServiceTest.java
@@ -3,6 +3,7 @@ package com.example.solidconnection.application.service;
 import com.example.solidconnection.application.domain.Application;
 import com.example.solidconnection.application.domain.Gpa;
 import com.example.solidconnection.application.domain.LanguageTest;
+import com.example.solidconnection.application.dto.ApplicationSubmissionResponse;
 import com.example.solidconnection.application.dto.ApplyRequest;
 import com.example.solidconnection.application.dto.UniversityChoiceRequest;
 import com.example.solidconnection.application.repository.ApplicationRepository;
@@ -21,7 +22,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import static com.example.solidconnection.application.service.ApplicationSubmissionService.APPLICATION_UPDATE_COUNT_LIMIT;
 import static com.example.solidconnection.custom.exception.ErrorCode.APPLY_UPDATE_LIMIT_EXCEED;
-import static com.example.solidconnection.custom.exception.ErrorCode.CANT_APPLY_FOR_SAME_UNIVERSITY;
 import static com.example.solidconnection.custom.exception.ErrorCode.INVALID_GPA_SCORE_STATUS;
 import static com.example.solidconnection.custom.exception.ErrorCode.INVALID_LANGUAGE_TEST_SCORE_STATUS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -56,12 +56,12 @@ class ApplicationSubmissionServiceTest extends BaseIntegrationTest {
         ApplyRequest request = new ApplyRequest(gpaScore.getId(), languageTestScore.getId(), universityChoiceRequest);
 
         // when
-        boolean result = applicationSubmissionService.apply(테스트유저_1, request);
+        ApplicationSubmissionResponse response = applicationSubmissionService.apply(테스트유저_1, request);
 
         // then
         Application savedApplication = applicationRepository.findBySiteUserAndTerm(테스트유저_1, term).orElseThrow();
         assertAll(
-                () -> assertThat(result).isTrue(),
+                () -> assertThat(response.applyCount()).isEqualTo(savedApplication.getUpdateCount() + 1),
                 () -> assertThat(savedApplication.getGpa()).isEqualTo(gpaScore.getGpa()),
                 () -> assertThat(savedApplication.getLanguageTest()).isEqualTo(languageTestScore.getLanguageTest()),
                 () -> assertThat(savedApplication.getVerifyStatus()).isEqualTo(VerifyStatus.APPROVED),


### PR DESCRIPTION
## 관련 이슈

- resolves: #204

## 작업 내용

1. 지원 시 지원횟수 응답값을 추가하였습니다.
2. 학기별 지원 최대횟수가 4번되는 버그를 수정하였습니다.
3. 지원 관련 서비스 로직의 불필요한 조건문을 제거하였습니다.

## 특이 사항

기존 지원서 제출 api 서비스 로직에서 성공 시 true, 실패 시 예외로 되어있었는데 이렇게되면 true를 반환할 이유가 없다고 생각해서 바로 지원횟수를 응답하는 응답 dto로 반환하게 변경하였습니다.