### PR TITLE
chore: ci 스크립트 작성 및 ci 통과를 위한 코드 수정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI with Gradle
+
+on:
+  pull_request:
+    branches: [ "develop", "release", "master" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Make Gradle wrapper executable
+        run: chmod +x ./gradlew
+
+      - name: Build with Gradle Wrapper
+        run: ./gradlew build
+
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v5
+        if: success() || failure()
+        with:
+          report_paths: '**/build/test-results/test/TEST-*.xml'

--- a/src/main/java/com/example/solidconnection/auth/client/AppleOAuthClientSecretProvider.java
+++ b/src/main/java/com/example/solidconnection/auth/client/AppleOAuthClientSecretProvider.java
@@ -35,7 +35,7 @@ public class AppleOAuthClientSecretProvider {
 
     @PostConstruct
     private void initPrivateKey() {
-        privateKey = readPrivateKey();
+        privateKey = loadPrivateKey();
     }
 
     public String generateClientSecret() {
@@ -53,7 +53,7 @@ public class AppleOAuthClientSecretProvider {
                 .compact();
     }
 
-    private PrivateKey readPrivateKey() {
+    private PrivateKey loadPrivateKey() {
         try {
             String secretKey = appleOAuthClientProperties.secretKey();
             byte[] encoded = Base64.decodeBase64(secretKey);

--- a/src/main/java/com/example/solidconnection/auth/client/AppleOAuthClientSecretProvider.java
+++ b/src/main/java/com/example/solidconnection/auth/client/AppleOAuthClientSecretProvider.java
@@ -19,7 +19,7 @@ import java.util.Date;
 import static com.example.solidconnection.custom.exception.ErrorCode.FAILED_TO_READ_APPLE_PRIVATE_KEY;
 
 /*
- * 애플 OAuth 에 필요하 클라이언트 시크릿은 매번 동적으로 생성해야 한다.
+ * 애플 OAuth 에 필요한 클라이언트 시크릿은 매번 동적으로 생성해야 한다.
  * 클라이언트 시크릿은 애플 개발자 계정에서 발급받은 개인키(*.p8)를 사용하여 JWT 를 생성한다.
  * https://developer.apple.com/documentation/accountorganizationaldatasharing/creating-a-client-secret
  * */

--- a/src/main/java/com/example/solidconnection/config/client/AppleOAuthClientProperties.java
+++ b/src/main/java/com/example/solidconnection/config/client/AppleOAuthClientProperties.java
@@ -10,6 +10,7 @@ public record AppleOAuthClientProperties(
         String publicKeyUrl,
         String clientId,
         String teamId,
-        String keyId
+        String keyId,
+        String secretKey
 ) {
 }

--- a/src/main/java/com/example/solidconnection/entity/common/BaseEntity.java
+++ b/src/main/java/com/example/solidconnection/entity/common/BaseEntity.java
@@ -9,8 +9,10 @@ import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.time.ZoneId;
 import java.time.ZonedDateTime;
+
+import static java.time.ZoneOffset.UTC;
+import static java.time.temporal.ChronoUnit.MICROS;
 
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
@@ -24,12 +26,12 @@ public abstract class BaseEntity {
 
     @PrePersist
     public void onPrePersist() {
-        this.createdAt = ZonedDateTime.now(ZoneId.of("UTC"));
+        this.createdAt = ZonedDateTime.now(UTC).truncatedTo(MICROS); // 나노초 6자리 까지만 저장
         this.updatedAt = this.createdAt;
     }
 
     @PreUpdate
     public void onPreUpdate() {
-        this.updatedAt = ZonedDateTime.now(ZoneId.of("UTC"));
+        this.updatedAt = ZonedDateTime.now(UTC).truncatedTo(MICROS);
     }
 }

--- a/src/test/java/com/example/solidconnection/database/DatabaseConnectionTest.java
+++ b/src/test/java/com/example/solidconnection/database/DatabaseConnectionTest.java
@@ -8,7 +8,6 @@ import org.springframework.boot.jdbc.EmbeddedDatabaseConnection;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.test.context.ActiveProfiles;
 
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
@@ -20,7 +19,6 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 @Disabled
 @AutoConfigureTestDatabase(connection = EmbeddedDatabaseConnection.H2, replace = AutoConfigureTestDatabase.Replace.ANY)
-@ActiveProfiles("test")
 @DataJpaTest
 class DatabaseConnectionTest {
 

--- a/src/test/java/com/example/solidconnection/database/RedisConnectionTest.java
+++ b/src/test/java/com/example/solidconnection/database/RedisConnectionTest.java
@@ -6,12 +6,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.test.context.ActiveProfiles;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Disabled
-@ActiveProfiles("test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class RedisConnectionTest {
 

--- a/src/test/java/com/example/solidconnection/e2e/ApplicantsQueryTest.java
+++ b/src/test/java/com/example/solidconnection/e2e/ApplicantsQueryTest.java
@@ -105,7 +105,7 @@ class ApplicantsQueryTest extends UniversityDataSetUpEndToEndTest {
         ApplicationsResponse response = RestAssured.given().log().all()
                 .header("Authorization", "Bearer " + accessToken)
                 .when().log().all()
-                .get("/applications")
+                .get("/applications/competitors")
                 .then().log().all()
                 .statusCode(200)
                 .extract().as(ApplicationsResponse.class);
@@ -119,30 +119,24 @@ class ApplicantsQueryTest extends UniversityDataSetUpEndToEndTest {
                         List.of(ApplicantResponse.of(사용자1_지원정보, false))),
                 UniversityApplicantsResponse.of(괌대학_B_지원_정보,
                         List.of(ApplicantResponse.of(나의_지원정보, true))),
-                UniversityApplicantsResponse.of(메이지대학_지원_정보,
-                        List.of(ApplicantResponse.of(사용자2_지원정보, false))),
-                UniversityApplicantsResponse.of(네바다주립대학_라스베이거스_지원_정보,
-                        List.of(ApplicantResponse.of(사용자3_지원정보, false)))
+                UniversityApplicantsResponse.of(린츠_카톨릭대학_지원_정보,
+                        List.of())
         ));
         assertThat(secondChoiceApplicants).containsAnyElementsOf(List.of(
                 UniversityApplicantsResponse.of(괌대학_A_지원_정보,
-                        List.of(ApplicantResponse.of(나의_지원정보, true))),
+                        List.of(ApplicantResponse.of(나의_지원정보, false))),
                 UniversityApplicantsResponse.of(괌대학_B_지원_정보,
-                        List.of(ApplicantResponse.of(사용자1_지원정보, false))),
-                UniversityApplicantsResponse.of(메이지대학_지원_정보,
-                        List.of(ApplicantResponse.of(사용자3_지원정보, false))),
-                UniversityApplicantsResponse.of(그라츠대학_지원_정보,
-                        List.of(ApplicantResponse.of(사용자2_지원정보, false)))
+                        List.of(ApplicantResponse.of(사용자1_지원정보, true))),
+                UniversityApplicantsResponse.of(린츠_카톨릭대학_지원_정보,
+                        List.of())
         ));
         assertThat(thirdChoiceApplicants).containsAnyElementsOf(List.of(
+                UniversityApplicantsResponse.of(괌대학_A_지원_정보,
+                        List.of()),
+                UniversityApplicantsResponse.of(괌대학_B_지원_정보,
+                        List.of()),
                 UniversityApplicantsResponse.of(린츠_카톨릭대학_지원_정보,
-                        List.of(ApplicantResponse.of(나의_지원정보, true))),
-                UniversityApplicantsResponse.of(서던덴마크대학교_지원_정보,
-                        List.of(ApplicantResponse.of(사용자2_지원정보, false))),
-                UniversityApplicantsResponse.of(그라츠공과대학_지원_정보,
-                        List.of(ApplicantResponse.of(사용자1_지원정보, false))),
-                UniversityApplicantsResponse.of(메이지대학_지원_정보,
-                        List.of(ApplicantResponse.of(사용자3_지원정보, false)))
+                        List.of(ApplicantResponse.of(나의_지원정보, true)))
         ));
     }
 
@@ -151,7 +145,7 @@ class ApplicantsQueryTest extends UniversityDataSetUpEndToEndTest {
         ApplicationsResponse response = RestAssured.given().log().all()
                 .header("Authorization", "Bearer " + accessToken)
                 .when().log().all()
-                .get("/applications?region=" + 영미권.getCode())
+                .get("/applications/competitors?region=" + 영미권.getCode())
                 .then().log().all()
                 .statusCode(200)
                 .extract().as(ApplicationsResponse.class);
@@ -163,60 +157,14 @@ class ApplicantsQueryTest extends UniversityDataSetUpEndToEndTest {
                 UniversityApplicantsResponse.of(괌대학_A_지원_정보,
                         List.of(ApplicantResponse.of(사용자1_지원정보, false))),
                 UniversityApplicantsResponse.of(괌대학_B_지원_정보,
-                        List.of(ApplicantResponse.of(나의_지원정보, true))),
-                UniversityApplicantsResponse.of(네바다주립대학_라스베이거스_지원_정보,
-                        List.of(ApplicantResponse.of(사용자3_지원정보, false)))));
+                        List.of(ApplicantResponse.of(나의_지원정보, true)))
+        ));
         assertThat(secondChoiceApplicants).containsAnyElementsOf(List.of(
                 UniversityApplicantsResponse.of(괌대학_A_지원_정보,
                         List.of(ApplicantResponse.of(나의_지원정보, true))),
                 UniversityApplicantsResponse.of(괌대학_B_지원_정보,
-                        List.of(ApplicantResponse.of(사용자1_지원정보, false)))));
-    }
-
-    @Test
-    void 대학_국문_이름으로_필터링해서_지원자를_조회한다() {
-        ApplicationsResponse response = RestAssured.given().log().all()
-                .header("Authorization", "Bearer " + accessToken)
-                .when().log().all()
-                .get("/applications?keyword=라")
-                .then().log().all()
-                .statusCode(200)
-                .extract().as(ApplicationsResponse.class);
-
-        List<UniversityApplicantsResponse> firstChoiceApplicants = response.firstChoice();
-        List<UniversityApplicantsResponse> secondChoiceApplicants = response.secondChoice();
-
-        assertThat(firstChoiceApplicants).containsExactlyInAnyOrder(
-                UniversityApplicantsResponse.of(그라츠대학_지원_정보, List.of()),
-                UniversityApplicantsResponse.of(그라츠공과대학_지원_정보, List.of()),
-                UniversityApplicantsResponse.of(네바다주립대학_라스베이거스_지원_정보,
-                        List.of(ApplicantResponse.of(사용자3_지원정보, false))));
-        assertThat(secondChoiceApplicants).containsAnyElementsOf(List.of(
-                UniversityApplicantsResponse.of(그라츠대학_지원_정보,
-                        List.of(ApplicantResponse.of(사용자2_지원정보, false))),
-                UniversityApplicantsResponse.of(그라츠공과대학_지원_정보,
-                        List.of(ApplicantResponse.of(사용자3_지원정보, false))),
-                UniversityApplicantsResponse.of(네바다주립대학_라스베이거스_지원_정보, List.of())));
-    }
-
-    @Test
-    void 국가_국문_이름으로_필터링해서_지원자를_조회한다() {
-        ApplicationsResponse response = RestAssured.given().log().all()
-                .header("Authorization", "Bearer " + accessToken)
-                .when().log().all()
-                .get("/applications?keyword=일본")
-                .then().log().all()
-                .statusCode(200)
-                .extract().as(ApplicationsResponse.class);
-
-        List<UniversityApplicantsResponse> firstChoiceApplicants = response.firstChoice();
-        List<UniversityApplicantsResponse> secondChoiceApplicants = response.secondChoice();
-
-        assertThat(firstChoiceApplicants).containsExactlyInAnyOrder(
-                UniversityApplicantsResponse.of(메이지대학_지원_정보,
-                        List.of(ApplicantResponse.of(사용자2_지원정보, false))));
-        assertThat(secondChoiceApplicants).containsExactlyInAnyOrder(
-                UniversityApplicantsResponse.of(메이지대학_지원_정보, List.of()));
+                        List.of(ApplicantResponse.of(사용자1_지원정보, false)))
+        ));
     }
 
     @Test
