### PR TITLE
fix: 토큰 재발급 로직 수정

### DIFF
--- a/src/main/java/com/example/solidconnection/auth/controller/AuthController.java
+++ b/src/main/java/com/example/solidconnection/auth/controller/AuthController.java
@@ -3,6 +3,7 @@ package com.example.solidconnection.auth.controller;
 import com.example.solidconnection.auth.dto.EmailSignInRequest;
 import com.example.solidconnection.auth.dto.EmailSignUpTokenRequest;
 import com.example.solidconnection.auth.dto.EmailSignUpTokenResponse;
+import com.example.solidconnection.auth.dto.ReissueRequest;
 import com.example.solidconnection.auth.dto.ReissueResponse;
 import com.example.solidconnection.auth.dto.SignInResponse;
 import com.example.solidconnection.auth.dto.SignUpRequest;
@@ -114,13 +115,9 @@ public class AuthController {
 
     @PostMapping("/reissue")
     public ResponseEntity<ReissueResponse> reissueToken(
-            Authentication authentication
+            ReissueRequest reissueRequest
     ) {
-        String accessToken = authentication.getCredentials().toString();
-        if (accessToken == null) {
-            throw new CustomException(ErrorCode.AUTHENTICATION_FAILED, "토큰이 없습니다.");
-        }
-        ReissueResponse reissueResponse = authService.reissue(accessToken);
+        ReissueResponse reissueResponse = authService.reissue(reissueRequest);
         return ResponseEntity.ok(reissueResponse);
     }
 }

