### PR TITLE
refactor: 대학(추천, 좋아요) 통합 테스트 데이터 Fixture 메서드로 변경

### DIFF
--- a/src/test/java/com/example/solidconnection/university/service/GeneralUniversityRecommendServiceTest.java
+++ b/src/test/java/com/example/solidconnection/university/service/GeneralUniversityRecommendServiceTest.java
@@ -1,8 +1,9 @@
 package com.example.solidconnection.university.service;
 
 import com.example.solidconnection.support.TestContainerSpringBootTest;
-import com.example.solidconnection.support.integration.BaseIntegrationTest;
 import com.example.solidconnection.university.domain.UniversityInfoForApply;
+import com.example.solidconnection.university.fixture.UniversityInfoForApplyFixture;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,20 +15,37 @@ import static com.example.solidconnection.university.service.UniversityRecommend
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-@DisplayName("공통 추천 대학 서비스 테스트")
 @TestContainerSpringBootTest
-class GeneralUniversityRecommendServiceTest extends BaseIntegrationTest {
+@DisplayName("공통 추천 대학 서비스 테스트")
+class GeneralUniversityRecommendServiceTest {
 
     @Autowired
     private GeneralUniversityRecommendService generalUniversityRecommendService;
 
+    @Autowired
+    private UniversityInfoForApplyFixture universityInfoForApplyFixture;
+
     @Value("${university.term}")
     private String term;
+
+    @BeforeEach
+    void setUp() {
+        universityInfoForApplyFixture.괌대학_A_지원_정보();
+        universityInfoForApplyFixture.괌대학_B_지원_정보();
+        universityInfoForApplyFixture.네바다주립대학_라스베이거스_지원_정보();
+        universityInfoForApplyFixture.메모리얼대학_세인트존스_A_지원_정보();
+        universityInfoForApplyFixture.서던덴마크대학교_지원_정보();
+        universityInfoForApplyFixture.코펜하겐IT대학_지원_정보();
+        universityInfoForApplyFixture.그라츠대학_지원_정보();
+        universityInfoForApplyFixture.그라츠공과대학_지원_정보();
+        universityInfoForApplyFixture.린츠_카톨릭대학_지원_정보();
+        universityInfoForApplyFixture.메이지대학_지원_정보();
+        generalUniversityRecommendService.init();
+    }
 
     @Test
     void 모집_시기의_대학들_중에서_랜덤하게_N개를_추천_목록으로_구성한다() {
         // given
-        generalUniversityRecommendService.init();
         List<UniversityInfoForApply> universities = generalUniversityRecommendService.getRecommendUniversities();
 
         // when & then

--- a/src/test/java/com/example/solidconnection/university/service/UniversityLikeServiceTest.java
+++ b/src/test/java/com/example/solidconnection/university/service/UniversityLikeServiceTest.java
@@ -4,13 +4,15 @@ import com.example.solidconnection.custom.exception.CustomException;
 import com.example.solidconnection.siteuser.domain.SiteUser;
 import com.example.solidconnection.siteuser.repository.LikedUniversityRepository;
 import com.example.solidconnection.siteuser.repository.SiteUserRepository;
-import com.example.solidconnection.support.integration.BaseIntegrationTest;
+import com.example.solidconnection.support.TestContainerSpringBootTest;
 import com.example.solidconnection.type.PreparationStatus;
 import com.example.solidconnection.type.Role;
 import com.example.solidconnection.university.domain.LikedUniversity;
 import com.example.solidconnection.university.domain.UniversityInfoForApply;
 import com.example.solidconnection.university.dto.IsLikeResponse;
 import com.example.solidconnection.university.dto.LikeResultResponse;
+import com.example.solidconnection.university.fixture.UniversityInfoForApplyFixture;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -25,8 +27,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+@TestContainerSpringBootTest
 @DisplayName("대학교 좋아요 서비스 테스트")
-class UniversityLikeServiceTest extends BaseIntegrationTest {
+class UniversityLikeServiceTest {
 
     @Autowired
     private UniversityLikeService universityLikeService;
@@ -37,14 +40,23 @@ class UniversityLikeServiceTest extends BaseIntegrationTest {
     @Autowired
     private SiteUserRepository siteUserRepository;
 
+    @Autowired
+    private UniversityInfoForApplyFixture universityInfoForApplyFixture;
+
+    private SiteUser testUser;
+    private UniversityInfoForApply 괌대학_A_지원_정보;
+
+    @BeforeEach
+    void setUp() {
+        testUser = createSiteUser();
+        괌대학_A_지원_정보 = universityInfoForApplyFixture.괌대학_A_지원_정보();
+    }
+
     @Nested
     class 대학_좋아요를_등록한다 {
 
         @Test
         void 성공적으로_좋아요를_등록한다() {
-            // given
-            SiteUser testUser = createSiteUser();
-
             // when
             LikeResultResponse response = universityLikeService.likeUniversity(testUser, 괌대학_A_지원_정보.getId());
 
@@ -60,7 +72,6 @@ class UniversityLikeServiceTest extends BaseIntegrationTest {
         @Test
         void 이미_좋아요한_대학이면_예외_응답을_반환한다() {
             // given
-            SiteUser testUser = createSiteUser();
             saveLikedUniversity(testUser, 괌대학_A_지원_정보);
 
             // when & then
@@ -76,7 +87,6 @@ class UniversityLikeServiceTest extends BaseIntegrationTest {
         @Test
         void 성공적으로_좋아요를_취소한다() {
             // given
-            SiteUser testUser = createSiteUser();
             saveLikedUniversity(testUser, 괌대학_A_지원_정보);
 
             // when
@@ -93,9 +103,6 @@ class UniversityLikeServiceTest extends BaseIntegrationTest {
 
         @Test
         void 좋아요하지_않은_대학이면_예외_응답을_반환한다() {
-            // given
-            SiteUser testUser = createSiteUser();
-
             // when & then
             assertThatCode(() -> universityLikeService.cancelLikeUniversity(testUser, 괌대학_A_지원_정보.getId()))
                     .isInstanceOf(CustomException.class)
@@ -106,7 +113,6 @@ class UniversityLikeServiceTest extends BaseIntegrationTest {
     @Test
     void 존재하지_않는_대학_좋아요_시도하면_예외_응답을_반환한다() {
         // given
-        SiteUser testUser = createSiteUser();
         Long invalidUniversityId = 9999L;
 
         // when & then
@@ -118,7 +124,6 @@ class UniversityLikeServiceTest extends BaseIntegrationTest {
     @Test
     void 좋아요한_대학인지_확인한다() {
         // given
-        SiteUser testUser = createSiteUser();
         saveLikedUniversity(testUser, 괌대학_A_지원_정보);
 
         // when
@@ -130,9 +135,6 @@ class UniversityLikeServiceTest extends BaseIntegrationTest {
 
     @Test
     void 좋아요하지_않은_대학인지_확인한다() {
-        // given
-        SiteUser testUser = createSiteUser();
-
         // when
         IsLikeResponse response = universityLikeService.getIsLiked(testUser, 괌대학_A_지원_정보.getId());
 
@@ -143,7 +145,6 @@ class UniversityLikeServiceTest extends BaseIntegrationTest {
     @Test
     void 존재하지_않는_대학의_좋아요_여부를_조회하면_예외_응답을_반환한다() {
         // given
-        SiteUser testUser = createSiteUser();
         Long invalidUniversityId = 9999L;
 
         // when & then
@@ -152,6 +153,7 @@ class UniversityLikeServiceTest extends BaseIntegrationTest {
                 .hasMessage(UNIVERSITY_INFO_FOR_APPLY_NOT_FOUND.getMessage());
     }
 
+    // todo : 추후 Fixture로 대체 필요
     private SiteUser createSiteUser() {
         SiteUser siteUser = new SiteUser(
                 "test@example.com",

--- a/src/test/java/com/example/solidconnection/university/service/UniversityRecommendServiceTest.java
+++ b/src/test/java/com/example/solidconnection/university/service/UniversityRecommendServiceTest.java
@@ -1,16 +1,20 @@
 package com.example.solidconnection.university.service;
 
+import com.example.solidconnection.country.fixture.CountryFixture;
 import com.example.solidconnection.entity.InterestedCountry;
 import com.example.solidconnection.entity.InterestedRegion;
+import com.example.solidconnection.region.fixture.RegionFixture;
 import com.example.solidconnection.repositories.InterestedCountyRepository;
 import com.example.solidconnection.repositories.InterestedRegionRepository;
 import com.example.solidconnection.siteuser.domain.SiteUser;
 import com.example.solidconnection.siteuser.repository.SiteUserRepository;
-import com.example.solidconnection.support.integration.BaseIntegrationTest;
+import com.example.solidconnection.support.TestContainerSpringBootTest;
 import com.example.solidconnection.type.PreparationStatus;
 import com.example.solidconnection.type.Role;
+import com.example.solidconnection.university.domain.UniversityInfoForApply;
 import com.example.solidconnection.university.dto.UniversityInfoForApplyPreviewResponse;
 import com.example.solidconnection.university.dto.UniversityRecommendsResponse;
+import com.example.solidconnection.university.fixture.UniversityInfoForApplyFixture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -21,8 +25,9 @@ import java.util.List;
 import static com.example.solidconnection.university.service.UniversityRecommendService.RECOMMEND_UNIVERSITY_NUM;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@TestContainerSpringBootTest
 @DisplayName("대학교 추천 서비스 테스트")
-class UniversityRecommendServiceTest extends BaseIntegrationTest {
+class UniversityRecommendServiceTest {
 
     @Autowired
     private UniversityRecommendService universityRecommendService;
@@ -39,16 +44,47 @@ class UniversityRecommendServiceTest extends BaseIntegrationTest {
     @Autowired
     private GeneralUniversityRecommendService generalUniversityRecommendService;
 
+    @Autowired
+    private RegionFixture regionFixture;
+
+    @Autowired
+    private CountryFixture countryFixture;
+
+    @Autowired
+    private UniversityInfoForApplyFixture universityInfoForApplyFixture;
+
+    private SiteUser testUser;
+    private UniversityInfoForApply 괌대학_A_지원_정보;
+    private UniversityInfoForApply 괌대학_B_지원_정보;
+    private UniversityInfoForApply 네바다주립대학_라스베이거스_지원_정보;
+    private UniversityInfoForApply 메모리얼대학_세인트존스_A_지원_정보;
+    private UniversityInfoForApply 서던덴마크대학교_지원_정보;
+    private UniversityInfoForApply 코펜하겐IT대학_지원_정보;
+    private UniversityInfoForApply 그라츠대학_지원_정보;
+    private UniversityInfoForApply 그라츠공과대학_지원_정보;
+    private UniversityInfoForApply 린츠_카톨릭대학_지원_정보;
+    private UniversityInfoForApply 메이지대학_지원_정보;
+
     @BeforeEach
     void setUp() {
+        testUser = createSiteUser();
+        괌대학_A_지원_정보 = universityInfoForApplyFixture.괌대학_A_지원_정보();
+        괌대학_B_지원_정보 = universityInfoForApplyFixture.괌대학_B_지원_정보();
+        네바다주립대학_라스베이거스_지원_정보 = universityInfoForApplyFixture.네바다주립대학_라스베이거스_지원_정보();
+        메모리얼대학_세인트존스_A_지원_정보 = universityInfoForApplyFixture.메모리얼대학_세인트존스_A_지원_정보();
+        서던덴마크대학교_지원_정보 = universityInfoForApplyFixture.서던덴마크대학교_지원_정보();
+        코펜하겐IT대학_지원_정보 = universityInfoForApplyFixture.코펜하겐IT대학_지원_정보();
+        그라츠대학_지원_정보 = universityInfoForApplyFixture.그라츠대학_지원_정보();
+        그라츠공과대학_지원_정보 = universityInfoForApplyFixture.그라츠공과대학_지원_정보();
+        린츠_카톨릭대학_지원_정보 = universityInfoForApplyFixture.린츠_카톨릭대학_지원_정보();
+        메이지대학_지원_정보 = universityInfoForApplyFixture.메이지대학_지원_정보();
         generalUniversityRecommendService.init();
     }
 
     @Test
     void 관심_지역_설정한_사용자의_맞춤_추천_대학을_조회한다() {
         // given
-        SiteUser testUser = createSiteUser();
-        interestedRegionRepository.save(new InterestedRegion(testUser, 영미권));
+        interestedRegionRepository.save(new InterestedRegion(testUser, regionFixture.영미권()));
 
         // when
         UniversityRecommendsResponse response = universityRecommendService.getPersonalRecommends(testUser);
@@ -67,8 +103,7 @@ class UniversityRecommendServiceTest extends BaseIntegrationTest {
     @Test
     void 관심_국가_설정한_사용자의_맞춤_추천_대학을_조회한다() {
         // given
-        SiteUser testUser = createSiteUser();
-        interestedCountyRepository.save(new InterestedCountry(testUser, 덴마크));
+        interestedCountyRepository.save(new InterestedCountry(testUser, countryFixture.덴마크()));
 
         // when
         UniversityRecommendsResponse response = universityRecommendService.getPersonalRecommends(testUser);
@@ -85,9 +120,8 @@ class UniversityRecommendServiceTest extends BaseIntegrationTest {
     @Test
     void 관심_지역과_국가_모두_설정한_사용자의_맞춤_추천_대학을_조회한다() {
         // given
-        SiteUser testUser = createSiteUser();
-        interestedRegionRepository.save(new InterestedRegion(testUser, 영미권));
-        interestedCountyRepository.save(new InterestedCountry(testUser, 덴마크));
+        interestedRegionRepository.save(new InterestedRegion(testUser, regionFixture.영미권()));
+        interestedCountyRepository.save(new InterestedCountry(testUser, countryFixture.덴마크()));
 
         // when
         UniversityRecommendsResponse response = universityRecommendService.getPersonalRecommends(testUser);
@@ -107,9 +141,6 @@ class UniversityRecommendServiceTest extends BaseIntegrationTest {
 
     @Test
     void 관심사_미설정_사용자는_일반_추천_대학을_조회한다() {
-        // given
-        SiteUser testUser = createSiteUser();
-
         // when
         UniversityRecommendsResponse response = universityRecommendService.getPersonalRecommends(testUser);
 
@@ -138,6 +169,7 @@ class UniversityRecommendServiceTest extends BaseIntegrationTest {
                 );
     }
 
+    // todo : 추후 Fixture로 대체 필요
     private SiteUser createSiteUser() {
         SiteUser siteUser = new SiteUser(
                 "test@example.com",


### PR DESCRIPTION
## 관련 이슈

- resolves: #312

## 작업 내용

기존 BaseIntegrationTest로 생성하던 테스트 데이터를 Fixture 메서드로 생성하도록 변경하였습니다.

## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

## 리뷰 요구사항 (선택)

추천 관련 통합테스트는 모든 대학들을 세팅해주는 게 좋은 거 같은데 어떻게 생각하시나요? 

generalUniversityRecommendService.init(); 이거 호출 전에 테스트 데이터가 6개 이상 없으면 바로 Out of Range 터지더라구요 그래서 BeforeEach로 지금 한 번에 생성해주고 있긴한데 더 좋은 방식이 있을까요? 🥲