### PR TITLE
chore: codeowners로 리뷰어 자동 배정되도록

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Gyuhyeok99 @nayonsoso @wibaek


### PR DESCRIPTION
## 작업 내용
![image](https://github.com/user-attachments/assets/de1fe6e3-754f-4b33-bca4-e6a2d1a6ba3a)

GitHub Code owners 기능을 사용하여 이 레포에 올라오는 모든 PR의 리뷰어가 
위백님, 규혁님, 저로 자동 배정되게 했습니다😊
이 PR이 머지되면 적용됩니다.

ref. https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

fork 레포 → 팀 레포로의 PR에는 리뷰어로 자동 배정되지만, 
fork 레포 → fork 레포로의 PR에는 (fork 레포에 write할 수 있게 추가되어있지 않는 한) 리뷰어로 배정되지 않습니다.
예를 들어 제가 제 fork 레포로의 PR을 만들었다고 해서, 위백님과 규혁님이 해당 PR의 리뷰어로 배정되진 않습니다.

![image](https://github.com/user-attachments/assets/8db6b330-3620-434c-abfc-90ced8a9e1d3)


## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
