### PR TITLE
feat: 지원서 전체 현황 관리자만 볼 수 있게 aop 적용

### DIFF
--- a/src/main/java/com/example/solidconnection/application/controller/ApplicationController.java
+++ b/src/main/java/com/example/solidconnection/application/controller/ApplicationController.java
@@ -6,6 +6,7 @@ import com.example.solidconnection.application.dto.ApplyRequest;
 import com.example.solidconnection.application.service.ApplicationQueryService;
 import com.example.solidconnection.application.service.ApplicationSubmissionService;
 import com.example.solidconnection.custom.resolver.AuthorizedUser;
+import com.example.solidconnection.custom.security.annotation.RequireAdminAccess;
 import com.example.solidconnection.siteuser.domain.SiteUser;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -38,6 +39,7 @@ public class ApplicationController {
                 .body(applicationSubmissionResponse);
     }
 
+    @RequireAdminAccess
     @GetMapping
     public ResponseEntity<ApplicationsResponse> getApplicants(
             @AuthorizedUser SiteUser siteUser,

--- a/src/main/java/com/example/solidconnection/custom/security/annotation/RequireAdminAccess.java
+++ b/src/main/java/com/example/solidconnection/custom/security/annotation/RequireAdminAccess.java
@@ -1,0 +1,11 @@
+package com.example.solidconnection.custom.security.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RequireAdminAccess {
+}

--- a/src/main/java/com/example/solidconnection/custom/security/aspect/AdminAuthorizationAspect.java
+++ b/src/main/java/com/example/solidconnection/custom/security/aspect/AdminAuthorizationAspect.java
@@ -1,0 +1,35 @@
+package com.example.solidconnection.custom.security.aspect;
+
+import com.example.solidconnection.custom.exception.CustomException;
+import com.example.solidconnection.custom.security.annotation.RequireAdminAccess;
+import com.example.solidconnection.siteuser.domain.SiteUser;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+import static com.example.solidconnection.custom.exception.ErrorCode.ACCESS_DENIED;
+import static com.example.solidconnection.type.Role.ADMIN;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class AdminAuthorizationAspect {
+
+    @Around("@annotation(requireAdminAccess)")
+    public Object checkAdminAccess(ProceedingJoinPoint joinPoint,
+                                   RequireAdminAccess requireAdminAccess) throws Throwable {
+        SiteUser siteUser = null;
+        for (Object arg : joinPoint.getArgs()) {
+            if (arg instanceof SiteUser) {
+                siteUser = (SiteUser) arg;
+                break;
+            }
+        }
+        if (siteUser == null || !ADMIN.equals(siteUser.getRole())) {
+            throw new CustomException(ACCESS_DENIED);
+        }
+        return joinPoint.proceed();
+    }
+}

--- a/src/test/java/com/example/solidconnection/custom/security/aspect/AdminAuthorizationAspectTest.java
+++ b/src/test/java/com/example/solidconnection/custom/security/aspect/AdminAuthorizationAspectTest.java
@@ -1,0 +1,99 @@
+package com.example.solidconnection.custom.security.aspect;
+
+import com.example.solidconnection.custom.exception.CustomException;
+import com.example.solidconnection.custom.security.annotation.RequireAdminAccess;
+import com.example.solidconnection.siteuser.domain.SiteUser;
+import com.example.solidconnection.support.TestContainerSpringBootTest;
+import com.example.solidconnection.type.Gender;
+import com.example.solidconnection.type.PreparationStatus;
+import com.example.solidconnection.type.Role;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+
+import static com.example.solidconnection.custom.exception.ErrorCode.ACCESS_DENIED;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
+
+@TestContainerSpringBootTest
+@DisplayName("어드민 권한 검사 Aspect 테스트")
+class AdminAuthorizationAspectTest {
+
+    @Autowired
+    private TestService testService;
+
+    @Test
+    void 어드민_사용자는_어드민_전용_메소드에_접근할_수_있다() {
+        // given
+        SiteUser adminUser = createSiteUser(Role.ADMIN);
+
+        // when
+        boolean response = testService.adminOnlyMethod(adminUser);
+
+        // then
+        assertThat(response).isTrue();
+    }
+
+    @Test
+    void 일반_사용자가_어드민_전용_메소드에_접근하면_예외_응답을_반환한다() {
+        // given
+        SiteUser mentorUser = createSiteUser(Role.MENTOR);
+
+        // when & then
+        assertThatCode(() -> testService.adminOnlyMethod(mentorUser))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(ACCESS_DENIED.getMessage());
+    }
+
+    @Test
+    void 어드민_어노테이션이_없는_메소드는_모두_접근_가능하다() {
+        // given
+        SiteUser menteeUser = createSiteUser(Role.MENTEE);
+        SiteUser adminUser = createSiteUser(Role.ADMIN);
+
+        // when
+        boolean menteeResponse = testService.publicMethod(menteeUser);
+        boolean adminResponse = testService.publicMethod(adminUser);
+
+        // then
+        assertThat(menteeResponse).isTrue();
+        assertThat(adminResponse).isTrue();
+    }
+
+    private SiteUser createSiteUser(Role role) {
+        return new SiteUser(
+                "test@example.com",
+                "nickname",
+                "profileImageUrl",
+                "1999-01-01",
+                PreparationStatus.CONSIDERING,
+                role,
+                Gender.MALE
+        );
+    }
+
+    @TestConfiguration
+    static class TestConfig {
+
+        @Bean
+        public TestService testService() {
+            return new TestService();
+        }
+    }
+
+    @Component
+    static class TestService {
+
+        @RequireAdminAccess
+        public boolean adminOnlyMethod(SiteUser siteUser) {
+            return true;
+        }
+
+        public boolean publicMethod(SiteUser siteUser) {
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
### **User description**
## 관련 이슈

- resolves: #253

## 작업 내용

지원서 전체 현황 조회 API에 관리자(ADMIN) 전용 접근 제한 기능을 구현했습니다.

1. @RequireAdminAccess 어노테이션 생성
- 관리자 전용 API에 적용할 수 있는 커스텀 어노테이션

2. AOP를 활용한 권한 검사 로직 구현
- 메소드 파라미터에서 SiteUser 객체를 자동으로 찾아 권한 검사
- ADMIN 역할이 아닌 경우 예외 발생


<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

## 특이 사항

현재는 관리자(ADMIN) 전용 API만 구분하도록 간단하게 구현하였는데 추후에 멘토 등의 복잡한 구분이 생기게 될 때 좀 더 범용적인 역할 기반 접근 제어로 확장해야할 거 같습니다.

## 리뷰 요구사항 (선택)

- 제가 AOP를 실제 적용해보는 건 사실 처음이라 부족한 부분 말씀해주시면 좀 더 공부해서 반영해보겠습니다 
- 어노테이션 이름을 RequireAdminAccess로 지었는데 괜찮나요?


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Added `@RequireAdminAccess` annotation for admin-only API access.

- Implemented AOP-based admin authorization logic.

- Restricted access to application overview API to admins.

- Added unit tests for admin authorization aspect.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ApplicationController.java</strong><dd><code>Restrict application overview API to admins</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/example/solidconnection/application/controller/ApplicationController.java

<li>Added <code>@RequireAdminAccess</code> annotation to restrict access.<br> <li> Applied annotation to the <code>getApplicants</code> method.


</details>


  </td>
  <td><a href="https://github.com/solid-connection/solid-connect-server/pull/254/files#diff-b06a5bb7addc58081d9619e95898533640dfc77652dc9eb8166d1bd7282126d6">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>RequireAdminAccess.java</strong><dd><code>Add custom annotation for admin access</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/example/solidconnection/custom/security/annotation/RequireAdminAccess.java

<li>Created custom annotation <code>@RequireAdminAccess</code>.<br> <li> Defined it for method-level access control.


</details>


  </td>
  <td><a href="https://github.com/solid-connection/solid-connect-server/pull/254/files#diff-06f665eb9874b1b3624cbe17b9dd209915b029cc8a7444cd6827d0b944d1777c">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AdminAuthorizationAspect.java</strong><dd><code>Implement AOP-based admin authorization logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/example/solidconnection/custom/security/aspect/AdminAuthorizationAspect.java

<li>Implemented AOP aspect for admin access control.<br> <li> Validates <code>SiteUser</code> role as ADMIN.<br> <li> Throws exception for unauthorized access.


</details>


  </td>
  <td><a href="https://github.com/solid-connection/solid-connect-server/pull/254/files#diff-253b70ddef89efe83e47e5cb3b94792204ed9db702a6d9cae4ec72a5cd6b64b4">+35/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AdminAuthorizationAspectTest.java</strong><dd><code>Add tests for admin authorization aspect</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/test/java/com/example/solidconnection/custom/security/aspect/AdminAuthorizationAspectTest.java

<li>Added unit tests for admin access control aspect.<br> <li> Verified behavior for admin and non-admin users.<br> <li> Tested unrestricted access for non-annotated methods.


</details>


  </td>
  <td><a href="https://github.com/solid-connection/solid-connect-server/pull/254/files#diff-b3f14992df89f2c1be9089a7283dc621269b757ba97c6895683edcd26c2c86bf">+99/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced security measures now require administrative privileges to access certain sensitive features, ensuring that only authorized admin users can perform these operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->