### PR TITLE
refactor: 로그아웃, 탈퇴 시 refresh 토큰을 삭제하도록

### DIFF
--- a/src/main/java/com/example/solidconnection/auth/controller/AuthController.java
+++ b/src/main/java/com/example/solidconnection/auth/controller/AuthController.java
@@ -97,10 +97,7 @@ public class AuthController {
     public ResponseEntity<Void> signOut(
             Authentication authentication
     ) {
-        String accessToken = (String) authentication.getCredentials();
-        if (accessToken == null || accessToken.isBlank()) {
-            throw new CustomException(ErrorCode.AUTHENTICATION_FAILED, "토큰이 없습니다.");
-        }
+        String accessToken = getAccessToken(authentication);
         authService.signOut(accessToken);
         return ResponseEntity.ok().build();
     }
@@ -108,12 +105,9 @@ public class AuthController {
     @PatchMapping("/quit")
     public ResponseEntity<Void> quit(
             @AuthorizedUser SiteUser siteUser,
-            Authentication authentication
+            Authentication authentication // todo: #299를 작업하며 인자를 (Authentication authentication)만 받도록 수정해야 함
     ) {
-        String accessToken = (String) authentication.getCredentials();
-        if (accessToken == null || accessToken.isBlank()) {
-            throw new CustomException(ErrorCode.AUTHENTICATION_FAILED, "토큰이 없습니다.");
-        }
+        String accessToken = getAccessToken(authentication);
         authService.quit(siteUser, accessToken);
         return ResponseEntity.ok().build();
     }
@@ -124,5 +118,12 @@ public class AuthController {
     ) {
         ReissueResponse reissueResponse = authService.reissue(reissueRequest);
         return ResponseEntity.ok(reissueResponse);
+    }
+
+    private String getAccessToken(Authentication authentication) {
+        if (authentication == null || !(authentication.getCredentials() instanceof String accessToken)) {
+            throw new CustomException(ErrorCode.AUTHENTICATION_FAILED, "엑세스 토큰이 없습니다.");
+        }
+        return accessToken;
     }
 }

--- a/src/main/java/com/example/solidconnection/auth/controller/AuthController.java
+++ b/src/main/java/com/example/solidconnection/auth/controller/AuthController.java
@@ -107,9 +107,14 @@ public class AuthController {
 
     @PatchMapping("/quit")
     public ResponseEntity<Void> quit(
-            @AuthorizedUser SiteUser siteUser
+            @AuthorizedUser SiteUser siteUser,
+            Authentication authentication
     ) {
-        authService.quit(siteUser);
+        String accessToken = (String) authentication.getCredentials();
+        if (accessToken == null || accessToken.isBlank()) {
+            throw new CustomException(ErrorCode.AUTHENTICATION_FAILED, "토큰이 없습니다.");
+        }
+        authService.quit(siteUser, accessToken);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/example/solidconnection/auth/service/AuthService.java
+++ b/src/main/java/com/example/solidconnection/auth/service/AuthService.java
@@ -19,8 +19,9 @@ public class AuthService {
     private final AuthTokenProvider authTokenProvider;
 
     /*
-     * 로그아웃 한다.
+     * 로그아웃한다.
      * - 엑세스 토큰을 블랙리스트에 추가한다.
+     * - 리프레시 토큰을 삭제한다.
      * */
     public void signOut(String token) {
         AccessToken accessToken = authTokenProvider.toAccessToken(token);
@@ -32,11 +33,13 @@ public class AuthService {
      * 탈퇴한다.
      * - 탈퇴한 시점의 다음날을 탈퇴일로 잡는다.
      * - e.g. 2024-01-01 18:00 탈퇴 시, 2024-01-02 00:00 가 탈퇴일이 된다.
+     * - 로그아웃한다.
      * */
     @Transactional
-    public void quit(SiteUser siteUser) {
+    public void quit(SiteUser siteUser, String token) { // todo: #299를 작업하며 인자를 (String token)만 받도록 수정해야 함
         LocalDate tomorrow = LocalDate.now().plusDays(1);
         siteUser.setQuitedAt(tomorrow);
+        signOut(token);
     }
 
     /*

--- a/src/main/java/com/example/solidconnection/auth/service/AuthService.java
+++ b/src/main/java/com/example/solidconnection/auth/service/AuthService.java
@@ -24,6 +24,7 @@ public class AuthService {
      * */
     public void signOut(String token) {
         AccessToken accessToken = authTokenProvider.toAccessToken(token);
+        authTokenProvider.deleteRefreshTokenByAccessToken(accessToken);
         authTokenProvider.addToBlacklist(accessToken);
     }
 

--- a/src/main/java/com/example/solidconnection/auth/service/AuthTokenProvider.java
+++ b/src/main/java/com/example/solidconnection/auth/service/AuthTokenProvider.java
@@ -49,6 +49,12 @@ public class AuthTokenProvider extends TokenProvider implements BlacklistChecker
         return Objects.equals(requestedRefreshToken, foundRefreshToken);
     }
 
+    public void deleteRefreshTokenByAccessToken(AccessToken accessToken) {
+        String subject = accessToken.subject().value();
+        String refreshTokenKey = TokenType.REFRESH.addPrefix(subject);
+        redisTemplate.delete(refreshTokenKey);
+    }
+
     @Override
     public boolean isTokenBlacklisted(String accessToken) {
         String blackListTokenKey = TokenType.BLACKLIST.addPrefix(accessToken);

--- a/src/test/java/com/example/solidconnection/auth/service/AuthTokenProviderTest.java
+++ b/src/test/java/com/example/solidconnection/auth/service/AuthTokenProviderTest.java
@@ -69,6 +69,20 @@ class AuthTokenProviderTest {
                     () -> assertThat(authTokenProvider.isValidRefreshToken(fakeRefreshToken.token())).isFalse()
             );
         }
+
+        @Test
+        void 액세서_토큰에_해당하는_리프레시_토큰을_삭제한다() {
+            // given
+            authTokenProvider.generateAndSaveRefreshToken(subject);
+            AccessToken accessToken = authTokenProvider.generateAccessToken(subject);
+
+            // when
+            authTokenProvider.deleteRefreshTokenByAccessToken(accessToken);
+
+            // then
+            String refreshTokenKey = TokenType.REFRESH.addPrefix(subject.value());
+            assertThat(redisTemplate.opsForValue().get(refreshTokenKey)).isNull();
+        }
     }
 
     @Nested


### PR DESCRIPTION
## 관련 이슈

- resolves: #298
- resolves: #99 

## 작업 내용

- 로그아웃 시, 엑세스 토큰에 해당하는 리프레시 토큰을 redis 로부터 삭제합니다.
- 탈퇴 시, 로그아웃합니다. 
  - 리프레시 토큰 삭제
  - 액세스 토큰을 블랙리스트에 추가

![image](https://github.com/user-attachments/assets/7127099f-e4c3-481a-928e-142585b3cedc)


## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

https://github.com/solid-connection/solid-connect-server/pull/297#pullrequestreview-2821601660 에서 이야기된 것처럼,
Authentication 으로부터 String accessToken을 추출하는것은 중복 코드가 2곳 뿐이며,
auth 패키지 이외에는 이 로직이 사용되는 곳이 없을 것이기에 ArgumentResolver로 만드는것은 과하다 생각했습니다.
그래서 우선은 private 메서드를 만들어주었습니다.

+) TODO 부분도 빠르게 작업해보겠습니다 🏃‍♀️🏃‍♀️

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
