### PR TITLE
refactor: 문자열 토큰을 Token 클래스로

### DIFF
--- a/src/main/java/com/example/solidconnection/auth/controller/AuthController.java
+++ b/src/main/java/com/example/solidconnection/auth/controller/AuthController.java
@@ -9,6 +9,7 @@ import com.example.solidconnection.auth.dto.SignInResponse;
 import com.example.solidconnection.auth.dto.SignUpRequest;
 import com.example.solidconnection.auth.dto.oauth.OAuthCodeRequest;
 import com.example.solidconnection.auth.dto.oauth.OAuthResponse;
+import com.example.solidconnection.auth.service.AccessToken;
 import com.example.solidconnection.auth.service.AuthService;
 import com.example.solidconnection.auth.service.CommonSignUpTokenProvider;
 import com.example.solidconnection.auth.service.EmailSignInService;
@@ -97,11 +98,10 @@ public class AuthController {
     public ResponseEntity<Void> signOut(
             Authentication authentication
     ) {
-        String token = authentication.getCredentials().toString();
-        if (token == null) {
+        if (!(authentication.getCredentials() instanceof AccessToken accessToken)) { // null or AccessToken 로 형변환 실패
             throw new CustomException(ErrorCode.AUTHENTICATION_FAILED, "토큰이 없습니다.");
         }
-        authService.signOut(token);
+        authService.signOut(accessToken);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/example/solidconnection/auth/dto/ReissueResponse.java
+++ b/src/main/java/com/example/solidconnection/auth/dto/ReissueResponse.java
@@ -1,5 +1,12 @@
 package com.example.solidconnection.auth.dto;
 
+import com.example.solidconnection.auth.service.AccessToken;
+
 public record ReissueResponse(
-        String accessToken) {
+        String accessToken
+) {
+
+    public static ReissueResponse from(AccessToken accessToken) {
+        return new ReissueResponse(accessToken.token());
+    }
 }

--- a/src/main/java/com/example/solidconnection/auth/dto/SignInResponse.java
+++ b/src/main/java/com/example/solidconnection/auth/dto/SignInResponse.java
@@ -1,7 +1,14 @@
 package com.example.solidconnection.auth.dto;
 
+import com.example.solidconnection.auth.service.AccessToken;
+import com.example.solidconnection.auth.service.RefreshToken;
+
 public record SignInResponse(
         String accessToken,
         String refreshToken
 ) {
+
+    public static SignInResponse of(AccessToken accessToken, RefreshToken refreshToken) {
+        return new SignInResponse(accessToken.token(), refreshToken.token());
+    }
 }

--- a/src/main/java/com/example/solidconnection/auth/service/AccessToken.java
+++ b/src/main/java/com/example/solidconnection/auth/service/AccessToken.java
@@ -1,0 +1,11 @@
+package com.example.solidconnection.auth.service;
+
+public record AccessToken(
+        Subject subject,
+        String token
+) {
+
+    public AccessToken(String subject, String token) {
+        this(new Subject(subject), token);
+    }
+}

--- a/src/main/java/com/example/solidconnection/auth/service/AuthTokenProvider.java
+++ b/src/main/java/com/example/solidconnection/auth/service/AuthTokenProvider.java
@@ -3,49 +3,70 @@ package com.example.solidconnection.auth.service;
 import com.example.solidconnection.auth.domain.TokenType;
 import com.example.solidconnection.config.security.JwtProperties;
 import com.example.solidconnection.siteuser.domain.SiteUser;
+import com.example.solidconnection.util.JwtUtils;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
-import java.util.Optional;
+import java.util.Objects;
 
 @Component
-public class AuthTokenProvider extends TokenProvider {
+public class AuthTokenProvider extends TokenProvider implements BlacklistChecker {
 
     public AuthTokenProvider(JwtProperties jwtProperties, RedisTemplate<String, String> redisTemplate) {
         super(jwtProperties, redisTemplate);
     }
 
-    public String generateAccessToken(SiteUser siteUser) {
-        String subject = getSubject(siteUser);
-        return generateToken(subject, TokenType.ACCESS);
+    public AccessToken generateAccessToken(Subject subject) {
+        String token = generateToken(subject.value(), TokenType.ACCESS);
+        return new AccessToken(subject, token);
     }
 
-    public String generateAccessToken(String subject) {
-        return generateToken(subject, TokenType.ACCESS);
+    public RefreshToken generateAndSaveRefreshToken(Subject subject) {
+        String token = generateToken(subject.value(), TokenType.REFRESH);
+        saveToken(token, TokenType.REFRESH);
+        return new RefreshToken(subject, token);
     }
 
-    public String generateAndSaveRefreshToken(SiteUser siteUser) {
-        String subject = getSubject(siteUser);
-        String refreshToken = generateToken(subject, TokenType.REFRESH);
-        return saveToken(refreshToken, TokenType.REFRESH);
+    /*
+    * 액세스 토큰을 블랙리스트에 저장한다.
+    * - key = BLACKLIST:{subject}
+    * - value = {accessToken}
+    * */
+    public void addToBlacklist(AccessToken accessToken) {
+        saveToken(accessToken.token(), TokenType.BLACKLIST);
     }
 
-    public String generateAndSaveBlackListToken(String accessToken) {
-        String blackListToken = generateToken(accessToken, TokenType.BLACKLIST);
-        return saveToken(blackListToken, TokenType.BLACKLIST);
-    }
-
-    public Optional<String> findRefreshToken(String subject) {
+    /*
+    * 유효한 리프레시 토큰인지 확인한다.
+    * - 요청된 토큰과 같은 subject 의 리프레시 토큰을 조회한다.
+    * - 조회된 리프레시 토큰과 요청된 토큰이 같은지 비교한다.
+    * */
+    public boolean isValidRefreshToken(String requestedRefreshToken) {
+        String subject = JwtUtils.parseSubject(requestedRefreshToken, jwtProperties.secret());
         String refreshTokenKey = TokenType.REFRESH.addPrefix(subject);
-        return Optional.ofNullable(redisTemplate.opsForValue().get(refreshTokenKey));
+        String foundRefreshToken = redisTemplate.opsForValue().get(refreshTokenKey);
+        return Objects.equals(requestedRefreshToken, foundRefreshToken);
     }
 
-    public Optional<String> findBlackListToken(String subject) {
+    /*
+    * 블랙리스트에 등록된 토큰인지 확인한다.
+    * - 액세스 토큰의 subject 에 해당하는 블랙리스트 토큰을 조회한다.
+    * - 조회된 블랙리스트 토큰과 요청된 액세스 토큰이 같은지 비교한다.
+    */
+    @Override
+    public boolean isTokenBlacklisted(String accessToken) {
+        String subject = JwtUtils.parseSubject(accessToken, jwtProperties.secret());
         String blackListTokenKey = TokenType.BLACKLIST.addPrefix(subject);
-        return Optional.ofNullable(redisTemplate.opsForValue().get(blackListTokenKey));
+        String foundBlackListToken = redisTemplate.opsForValue().get(blackListTokenKey);
+        return Objects.equals(accessToken, foundBlackListToken);
     }
 
-    private String getSubject(SiteUser siteUser) {
-        return siteUser.getId().toString();
+    public Subject parseSubject(String token) {
+        String subject = JwtUtils.parseSubject(token, jwtProperties.secret());
+        return new Subject(subject);
+    }
+
+    public Subject toSubject(SiteUser siteUser) {
+        return new Subject(siteUser.getId().toString());
     }
 }

--- a/src/main/java/com/example/solidconnection/auth/service/BlacklistChecker.java
+++ b/src/main/java/com/example/solidconnection/auth/service/BlacklistChecker.java
@@ -1,0 +1,6 @@
+package com.example.solidconnection.auth.service;
+
+public interface BlacklistChecker {
+
+    boolean isTokenBlacklisted(String token);
+}

--- a/src/main/java/com/example/solidconnection/auth/service/RefreshToken.java
+++ b/src/main/java/com/example/solidconnection/auth/service/RefreshToken.java
@@ -1,0 +1,11 @@
+package com.example.solidconnection.auth.service;
+
+public record RefreshToken(
+        Subject subject,
+        String token
+) {
+
+    RefreshToken(String subject, String token) {
+        this(new Subject(subject), token);
+    }
+}

--- a/src/main/java/com/example/solidconnection/auth/service/SignInService.java
+++ b/src/main/java/com/example/solidconnection/auth/service/SignInService.java
@@ -15,9 +15,10 @@ public class SignInService {
     @Transactional
     public SignInResponse signIn(SiteUser siteUser) {
         resetQuitedAt(siteUser);
-        String accessToken = authTokenProvider.generateAccessToken(siteUser);
-        String refreshToken = authTokenProvider.generateAndSaveRefreshToken(siteUser);
-        return new SignInResponse(accessToken, refreshToken);
+        Subject subject = authTokenProvider.toSubject(siteUser);
+        AccessToken accessToken = authTokenProvider.generateAccessToken(subject);
+        RefreshToken refreshToken = authTokenProvider.generateAndSaveRefreshToken(subject);
+        return SignInResponse.of(accessToken, refreshToken);
     }
 
     private void resetQuitedAt(SiteUser siteUser) {

--- a/src/main/java/com/example/solidconnection/auth/service/Subject.java
+++ b/src/main/java/com/example/solidconnection/auth/service/Subject.java
@@ -1,0 +1,6 @@
+package com.example.solidconnection.auth.service;
+
+public record Subject(
+        String value
+) {
+}

--- a/src/main/java/com/example/solidconnection/custom/security/filter/SignOutCheckFilter.java
+++ b/src/main/java/com/example/solidconnection/custom/security/filter/SignOutCheckFilter.java
@@ -1,6 +1,6 @@
 package com.example.solidconnection.custom.security.filter;
 
-import com.example.solidconnection.auth.service.AuthTokenProvider;
+import com.example.solidconnection.auth.service.BlacklistChecker;
 import com.example.solidconnection.custom.exception.CustomException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -20,7 +20,7 @@ import static com.example.solidconnection.util.JwtUtils.parseTokenFromRequest;
 @RequiredArgsConstructor
 public class SignOutCheckFilter extends OncePerRequestFilter {
 
-    private final AuthTokenProvider authTokenProvider;
+    private final BlacklistChecker tokenBlacklistChecker;
 
     @Override
     protected void doFilterInternal(@NonNull HttpServletRequest request,
@@ -34,6 +34,6 @@ public class SignOutCheckFilter extends OncePerRequestFilter {
     }
 
     private boolean hasSignedOut(String accessToken) {
-        return authTokenProvider.findBlackListToken(accessToken).isPresent();
+        return tokenBlacklistChecker.isTokenBlacklisted(accessToken);
     }
 }

--- a/src/test/java/com/example/solidconnection/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/example/solidconnection/auth/service/AuthServiceTest.java
@@ -1,16 +1,13 @@
 package com.example.solidconnection.auth.service;
 
-import com.example.solidconnection.auth.domain.TokenType;
 import com.example.solidconnection.auth.dto.ReissueRequest;
 import com.example.solidconnection.auth.dto.ReissueResponse;
-import com.example.solidconnection.config.security.JwtProperties;
 import com.example.solidconnection.custom.exception.CustomException;
 import com.example.solidconnection.siteuser.domain.SiteUser;
 import com.example.solidconnection.siteuser.repository.SiteUserRepository;
 import com.example.solidconnection.support.TestContainerSpringBootTest;
 import com.example.solidconnection.type.PreparationStatus;
 import com.example.solidconnection.type.Role;
-import com.example.solidconnection.util.JwtUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -35,19 +32,16 @@ class AuthServiceTest {
     @Autowired
     private SiteUserRepository siteUserRepository;
 
-    @Autowired
-    private JwtProperties jwtProperties;
-
     @Test
     void 로그아웃한다() {
         // given
-        String accessToken = "accessToken";
+        AccessToken accessToken = new AccessToken("subject", "accessToken");
 
         // when
         authService.signOut(accessToken);
 
         // then
-        assertThat(authTokenProvider.findBlackListToken(accessToken)).isNotNull();
+        assertThat(authTokenProvider.isTokenBlacklisted(accessToken.token())).isTrue();
     }
 
     @Test
@@ -67,26 +61,25 @@ class AuthServiceTest {
     class 토큰을_재발급한다 {
 
         @Test
-        void 요청의_리프레시_토큰이_저장되어_있고_값이_일치면_액세스_토큰을_재발급한다() {
+        void 요청의_리프레시_토큰이_저장되어_있으면_액세스_토큰을_재발급한다() {
             // given
-            SiteUser siteUser = createSiteUser();
-            String refreshToken = authTokenProvider.generateAndSaveRefreshToken(siteUser);
-            ReissueRequest reissueRequest = new ReissueRequest(refreshToken);
+            RefreshToken refreshToken = authTokenProvider.generateAndSaveRefreshToken(new Subject("subject"));
+            ReissueRequest reissueRequest = new ReissueRequest(refreshToken.token());
 
             // when
             ReissueResponse reissuedAccessToken = authService.reissue(reissueRequest);
 
-            // then
-            String actualSubject = JwtUtils.parseSubject(reissuedAccessToken.accessToken(), jwtProperties.secret());
-            String expectedSubject = JwtUtils.parseSubject(refreshToken, jwtProperties.secret());
+            // then - 요청의 리프레시 토큰과 재발급한 액세스 토큰의 subject 가 동일해야 한다.
+            Subject expectedSubject = authTokenProvider.parseSubject(refreshToken.token());
+            Subject actualSubject = authTokenProvider.parseSubject(reissuedAccessToken.accessToken());
             assertThat(actualSubject).isEqualTo(expectedSubject);
         }
 
         @Test
         void 요청의_리프레시_토큰이_저장되어있지_않다면_예외_응답을_반환한다() {
             // given
-            String refreshToken = authTokenProvider.generateToken("subject", TokenType.REFRESH);
-            ReissueRequest reissueRequest = new ReissueRequest(refreshToken);
+            String invalidRefreshToken = authTokenProvider.generateAccessToken(new Subject("subject")).token();
+            ReissueRequest reissueRequest = new ReissueRequest(invalidRefreshToken);
 
             // when, then
             assertThatCode(() -> authService.reissue(reissueRequest))

--- a/src/test/java/com/example/solidconnection/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/example/solidconnection/auth/service/AuthServiceTest.java
@@ -35,7 +35,7 @@ class AuthServiceTest {
     @Test
     void 로그아웃한다() {
         // given
-        AccessToken accessToken = new AccessToken("subject", "accessToken");
+        AccessToken accessToken = authTokenProvider.generateAccessToken(new Subject("subject")); // todo: #296
 
         // when
         authService.signOut(accessToken);

--- a/src/test/java/com/example/solidconnection/custom/security/filter/SignOutCheckFilterTest.java
+++ b/src/test/java/com/example/solidconnection/custom/security/filter/SignOutCheckFilterTest.java
@@ -59,8 +59,8 @@ class SignOutCheckFilterTest {
         // given
         String token = createToken(subject);
         request = createRequest(token);
-        String refreshTokenKey = BLACKLIST.addPrefix(token);
-        redisTemplate.opsForValue().set(refreshTokenKey, "signOut");
+        String refreshTokenKey = BLACKLIST.addPrefix(subject);
+        redisTemplate.opsForValue().set(refreshTokenKey, token);
 
         // when & then
         assertThatCode(() -> signOutCheckFilter.doFilterInternal(request, response, filterChain))


### PR DESCRIPTION
## 관련 이슈

- resolves: #293 

## 작업 내용
**1/ Subject, AccessToken, RefreshToken 객체 생성**
- 처음엔 Token 클래스를 만들어 모든곳에 쓸까 싶었지만,
   어떤 종류인지에 따라서 명확하게 관리 로직이 달라지고, 토큰의 종류도 늘어날 것 같지 않아 각각 만들어주었다.
- TokenProvider 외부에서 토큰과 관련된 로직을 수행할 때는, 반드시 이 객체들의 형식을 사용하게 했다.
   우리가 사용하는 토큰이 jwt 토큰이라는 구체적인 기술에 대한 정보를 숨기고, 자바 객체를 사용하게 하여 객체지향적인 코드로 만들었다.

**2/ AuthTokenProvider의 함수 시그니처 변경** 
- 의미가 잘 전달되도록, 함수 시그니처를 변경했다.
  `Optional<String> findRefreshToken → boolean isValidRefreshToken()`
  `Optional<String> findBlackListoken → boolean isTokenBlacklisted()`

**3/ 스프링 시큐리티 필터가 서비스단을 의존하는 것 해결** 
- 기존에는 SignOutCheckFilter가 블랙리스트 체크를 위해 AuthTokenProvider를 직접 의존하고 있었다.
   DIP위반을 해결하기 위해, 블랙리스트 체크를 위한 인터페이스를 만들고 거기에 의존하도록 바꿨다.
![image](https://github.com/user-attachments/assets/a7eb38d9-ec00-47e5-96aa-bb428f128579)

**4/ 블랙리스트 저장 방법 변경 (!피드백 필요!)** 
- AS-IS
  - key : "BLACKLIST:" + accessToken
  - value : accessToken을 subject로 하여 만든 토큰 
  - 블랙리스트 확인 방법 : "BLACKLIST:" + accessToken에 해당하는 값이 있는지
- 하지만 이는 prefix + subject를 키로 하는 다른 토큰의 저장 방식과 달라서 인지 부조화가 왔다.. 나중에 실수할 것 같았다😱
- TO-BE
  - key : "BLACKLIST:" + subject
  - value : accessToken
  - 블랙리스트 확인 방법 : 토큰의 subject를 추출하여 "BLACKLIST:" + subject을 만든 다음, 저장된 값이 현재의 토큰과 일치하는지

## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

- 새로운 이슈 발견 #296
  왜 사람들이 상속이나 util이 아니라 조합을 쓰라는지 확실히 알게되었습니다 👵🏻
- 클래스가 늘어남에 따라 패키지가 100% fit하진 않게 되었는데요, auth 부분 리팩터링 후 한번에 수정하겠습니다.

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