@@ -224,7 +172,7 @@ class ApplicantsQueryTest extends UniversityDataSetUpEndToEndTest {
         ApplicationsResponse response = RestAssured.given().log().all()
                 .header("Authorization", "Bearer " + accessToken)
                 .when().log().all()
-                .get("/applications")
+                .get("/applications/competitors")
                 .then().log().all()
                 .statusCode(200)
                 .extract().as(ApplicationsResponse.class);

--- a/src/test/java/com/example/solidconnection/support/DatabaseCleaner.java
+++ b/src/test/java/com/example/solidconnection/support/DatabaseCleaner.java
@@ -5,13 +5,11 @@ import jakarta.persistence.PersistenceContext;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Objects;
 
-@ActiveProfiles("test")
 @Component
 public class DatabaseCleaner {
 

--- a/src/test/java/com/example/solidconnection/support/MySQLTestContainer.java
+++ b/src/test/java/com/example/solidconnection/support/MySQLTestContainer.java
@@ -1,34 +1,24 @@
 package com.example.solidconnection.support;
 
-import jakarta.annotation.PostConstruct;
-import org.springframework.boot.jdbc.DataSourceBuilder;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.context.annotation.Bean;
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.testcontainers.containers.MySQLContainer;
-import org.testcontainers.junit.jupiter.Container;
 
-import javax.sql.DataSource;
+public class MySQLTestContainer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
 
-@TestConfiguration
-public class MySQLTestContainer {
-
-    @Container
     private static final MySQLContainer<?> CONTAINER = new MySQLContainer<>("mysql:8.0");
 
-    @Bean
-    public DataSource dataSource() {
-        return DataSourceBuilder.create()
-                .url(CONTAINER.getJdbcUrl())
-                .username(CONTAINER.getUsername())
-                .password(CONTAINER.getPassword())
-                .driverClassName(CONTAINER.getDriverClassName())
-                .build();
+    static {
+        CONTAINER.start();
     }
 
-    @PostConstruct
-    void startContainer() {
-        if (!CONTAINER.isRunning()) {
-            CONTAINER.start();
-        }
+    @Override
+    public void initialize(ConfigurableApplicationContext applicationContext) {
+        TestPropertyValues.of(
+                "spring.datasource.url=" + CONTAINER.getJdbcUrl(),
+                "spring.datasource.username=" + CONTAINER.getUsername(),
+                "spring.datasource.password=" + CONTAINER.getPassword()
+        ).applyTo(applicationContext.getEnvironment());
     }
 }

--- a/src/test/java/com/example/solidconnection/support/TestContainerDataJpaTest.java
+++ b/src/test/java/com/example/solidconnection/support/TestContainerDataJpaTest.java
@@ -2,7 +2,7 @@ package com.example.solidconnection.support;
 
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ContextConfiguration;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.lang.annotation.ElementType;
@@ -13,7 +13,7 @@ import java.lang.annotation.Target;
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Testcontainers
-@Import(MySQLTestContainer.class)
+@ContextConfiguration(initializers = MySQLTestContainer.class)
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface TestContainerDataJpaTest {

--- a/src/test/java/com/example/solidconnection/support/TestContainerDataJpaTest.java
+++ b/src/test/java/com/example/solidconnection/support/TestContainerDataJpaTest.java
@@ -3,7 +3,6 @@ package com.example.solidconnection.support;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.context.ActiveProfiles;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.lang.annotation.ElementType;
@@ -13,7 +12,6 @@ import java.lang.annotation.Target;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@ActiveProfiles("test")
 @Testcontainers
 @Import(MySQLTestContainer.class)
 @Target(ElementType.TYPE)

--- a/src/test/java/com/example/solidconnection/support/TestContainerSpringBootTest.java
+++ b/src/test/java/com/example/solidconnection/support/TestContainerSpringBootTest.java
@@ -3,7 +3,6 @@ package com.example.solidconnection.support;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ContextConfiguration;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
@@ -13,11 +12,10 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @ExtendWith({DatabaseClearExtension.class})
-@ContextConfiguration(initializers = RedisTestContainer.class)
+@ContextConfiguration(initializers = {RedisTestContainer.class, MySQLTestContainer.class})
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Testcontainers
-@Import({MySQLTestContainer.class})
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface TestContainerSpringBootTest {

--- a/src/test/java/com/example/solidconnection/support/TestContainerSpringBootTest.java
+++ b/src/test/java/com/example/solidconnection/support/TestContainerSpringBootTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ContextConfiguration;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.lang.annotation.ElementType;
@@ -12,10 +13,11 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @ExtendWith({DatabaseClearExtension.class})
+@ContextConfiguration(initializers = RedisTestContainer.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Testcontainers
-@Import({MySQLTestContainer.class, RedisTestContainer.class})
+@Import({MySQLTestContainer.class})
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface TestContainerSpringBootTest {

--- a/src/test/java/com/example/solidconnection/support/TestContainerSpringBootTest.java
+++ b/src/test/java/com/example/solidconnection/support/TestContainerSpringBootTest.java
@@ -4,7 +4,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.context.ActiveProfiles;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.lang.annotation.ElementType;
@@ -15,7 +14,6 @@ import java.lang.annotation.Target;
 @ExtendWith({DatabaseClearExtension.class})
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@ActiveProfiles("test")
 @Testcontainers
 @Import({MySQLTestContainer.class, RedisTestContainer.class})
 @Target(ElementType.TYPE)

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -51,7 +51,7 @@ oauth:
     team-id: team-id
     key-id: key-id
     redirect-url: "https://localhost:8080/auth/apple"
-    secret-key: MEECAQAwEwYHKoZIzj0CAQYIKoZIzj0DAQcEJzAlAgEBBCAfGIQ3TtNYAZG7i3m72odmdhfymkM9wAFg2rEL2RKUEA==
+    secret-key: MEECAQAwEwYHKoZIzj0CAQYIKoZIzj0DAQcEJzAlAgEBBCAfGIQ3TtNYAZG7i3m72odmdhfymkM9wAFg2rEL2RKUEA== # base64 encoded 된 임의의 값
 kakao:
     redirect-url: "http://localhost:8080/auth/kakao"
     client-id: client-id

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -7,7 +7,7 @@ spring:
       port: 6379
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: create
     generate-ddl: true
     show-sql: true
     database: mysql

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,72 @@
+spring:
+
+# db
+  data:
+    redis:
+      host: localhost
+      port: 6379
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    generate-ddl: true
+    show-sql: true
+    database: mysql
+    properties:
+      hibernate:
+        format_sql: true
+  flyway:
+    enabled: false
+
+# cloud
+cloud:
+  aws:
+    credentials:
+      access-key: access-key
+      secret-key: access-key
+    region:
+      static: ap-northeast-2
+    stack:
+      auto: false
+    s3:
+      bucket: solid-connection-uploaded
+      url:
+        default: default-url
+        uploaded: uploaded-url
+    cloudFront:
+      url:
+        default: default-url
+        uploaded: uploaded-url
+
+# variable
+view:
+  count:
+    scheduling:
+      delay: 3000
+oauth:
+  apple:
+    token-url: "https://appleid.apple.com/auth/token"
+    client-secret-audience-url: "https://appleid.apple.com"
+    public-key-url: "https://appleid.apple.com/auth/keys"
+    client-id: client-id
+    team-id: team-id
+    key-id: key-id
+    redirect-url: "https://localhost:8080/auth/apple"
+  kakao:
+    redirect-url: "http://localhost:8080/auth/kakao"
+    client-id: client-id
+    token-url: "https://kauth.kakao.com/oauth/token"
+    user-info_url: "https://kapi.kakao.com/v2/user/me"
+sentry:
+  environment: test
+  dsn: "https://test-public-key@sentry.test-domain.io/123456"
+  send-default-pii: true
+  traces-sample-rate: 1.0
+  exception-resolver-order: -2147483647
+university:
+  term: 2024-1
+jwt:
+  secret:
+    1234567-1234-1234-1234-12345678901
+cors:
+  allowed-origins:
+    - "http://localhost:8080"

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -51,7 +51,8 @@ oauth:
     team-id: team-id
     key-id: key-id
     redirect-url: "https://localhost:8080/auth/apple"
-  kakao:
+    secret-key: MEECAQAwEwYHKoZIzj0CAQYIKoZIzj0DAQcEJzAlAgEBBCAfGIQ3TtNYAZG7i3m72odmdhfymkM9wAFg2rEL2RKUEA==
+kakao:
     redirect-url: "http://localhost:8080/auth/kakao"
     client-id: client-id
     token-url: "https://kauth.kakao.com/oauth/token"


### PR DESCRIPTION
## 관련 이슈

- resolves: #111 

## 작업 내용

원래 목적은 ci 스크립트 작성이었는데,… 
ci 스크립트를 작성하고, 테스트들을 다 통과시키기 위해서는 세트로 발생하는 문제들이 꽤나 많았습니다🥲
❗️ **PR 디스크립션과 커밋 따라가시면 파악하기 쉬우실겁니다!** ❗️

1. [디스커션](https://github.com/solid-connection/solid-connect-server/discussions/257)에서 논의한대로 test를 위한 변수들을 **/src/test/resources/application.yml 파일로 분리**했습니다.
2. 위 과정에서 **애플 OAuth의 클라이언트 시크릿 만드는 부분의 코드를 변경**했습니다.
테스트 코드가 main/secret/AppleOAuthKey.p8 파일에 접근하지 못해서 테스트가 실패하는 문제가 있었는데,
동일하게 test/secret/ 경로에 AppleOAuthKey.p8 파일을 만들기보다, 다른 변수들처럼 yml 로 관리하는게 좋을 것 같아 바꿔줬습니다.
3. **redis test container 설정 코드를 변경**했습니다.
기존 설정이 잘못되어있더라고요🥲
이걸 왜 지금 알게 되었는지와, 어떻게 다시 설정했는지를 [디스커션](https://github.com/solid-connection/solid-connect-server/discussions/265)에 정리했습니다.
스프링의 환경변수인 Environment 에 대한 내용이 있으니 한번 읽어보셔도 도움될 것 같습니다.
4. 어플리케이션에서 초기화한 ZonedDateTime 과,
이를 MySQL DB에 넣었다가 꺼낸 상태의 ZonedDateTime을 비교하는 과정에서 문제가 발생했습니다.
[디스커션](https://github.com/solid-connection/solid-connect-server/discussions/264)에 문제 원인 정리했습니다.
5. **e2e 테스트 내용 변경했습니다.**
‘지원자는 자신이 지원한 학교의 경쟁자들만 볼 수 있다’는 내용이 e2e 테스트에는 반영이 안되었더라고요.
이로써 e2e 테스트의 또 다른 단점을 발견하게 되었습니다..😮‍💨
e2e 테스트 코드 지우는 PR 새로 만들겠습니다.

## 특이 사항

1. 코더레빗이 너무 말이 많아서 인간 개발자들의 코멘트가 묻히는 느낌이라,. 설정을 바꿨습니다. 어떤가요?
2. test containers로 ci 를 해서 빌드 시간이 오래 걸리는게 단점이라 생각했는데, ai 코드리뷰도 그 정도 걸리더라고요 ㅎㅎ;;