--- a/src/main/java/com/example/solidconnection/auth/controller/AuthController.java
+++ b/src/main/java/com/example/solidconnection/auth/controller/AuthController.java
@@ -116,11 +116,11 @@ public class AuthController {
     public ResponseEntity<ReissueResponse> reissueToken(
             Authentication authentication
     ) {
-        String token = authentication.getCredentials().toString();
-        if (token == null) {
+        String accessToken = authentication.getCredentials().toString();
+        if (accessToken == null) {
             throw new CustomException(ErrorCode.AUTHENTICATION_FAILED, "토큰이 없습니다.");
         }
-        ReissueResponse reissueResponse = authService.reissue(token);
+        ReissueResponse reissueResponse = authService.reissue(accessToken);
         return ResponseEntity.ok(reissueResponse);
     }
 }

--- a/src/main/java/com/example/solidconnection/auth/domain/TokenType.java
+++ b/src/main/java/com/example/solidconnection/auth/domain/TokenType.java
@@ -5,16 +5,16 @@ import lombok.Getter;
 @Getter
 public enum TokenType {
 
-    ACCESS("ACCESS:", 1000 * 60 * 60), // 1hour
-    REFRESH("REFRESH:", 1000 * 60 * 60 * 24 * 7), // 7days
+    ACCESS("ACCESS:", 1000L * 60 * 60), // 1hour
+    REFRESH("REFRESH:", 1000L * 60 * 60 * 24 * 90), // 90days
     BLACKLIST("BLACKLIST:", ACCESS.expireTime),
-    SIGN_UP("SIGN_UP:", 1000 * 60 * 10), // 10min
+    SIGN_UP("SIGN_UP:", 1000L * 60 * 10), // 10min
     ;
 
     private final String prefix;
-    private final int expireTime;
+    private final long expireTime;
 
-    TokenType(String prefix, int expireTime) {
+    TokenType(String prefix, long expireTime) {
         this.prefix = prefix;
         this.expireTime = expireTime;
     }

--- a/src/main/java/com/example/solidconnection/auth/dto/ReissueRequest.java
+++ b/src/main/java/com/example/solidconnection/auth/dto/ReissueRequest.java
@@ -1,0 +1,8 @@
+package com.example.solidconnection.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record ReissueRequest(
+        @NotBlank(message = "리프레시 토큰과 함께 요청해주세요.")
+        String refreshToken) {
+}

--- a/src/main/java/com/example/solidconnection/auth/service/AuthService.java
+++ b/src/main/java/com/example/solidconnection/auth/service/AuthService.java
@@ -1,6 +1,7 @@
 package com.example.solidconnection.auth.service;
 
 
+import com.example.solidconnection.auth.dto.ReissueRequest;
 import com.example.solidconnection.auth.dto.ReissueResponse;
 import com.example.solidconnection.config.security.JwtProperties;
 import com.example.solidconnection.custom.exception.CustomException;
@@ -10,6 +11,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.Objects;
 import java.util.Optional;
 
 import static com.example.solidconnection.custom.exception.ErrorCode.REFRESH_TOKEN_EXPIRED;
@@ -43,18 +45,19 @@ public class AuthService {
 
     /*
      * 액세스 토큰을 재발급한다.
-     * - 리프레시 토큰이 만료되었거나, 존재하지 않는다면 예외 응답을 반환한다.
-     * - 리프레시 토큰이 존재한다면, 액세스 토큰을 재발급한다.
+     * - 요청된 리프레시 토큰과 동일한 subject 의 토큰이 저장되어 있으며 값이 일치할 경우, 액세스 토큰을 재발급한다.
+     * - 그렇지 않으면 예외를 반환한다.
      * */
-    public ReissueResponse reissue(String accessToken) {
-        // 리프레시 토큰 만료 확인
-        String subject = parseSubject(accessToken, jwtProperties.secret());
-        Optional<String> optionalRefreshToken = authTokenProvider.findRefreshToken(subject);
-        if (optionalRefreshToken.isEmpty()) {
+    public ReissueResponse reissue(ReissueRequest reissueRequest) {
+        // 리프레시 토큰 확인
+        String requestedRefreshToken = reissueRequest.refreshToken();
+        String subject = parseSubject(requestedRefreshToken, jwtProperties.secret());
+        Optional<String> savedRefreshToken = authTokenProvider.findRefreshToken(subject);
+        if (!Objects.equals(requestedRefreshToken, savedRefreshToken.orElse(null))) {
             throw new CustomException(REFRESH_TOKEN_EXPIRED);
         }
         // 액세스 토큰 재발급
-        String newAccessToken = authTokenProvider.generateAccessToken(accessToken);
+        String newAccessToken = authTokenProvider.generateAccessToken(subject);
         return new ReissueResponse(newAccessToken);
     }
 }

--- a/src/main/java/com/example/solidconnection/auth/service/AuthService.java
+++ b/src/main/java/com/example/solidconnection/auth/service/AuthService.java
@@ -2,6 +2,7 @@ package com.example.solidconnection.auth.service;
 
 
 import com.example.solidconnection.auth.dto.ReissueResponse;
+import com.example.solidconnection.config.security.JwtProperties;
 import com.example.solidconnection.custom.exception.CustomException;
 import com.example.solidconnection.siteuser.domain.SiteUser;
 import lombok.RequiredArgsConstructor;
@@ -12,12 +13,14 @@ import java.time.LocalDate;
 import java.util.Optional;
 
 import static com.example.solidconnection.custom.exception.ErrorCode.REFRESH_TOKEN_EXPIRED;
+import static com.example.solidconnection.util.JwtUtils.parseSubject;
 
 @RequiredArgsConstructor
 @Service
 public class AuthService {
 
     private final AuthTokenProvider authTokenProvider;
+    private final JwtProperties jwtProperties;
 
     /*
      * 로그아웃 한다.
@@ -43,14 +46,15 @@ public class AuthService {
      * - 리프레시 토큰이 만료되었거나, 존재하지 않는다면 예외 응답을 반환한다.
      * - 리프레시 토큰이 존재한다면, 액세스 토큰을 재발급한다.
      * */
-    public ReissueResponse reissue(String subject) {
+    public ReissueResponse reissue(String accessToken) {
         // 리프레시 토큰 만료 확인
+        String subject = parseSubject(accessToken, jwtProperties.secret());
         Optional<String> optionalRefreshToken = authTokenProvider.findRefreshToken(subject);
         if (optionalRefreshToken.isEmpty()) {
             throw new CustomException(REFRESH_TOKEN_EXPIRED);
         }
         // 액세스 토큰 재발급
-        String newAccessToken = authTokenProvider.generateAccessToken(subject);
+        String newAccessToken = authTokenProvider.generateAccessToken(accessToken);
         return new ReissueResponse(newAccessToken);
     }
 }

--- a/src/main/java/com/example/solidconnection/auth/service/AuthTokenProvider.java
+++ b/src/main/java/com/example/solidconnection/auth/service/AuthTokenProvider.java
@@ -8,8 +8,6 @@ import org.springframework.stereotype.Component;
 
 import java.util.Optional;
 
-import static com.example.solidconnection.util.JwtUtils.parseSubjectIgnoringExpiration;
-
 @Component
 public class AuthTokenProvider extends TokenProvider {
 
@@ -45,10 +43,6 @@ public class AuthTokenProvider extends TokenProvider {
     public Optional<String> findBlackListToken(String subject) {
         String blackListTokenKey = TokenType.BLACKLIST.addPrefix(subject);
         return Optional.ofNullable(redisTemplate.opsForValue().get(blackListTokenKey));
-    }
-
-    public String getEmail(String token) {
-        return parseSubjectIgnoringExpiration(token, jwtProperties.secret());
     }
 
     private String getSubject(SiteUser siteUser) {

--- a/src/main/java/com/example/solidconnection/auth/service/AuthTokenProvider.java
+++ b/src/main/java/com/example/solidconnection/auth/service/AuthTokenProvider.java
@@ -18,7 +18,7 @@ public class AuthTokenProvider extends TokenProvider {
     }
 
     public String generateAccessToken(SiteUser siteUser) {
-        String subject = siteUser.getId().toString();
+        String subject = getSubject(siteUser);
         return generateToken(subject, TokenType.ACCESS);
     }
 
@@ -27,7 +27,7 @@ public class AuthTokenProvider extends TokenProvider {
     }
 
     public String generateAndSaveRefreshToken(SiteUser siteUser) {
-        String subject = siteUser.getId().toString();
+        String subject = getSubject(siteUser);
         String refreshToken = generateToken(subject, TokenType.REFRESH);
         return saveToken(refreshToken, TokenType.REFRESH);
     }
@@ -49,5 +49,9 @@ public class AuthTokenProvider extends TokenProvider {
 
     public String getEmail(String token) {
         return parseSubjectIgnoringExpiration(token, jwtProperties.secret());
+    }
+
+    private String getSubject(SiteUser siteUser) {
+        return siteUser.getId().toString();
     }
 }

--- a/src/main/java/com/example/solidconnection/util/JwtUtils.java
+++ b/src/main/java/com/example/solidconnection/util/JwtUtils.java
@@ -28,19 +28,19 @@ public class JwtUtils {
         return token.substring(TOKEN_PREFIX.length());
     }
 
-    public static String parseSubjectIgnoringExpiration(String token, String secretKey) {
+    public static String parseSubject(String token, String secretKey) {
         try {
             return parseClaims(token, secretKey).getSubject();
-        } catch (ExpiredJwtException e) {
-            return e.getClaims().getSubject();
         } catch (Exception e) {
             throw new CustomException(INVALID_TOKEN);
         }
     }
 
-    public static String parseSubject(String token, String secretKey) {
+    public static String parseSubjectIgnoringExpiration(String token, String secretKey) {
         try {
             return parseClaims(token, secretKey).getSubject();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims().getSubject();
         } catch (Exception e) {
             throw new CustomException(INVALID_TOKEN);
         }

--- a/src/test/java/com/example/solidconnection/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/example/solidconnection/auth/service/AuthServiceTest.java
@@ -1,0 +1,108 @@
+package com.example.solidconnection.auth.service;
+
+import com.example.solidconnection.auth.domain.TokenType;
+import com.example.solidconnection.auth.dto.ReissueRequest;
+import com.example.solidconnection.auth.dto.ReissueResponse;
+import com.example.solidconnection.config.security.JwtProperties;
+import com.example.solidconnection.custom.exception.CustomException;
+import com.example.solidconnection.siteuser.domain.SiteUser;
+import com.example.solidconnection.siteuser.repository.SiteUserRepository;
+import com.example.solidconnection.support.TestContainerSpringBootTest;
+import com.example.solidconnection.type.PreparationStatus;
+import com.example.solidconnection.type.Role;
+import com.example.solidconnection.util.JwtUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDate;
+
+import static com.example.solidconnection.custom.exception.ErrorCode.REFRESH_TOKEN_EXPIRED;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+@DisplayName("인증 서비스 테스트")
+@TestContainerSpringBootTest
+class AuthServiceTest {
+
+    @Autowired
+    private AuthService authService;
+
+    @Autowired
+    private AuthTokenProvider authTokenProvider;
+
+    @Autowired
+    private SiteUserRepository siteUserRepository;
+
+    @Autowired
+    private JwtProperties jwtProperties;
+
+    @Test
+    void 로그아웃한다() {
+        // given
+        String accessToken = "accessToken";
+
+        // when
+        authService.signOut(accessToken);
+
+        // then
+        assertThat(authTokenProvider.findBlackListToken(accessToken)).isNotNull();
+    }
+
+    @Test
+    void 탈퇴한다() {
+        // given
+        SiteUser siteUser = createSiteUser();
+
+        // when
+        authService.quit(siteUser);
+
+        // then
+        LocalDate tomorrow = LocalDate.now().plusDays(1);
+        assertThat(siteUser.getQuitedAt()).isEqualTo(tomorrow);
+    }
+
+    @Nested
+    class 토큰을_재발급한다 {
+
+        @Test
+        void 요청의_리프레시_토큰이_저장되어_있고_값이_일치면_액세스_토큰을_재발급한다() {
+            // given
+            SiteUser siteUser = createSiteUser();
+            String refreshToken = authTokenProvider.generateAndSaveRefreshToken(siteUser);
+            ReissueRequest reissueRequest = new ReissueRequest(refreshToken);
+
+            // when
+            ReissueResponse reissuedAccessToken = authService.reissue(reissueRequest);
+
+            // then
+            String actualSubject = JwtUtils.parseSubject(reissuedAccessToken.accessToken(), jwtProperties.secret());
+            String expectedSubject = JwtUtils.parseSubject(refreshToken, jwtProperties.secret());
+            assertThat(actualSubject).isEqualTo(expectedSubject);
+        }
+
+        @Test
+        void 요청의_리프레시_토큰이_저장되어있지_않다면_예외_응답을_반환한다() {
+            // given
+            String refreshToken = authTokenProvider.generateToken("subject", TokenType.REFRESH);
+            ReissueRequest reissueRequest = new ReissueRequest(refreshToken);
+
+            // when, then
+            assertThatCode(() -> authService.reissue(reissueRequest))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(REFRESH_TOKEN_EXPIRED.getMessage());
+        }
+    }
+
+    private SiteUser createSiteUser() {
+        SiteUser siteUser = new SiteUser(
+                "test@example.com",
+                "nickname",
+                "profileImageUrl",
+                PreparationStatus.CONSIDERING,
+                Role.MENTEE
+        );
+        return siteUserRepository.save(siteUser);
+    }
+}


### PR DESCRIPTION
## 관련 이슈

- resolves: #258 

## 작업 내용

분명 엑세스 토큰 재발급 로직이 있을텐데 왜 사용자가 만료가 빠르다고 느끼는가 싶어 코드를 봤더니
엑세스 로직에서 실수가 있었습니다 🤕
코멘트로 설명하겠습니다!

**그리고 몇가지 작은 리팩터링은 커밋을 따라가면 이해하시기 편하실겁니다~**

## 앞으로의 계획 - 피드백 부탁!

토큰도 Sting, subject도 String 형식이라 이런 실수가 발생했습니다.
Token 이라는 클래스를 만들면 이런 실수를 사전에 방지할 수 있을 것 같습니다.
그리고 Token 클래스가 필드로 subject를 가지게 하고,
`JwtAuthenticationFilter`에서 Token 객체를 생성할 때 subject를 초기화한다면
여러곳에서 JwtUtils.parseSubject() 를 호출하고있는 지금의 코드를 개선할 수 있을 것 같습니다!
(지금은 parseSubject 함수가 19군데에서 호출되고 있습니다.)