### PR TITLE
refactor: 유저 관련 통합 테스트 데이터 fixture 메서드로 변경

### DIFF
--- a/src/test/java/com/example/solidconnection/admin/service/AdminGpaScoreServiceTest.java
+++ b/src/test/java/com/example/solidconnection/admin/service/AdminGpaScoreServiceTest.java
@@ -9,10 +9,8 @@ import com.example.solidconnection.custom.exception.CustomException;
 import com.example.solidconnection.score.domain.GpaScore;
 import com.example.solidconnection.score.repository.GpaScoreRepository;
 import com.example.solidconnection.siteuser.domain.SiteUser;
-import com.example.solidconnection.siteuser.repository.SiteUserRepository;
+import com.example.solidconnection.siteuser.fixture.SiteUserFixture;
 import com.example.solidconnection.support.integration.BaseIntegrationTest;
-import com.example.solidconnection.type.PreparationStatus;
-import com.example.solidconnection.type.Role;
 import com.example.solidconnection.type.VerifyStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -38,26 +36,23 @@ class AdminGpaScoreServiceTest extends BaseIntegrationTest {
     private AdminGpaScoreService adminGpaScoreService;
 
     @Autowired
-    private SiteUserRepository siteUserRepository;
-
-    @Autowired
     private GpaScoreRepository gpaScoreRepository;
 
-    private SiteUser siteUser1;
-    private SiteUser siteUser2;
-    private SiteUser siteUser3;
+    @Autowired
+    private SiteUserFixture siteUserFixture;
+
     private GpaScore gpaScore1;
     private GpaScore gpaScore2;
     private GpaScore gpaScore3;
 
     @BeforeEach
     void setUp() {
-        siteUser1 = createSiteUser(1, "test1");
-        siteUser2 = createSiteUser(2, "test2");
-        siteUser3 = createSiteUser(3, "test3");
-        gpaScore3 = createGpaScore(siteUser3, VerifyStatus.REJECTED);
-        gpaScore2 = createGpaScore(siteUser2, VerifyStatus.PENDING);
-        gpaScore1 = createGpaScore(siteUser1, VerifyStatus.PENDING);
+        SiteUser 테스트_유저_1 = siteUserFixture.테스트_유저(1, "test1");
+        SiteUser 테스트_유저_2 = siteUserFixture.테스트_유저(2, "test2");
+        SiteUser 테스트_유저_3 = siteUserFixture.테스트_유저(3, "test3");
+        gpaScore3 = createGpaScore(테스트_유저_3, VerifyStatus.REJECTED);
+        gpaScore2 = createGpaScore(테스트_유저_2, VerifyStatus.PENDING);
+        gpaScore1 = createGpaScore(테스트_유저_1, VerifyStatus.PENDING);
     }
 
     @Nested
@@ -207,17 +202,6 @@ class AdminGpaScoreServiceTest extends BaseIntegrationTest {
                     .isInstanceOf(CustomException.class)
                     .hasMessage(GPA_SCORE_NOT_FOUND.getMessage());
         }
-    }
-
-    private SiteUser createSiteUser(int index, String nickname) {
-        SiteUser siteUser = new SiteUser(
-                "test" + index + " @example.com",
-                nickname,
-                "profileImageUrl",
-                PreparationStatus.CONSIDERING,
-                Role.MENTEE
-        );
-        return siteUserRepository.save(siteUser);
     }
 
     private GpaScore createGpaScore(SiteUser siteUser, VerifyStatus status) {

--- a/src/test/java/com/example/solidconnection/admin/service/AdminGpaScoreServiceTest.java
+++ b/src/test/java/com/example/solidconnection/admin/service/AdminGpaScoreServiceTest.java
@@ -47,12 +47,12 @@ class AdminGpaScoreServiceTest extends BaseIntegrationTest {
 
     @BeforeEach
     void setUp() {
-        SiteUser 테스트_유저_1 = siteUserFixture.테스트_유저(1, "test1");
-        SiteUser 테스트_유저_2 = siteUserFixture.테스트_유저(2, "test2");
-        SiteUser 테스트_유저_3 = siteUserFixture.테스트_유저(3, "test3");
-        gpaScore3 = createGpaScore(테스트_유저_3, VerifyStatus.REJECTED);
-        gpaScore2 = createGpaScore(테스트_유저_2, VerifyStatus.PENDING);
-        gpaScore1 = createGpaScore(테스트_유저_1, VerifyStatus.PENDING);
+        SiteUser user1 = siteUserFixture.사용자(1, "test1");
+        SiteUser user2 = siteUserFixture.사용자(2, "test2");
+        SiteUser user3 = siteUserFixture.사용자(3, "test3");
+        gpaScore3 = createGpaScore(user3, VerifyStatus.REJECTED);
+        gpaScore2 = createGpaScore(user2, VerifyStatus.PENDING);
+        gpaScore1 = createGpaScore(user1, VerifyStatus.PENDING);
     }
 
     @Nested

--- a/src/test/java/com/example/solidconnection/admin/service/AdminLanguageTestScoreServiceTest.java
+++ b/src/test/java/com/example/solidconnection/admin/service/AdminLanguageTestScoreServiceTest.java
@@ -48,12 +48,12 @@ class AdminLanguageTestScoreServiceTest extends BaseIntegrationTest {
 
     @BeforeEach
     void setUp() {
-        SiteUser 테스트_유저_1 = siteUserFixture.테스트_유저(1, "test1");
-        SiteUser 테스트_유저_2 = siteUserFixture.테스트_유저(2, "test2");
-        SiteUser 테스트_유저_3 = siteUserFixture.테스트_유저(3, "test3");
-        languageTestScore3 = createLanguageTestScore(테스트_유저_3, VerifyStatus.REJECTED);
-        languageTestScore2 = createLanguageTestScore(테스트_유저_2, VerifyStatus.PENDING);
-        languageTestScore1 = createLanguageTestScore(테스트_유저_1, VerifyStatus.PENDING);
+        SiteUser user1 = siteUserFixture.사용자(1, "test1");
+        SiteUser user2 = siteUserFixture.사용자(2, "test2");
+        SiteUser user3 = siteUserFixture.사용자(3, "test3");
+        languageTestScore3 = createLanguageTestScore(user3, VerifyStatus.REJECTED);
+        languageTestScore2 = createLanguageTestScore(user2, VerifyStatus.PENDING);
+        languageTestScore1 = createLanguageTestScore(user1, VerifyStatus.PENDING);
     }
 
     @Nested

--- a/src/test/java/com/example/solidconnection/admin/service/AdminLanguageTestScoreServiceTest.java
+++ b/src/test/java/com/example/solidconnection/admin/service/AdminLanguageTestScoreServiceTest.java
@@ -9,10 +9,8 @@ import com.example.solidconnection.custom.exception.CustomException;
 import com.example.solidconnection.score.domain.LanguageTestScore;
 import com.example.solidconnection.score.repository.LanguageTestScoreRepository;
 import com.example.solidconnection.siteuser.domain.SiteUser;
-import com.example.solidconnection.siteuser.repository.SiteUserRepository;
+import com.example.solidconnection.siteuser.fixture.SiteUserFixture;
 import com.example.solidconnection.support.integration.BaseIntegrationTest;
-import com.example.solidconnection.type.PreparationStatus;
-import com.example.solidconnection.type.Role;
 import com.example.solidconnection.type.VerifyStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -39,26 +37,23 @@ class AdminLanguageTestScoreServiceTest extends BaseIntegrationTest {
     private AdminLanguageTestScoreService adminLanguageTestScoreService;
 
     @Autowired
-    private SiteUserRepository siteUserRepository;
-
-    @Autowired
     private LanguageTestScoreRepository languageTestScoreRepository;
 
-    private SiteUser siteUser1;
-    private SiteUser siteUser2;
-    private SiteUser siteUser3;
+    @Autowired
+    private SiteUserFixture siteUserFixture;
+
     private LanguageTestScore languageTestScore1;
     private LanguageTestScore languageTestScore2;
     private LanguageTestScore languageTestScore3;
 
     @BeforeEach
     void setUp() {
-        siteUser1 = createSiteUser(1, "test1");
-        siteUser2 = createSiteUser(2, "test2");
-        siteUser3 = createSiteUser(3, "test3");
-        languageTestScore3 = createLanguageTestScore(siteUser3, VerifyStatus.REJECTED);
-        languageTestScore2 = createLanguageTestScore(siteUser2, VerifyStatus.PENDING);
-        languageTestScore1 = createLanguageTestScore(siteUser1, VerifyStatus.PENDING);
+        SiteUser 테스트_유저_1 = siteUserFixture.테스트_유저(1, "test1");
+        SiteUser 테스트_유저_2 = siteUserFixture.테스트_유저(2, "test2");
+        SiteUser 테스트_유저_3 = siteUserFixture.테스트_유저(3, "test3");
+        languageTestScore3 = createLanguageTestScore(테스트_유저_3, VerifyStatus.REJECTED);
+        languageTestScore2 = createLanguageTestScore(테스트_유저_2, VerifyStatus.PENDING);
+        languageTestScore1 = createLanguageTestScore(테스트_유저_1, VerifyStatus.PENDING);
     }
 
     @Nested
@@ -217,17 +212,6 @@ class AdminLanguageTestScoreServiceTest extends BaseIntegrationTest {
                     .isInstanceOf(CustomException.class)
                     .hasMessage(LANGUAGE_TEST_SCORE_NOT_FOUND.getMessage());
         }
-    }
-
-    private SiteUser createSiteUser(int index, String nickname) {
-        SiteUser siteUser = new SiteUser(
-                "test" + index + " @example.com",
-                nickname,
-                "profileImageUrl",
-                PreparationStatus.CONSIDERING,
-                Role.MENTEE
-        );
-        return siteUserRepository.save(siteUser);
     }
 
     private LanguageTestScore createLanguageTestScore(SiteUser siteUser, VerifyStatus status) {

--- a/src/test/java/com/example/solidconnection/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/example/solidconnection/auth/service/AuthServiceTest.java
@@ -56,18 +56,18 @@ class AuthServiceTest {
     @Test
     void 탈퇴한다() {
         // given
-        SiteUser 테스트_유저 = siteUserFixture.테스트_유저();
-        Subject subject = authTokenProvider.toSubject(테스트_유저);
+        SiteUser user = siteUserFixture.사용자();
+        Subject subject = authTokenProvider.toSubject(user);
         AccessToken accessToken = authTokenProvider.generateAccessToken(subject); // todo: #296
 
         // when
-        authService.quit(테스트_유저, accessToken.token());
+        authService.quit(user, accessToken.token());
 
         // then
         LocalDate tomorrow = LocalDate.now().plusDays(1);
         String refreshTokenKey = TokenType.REFRESH.addPrefix(subject.value());
         assertAll(
-                () -> assertThat(테스트_유저.getQuitedAt()).isEqualTo(tomorrow),
+                () -> assertThat(user.getQuitedAt()).isEqualTo(tomorrow),
                 () -> assertThat(redisTemplate.opsForValue().get(refreshTokenKey)).isNull(),
                 () -> assertThat(authTokenProvider.isTokenBlacklisted(accessToken.token())).isTrue()
         );

--- a/src/test/java/com/example/solidconnection/auth/service/EmailSignInServiceTest.java
+++ b/src/test/java/com/example/solidconnection/auth/service/EmailSignInServiceTest.java
@@ -31,8 +31,8 @@ class EmailSignInServiceTest {
         // given
         String email = "testEmail";
         String rawPassword = "testPassword";
-        SiteUser siteUser = siteUserFixture.테스트_유저(email, rawPassword);
-        EmailSignInRequest signInRequest = new EmailSignInRequest(siteUser.getEmail(), rawPassword);
+        SiteUser user = siteUserFixture.사용자(email, rawPassword);
+        EmailSignInRequest signInRequest = new EmailSignInRequest(user.getEmail(), rawPassword);
 
         // when
         SignInResponse signInResponse = emailSignInService.signIn(signInRequest);
@@ -62,7 +62,7 @@ class EmailSignInServiceTest {
         void 비밀번호가_일치하지_않으면_예외_응답을_반환한다() {
             // given
             String email = "testEmail";
-            siteUserFixture.테스트_유저(email, "testPassword");
+            siteUserFixture.사용자(email, "testPassword");
             EmailSignInRequest signInRequest = new EmailSignInRequest(email, "틀린비밀번호");
 
             // when & then

--- a/src/test/java/com/example/solidconnection/auth/service/EmailSignInServiceTest.java
+++ b/src/test/java/com/example/solidconnection/auth/service/EmailSignInServiceTest.java
@@ -4,18 +4,14 @@ import com.example.solidconnection.auth.dto.EmailSignInRequest;
 import com.example.solidconnection.auth.dto.SignInResponse;
 import com.example.solidconnection.custom.exception.CustomException;
 import com.example.solidconnection.custom.exception.ErrorCode;
-import com.example.solidconnection.siteuser.domain.AuthType;
 import com.example.solidconnection.siteuser.domain.SiteUser;
-import com.example.solidconnection.siteuser.repository.SiteUserRepository;
+import com.example.solidconnection.siteuser.fixture.SiteUserFixture;
 import com.example.solidconnection.support.TestContainerSpringBootTest;
-import com.example.solidconnection.type.PreparationStatus;
-import com.example.solidconnection.type.Role;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.crypto.password.PasswordEncoder;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -28,18 +24,14 @@ class EmailSignInServiceTest {
     private EmailSignInService emailSignInService;
 
     @Autowired
-    private SiteUserRepository siteUserRepository;
-
-    @Autowired
-    private PasswordEncoder passwordEncoder;
+    private SiteUserFixture siteUserFixture;
 
     @Test
     void 로그인에_성공한다() {
         // given
         String email = "testEmail";
         String rawPassword = "testPassword";
-        SiteUser siteUser = createSiteUser(email, rawPassword);
-        siteUserRepository.save(siteUser);
+        SiteUser siteUser = siteUserFixture.테스트_유저(email, rawPassword);
         EmailSignInRequest signInRequest = new EmailSignInRequest(siteUser.getEmail(), rawPassword);
 
         // when
@@ -70,8 +62,7 @@ class EmailSignInServiceTest {
         void 비밀번호가_일치하지_않으면_예외_응답을_반환한다() {
             // given
             String email = "testEmail";
-            SiteUser siteUser = createSiteUser(email, "testPassword");
-            siteUserRepository.save(siteUser);
+            siteUserFixture.테스트_유저(email, "testPassword");
             EmailSignInRequest signInRequest = new EmailSignInRequest(email, "틀린비밀번호");
 
             // when & then
@@ -79,18 +70,5 @@ class EmailSignInServiceTest {
                     .isInstanceOf(CustomException.class)
                     .hasMessageContaining(ErrorCode.USER_NOT_FOUND.getMessage());
         }
-    }
-
-    private SiteUser createSiteUser(String email, String rawPassword) {
-        String encodedPassword = passwordEncoder.encode(rawPassword);
-        return new SiteUser(
-                email,
-                "nickname",
-                "profileImageUrl",
-                PreparationStatus.CONSIDERING,
-                Role.MENTEE,
-                AuthType.EMAIL,
-                encodedPassword
-        );
     }
 }

--- a/src/test/java/com/example/solidconnection/auth/service/SignInServiceTest.java
+++ b/src/test/java/com/example/solidconnection/auth/service/SignInServiceTest.java
@@ -34,19 +34,19 @@ class SignInServiceTest {
     @Autowired
     private SiteUserFixture siteUserFixture;
 
-    private SiteUser 테스트_유저;
+    private SiteUser user;
     private String subject;
 
     @BeforeEach
     void setUp() {
-        테스트_유저 = siteUserFixture.테스트_유저();
-        subject = 테스트_유저.getId().toString();
+        user = siteUserFixture.사용자();
+        subject = user.getId().toString();
     }
 
     @Test
     void 성공적으로_로그인한다() {
         // when
-        SignInResponse signInResponse = signInService.signIn(테스트_유저);
+        SignInResponse signInResponse = signInService.signIn(user);
 
         // then
         String accessTokenSubject = JwtUtils.parseSubject(signInResponse.accessToken(), jwtProperties.secret());
@@ -61,12 +61,12 @@ class SignInServiceTest {
     @Test
     void 탈퇴한_이력이_있으면_초기화한다() {
         // given
-        테스트_유저.setQuitedAt(LocalDate.now().minusDays(1));
+        user.setQuitedAt(LocalDate.now().minusDays(1));
 
         // when
-        signInService.signIn(테스트_유저);
+        signInService.signIn(user);
 
         // then
-        assertThat(테스트_유저.getQuitedAt()).isNull();
+        assertThat(user.getQuitedAt()).isNull();
     }
 }

--- a/src/test/java/com/example/solidconnection/auth/service/SignInServiceTest.java
+++ b/src/test/java/com/example/solidconnection/auth/service/SignInServiceTest.java
@@ -4,10 +4,8 @@ import com.example.solidconnection.auth.domain.TokenType;
 import com.example.solidconnection.auth.dto.SignInResponse;
 import com.example.solidconnection.config.security.JwtProperties;
 import com.example.solidconnection.siteuser.domain.SiteUser;
-import com.example.solidconnection.siteuser.repository.SiteUserRepository;
+import com.example.solidconnection.siteuser.fixture.SiteUserFixture;
 import com.example.solidconnection.support.TestContainerSpringBootTest;
-import com.example.solidconnection.type.PreparationStatus;
-import com.example.solidconnection.type.Role;
 import com.example.solidconnection.util.JwtUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -31,28 +29,24 @@ class SignInServiceTest {
     private JwtProperties jwtProperties;
 
     @Autowired
-    private AuthTokenProvider authTokenProvider;
-
-    @Autowired
-    private SiteUserRepository siteUserRepository;
-
-    @Autowired
     private RedisTemplate<String, String> redisTemplate;
 
-    private SiteUser siteUser;
+    @Autowired
+    private SiteUserFixture siteUserFixture;
+
+    private SiteUser 테스트_유저;
     private String subject;
 
     @BeforeEach
     void setUp() {
-        siteUser = createSiteUser();
-        siteUserRepository.save(siteUser);
-        subject = siteUser.getId().toString();
+        테스트_유저 = siteUserFixture.테스트_유저();
+        subject = 테스트_유저.getId().toString();
     }
 
     @Test
     void 성공적으로_로그인한다() {
         // when
-        SignInResponse signInResponse = signInService.signIn(siteUser);
+        SignInResponse signInResponse = signInService.signIn(테스트_유저);
 
         // then
         String accessTokenSubject = JwtUtils.parseSubject(signInResponse.accessToken(), jwtProperties.secret());
@@ -67,23 +61,12 @@ class SignInServiceTest {
     @Test
     void 탈퇴한_이력이_있으면_초기화한다() {
         // given
-        siteUser.setQuitedAt(LocalDate.now().minusDays(1));
-        siteUserRepository.save(siteUser);
+        테스트_유저.setQuitedAt(LocalDate.now().minusDays(1));
 
         // when
-        signInService.signIn(siteUser);
+        signInService.signIn(테스트_유저);
 
         // then
-        assertThat(siteUser.getQuitedAt()).isNull();
-    }
-
-    private SiteUser createSiteUser() {
-        return new SiteUser(
-                "test@example.com",
-                "nickname",
-                "profileImageUrl",
-                PreparationStatus.CONSIDERING,
-                Role.MENTEE
-        );
+        assertThat(테스트_유저.getQuitedAt()).isNull();
     }
 }

--- a/src/test/java/com/example/solidconnection/community/post/service/PostLikeServiceTest.java
+++ b/src/test/java/com/example/solidconnection/community/post/service/PostLikeServiceTest.java
@@ -8,8 +8,10 @@ import com.example.solidconnection.community.post.dto.PostLikeResponse;
 import com.example.solidconnection.community.post.repository.PostLikeRepository;
 import com.example.solidconnection.community.post.repository.PostRepository;
 import com.example.solidconnection.siteuser.domain.SiteUser;
+import com.example.solidconnection.siteuser.fixture.SiteUserFixture;
 import com.example.solidconnection.support.integration.BaseIntegrationTest;
 import com.example.solidconnection.type.PostCategory;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -33,18 +35,28 @@ class PostLikeServiceTest extends BaseIntegrationTest {
     @Autowired
     private PostLikeRepository postLikeRepository;
 
+    @Autowired
+    private SiteUserFixture siteUserFixture;
+
+    private SiteUser user;
+
+    @BeforeEach
+    void setUp() {
+        user = siteUserFixture.사용자(1, "test1");
+    }
+
     @Nested
     class 게시글_좋아요_테스트 {
 
         @Test
         void 게시글을_성공적으로_좋아요한다() {
             // given
-            Post testPost = createPost(자유게시판, 테스트유저_1);
+            Post testPost = createPost(자유게시판, user);
             long beforeLikeCount = testPost.getLikeCount();
 
             // when
             PostLikeResponse response = postLikeService.likePost(
-                    테스트유저_1,
+                    user,
                     testPost.getId()
             );
 
@@ -54,20 +66,20 @@ class PostLikeServiceTest extends BaseIntegrationTest {
                     () -> assertThat(response.likeCount()).isEqualTo(beforeLikeCount + 1),
                     () -> assertThat(response.isLiked()).isTrue(),
                     () -> assertThat(likedPost.getLikeCount()).isEqualTo(beforeLikeCount + 1),
-                    () -> assertThat(postLikeRepository.findPostLikeByPostAndSiteUser(likedPost, 테스트유저_1)).isPresent()
+                    () -> assertThat(postLikeRepository.findPostLikeByPostAndSiteUser(likedPost, user)).isPresent()
             );
         }
 
         @Test
         void 이미_좋아요한_게시글을_다시_좋아요하면_예외_응답을_반환한다() {
             // given
-            Post testPost = createPost(자유게시판, 테스트유저_1);
-            postLikeService.likePost(테스트유저_1,  testPost.getId());
+            Post testPost = createPost(자유게시판, user);
+            postLikeService.likePost(user,  testPost.getId());
 
             // when & then
             assertThatThrownBy(() ->
                     postLikeService.likePost(
-                            테스트유저_1,
+                            user,
                             testPost.getId()
                     ))
                     .isInstanceOf(CustomException.class)
@@ -81,13 +93,13 @@ class PostLikeServiceTest extends BaseIntegrationTest {
         @Test
         void 게시글_좋아요를_성공적으로_취소한다() {
             // given
-            Post testPost = createPost(자유게시판, 테스트유저_1);
-            PostLikeResponse beforeResponse = postLikeService.likePost(테스트유저_1,  testPost.getId());
+            Post testPost = createPost(자유게시판, user);
+            PostLikeResponse beforeResponse = postLikeService.likePost(user,  testPost.getId());
             long beforeLikeCount = beforeResponse.likeCount();
 
             // when
             PostDislikeResponse response = postLikeService.dislikePost(
-                    테스트유저_1,
+                    user,
                     testPost.getId()
             );
 
@@ -97,19 +109,19 @@ class PostLikeServiceTest extends BaseIntegrationTest {
                     () -> assertThat(response.likeCount()).isEqualTo(beforeLikeCount - 1),
                     () -> assertThat(response.isLiked()).isFalse(),
                     () -> assertThat(unlikedPost.getLikeCount()).isEqualTo(beforeLikeCount - 1),
-                    () -> assertThat(postLikeRepository.findPostLikeByPostAndSiteUser(unlikedPost, 테스트유저_1)).isEmpty()
+                    () -> assertThat(postLikeRepository.findPostLikeByPostAndSiteUser(unlikedPost, user)).isEmpty()
             );
         }
 
         @Test
         void 좋아요하지_않은_게시글을_좋아요_취소하면_예외_응답을_반환한다() {
             // given
-            Post testPost = createPost(자유게시판, 테스트유저_1);
+            Post testPost = createPost(자유게시판, user);
 
             // when & then
             assertThatThrownBy(() ->
                     postLikeService.dislikePost(
-                            테스트유저_1,
+                            user,
                             testPost.getId()
                     ))
                     .isInstanceOf(CustomException.class)

--- a/src/test/java/com/example/solidconnection/community/post/service/PostQueryServiceTest.java
+++ b/src/test/java/com/example/solidconnection/community/post/service/PostQueryServiceTest.java
@@ -13,10 +13,12 @@ import com.example.solidconnection.community.post.repository.PostRepository;
 import com.example.solidconnection.community.post.repository.PostImageRepository;
 import com.example.solidconnection.service.RedisService;
 import com.example.solidconnection.siteuser.domain.SiteUser;
+import com.example.solidconnection.siteuser.fixture.SiteUserFixture;
 import com.example.solidconnection.support.integration.BaseIntegrationTest;
 import com.example.solidconnection.type.BoardCode;
 import com.example.solidconnection.type.PostCategory;
 import com.example.solidconnection.util.RedisUtils;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -47,6 +49,16 @@ class PostQueryServiceTest extends BaseIntegrationTest {
 
     @Autowired
     private PostImageRepository postImageRepository;
+
+    @Autowired
+    private SiteUserFixture siteUserFixture;
+
+    private SiteUser user;
+
+    @BeforeEach
+    void setUp() {
+        user = siteUserFixture.사용자(1, "test1");
+    }
 
     @Test
     void 게시판_코드와_카테고리로_게시글_목록을_조회한다() {
@@ -103,15 +115,15 @@ class PostQueryServiceTest extends BaseIntegrationTest {
         // given
         String expectedImageUrl = "test-image-url";
         List<String> imageUrls = List.of(expectedImageUrl);
-        Post testPost = createPost(자유게시판, 테스트유저_1, expectedImageUrl);
-        List<Comment> comments = createComments(testPost, 테스트유저_1, List.of("첫번째 댓글", "두번째 댓글"));
+        Post testPost = createPost(자유게시판, user, expectedImageUrl);
+        List<Comment> comments = createComments(testPost, user, List.of("첫번째 댓글", "두번째 댓글"));
 
-        String validateKey = redisUtils.getValidatePostViewCountRedisKey(테스트유저_1.getId(), testPost.getId());
+        String validateKey = redisUtils.getValidatePostViewCountRedisKey(user.getId(), testPost.getId());
         String viewCountKey = redisUtils.getPostViewCountRedisKey(testPost.getId());
 
         // when
         PostFindResponse response = postQueryService.findPostById(
-                테스트유저_1,
+                user,
                 testPost.getId()
         );
 
@@ -128,9 +140,9 @@ class PostQueryServiceTest extends BaseIntegrationTest {
                 () -> assertThat(response.postFindBoardResponse().code()).isEqualTo(자유게시판.getCode()),
                 () -> assertThat(response.postFindBoardResponse().koreanName()).isEqualTo(자유게시판.getKoreanName()),
 
-                () -> assertThat(response.postFindSiteUserResponse().id()).isEqualTo(테스트유저_1.getId()),
-                () -> assertThat(response.postFindSiteUserResponse().nickname()).isEqualTo(테스트유저_1.getNickname()),
-                () -> assertThat(response.postFindSiteUserResponse().profileImageUrl()).isEqualTo(테스트유저_1.getProfileImageUrl()),
+                () -> assertThat(response.postFindSiteUserResponse().id()).isEqualTo(user.getId()),
+                () -> assertThat(response.postFindSiteUserResponse().nickname()).isEqualTo(user.getNickname()),
+                () -> assertThat(response.postFindSiteUserResponse().profileImageUrl()).isEqualTo(user.getProfileImageUrl()),
 
                 () -> assertThat(response.postFindPostImageResponses())
                         .hasSize(imageUrls.size())

--- a/src/test/java/com/example/solidconnection/concurrency/PostLikeCountConcurrencyTest.java
+++ b/src/test/java/com/example/solidconnection/concurrency/PostLikeCountConcurrencyTest.java
@@ -52,14 +52,14 @@ class PostLikeCountConcurrencyTest {
 
     private Post post;
     private Board board;
-    private SiteUser 테스트_유저;
+    private SiteUser user;
 
     @BeforeEach
     void setUp() {
         board = createBoard();
         boardRepository.save(board);
-        테스트_유저 = siteUserFixture.테스트_유저();
-        post = createPost(board, 테스트_유저);
+        user = siteUserFixture.사용자();
+        post = createPost(board, user);
         postRepository.save(post);
     }
 

--- a/src/test/java/com/example/solidconnection/concurrency/PostLikeCountConcurrencyTest.java
+++ b/src/test/java/com/example/solidconnection/concurrency/PostLikeCountConcurrencyTest.java
@@ -6,11 +6,10 @@ import com.example.solidconnection.community.post.domain.Post;
 import com.example.solidconnection.community.post.repository.PostRepository;
 import com.example.solidconnection.community.post.service.PostLikeService;
 import com.example.solidconnection.siteuser.domain.SiteUser;
+import com.example.solidconnection.siteuser.fixture.SiteUserFixture;
 import com.example.solidconnection.siteuser.repository.SiteUserRepository;
 import com.example.solidconnection.support.TestContainerSpringBootTest;
 import com.example.solidconnection.type.PostCategory;
-import com.example.solidconnection.type.PreparationStatus;
-import com.example.solidconnection.type.Role;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -31,41 +30,37 @@ class PostLikeCountConcurrencyTest {
 
     @Autowired
     private PostLikeService postLikeService;
+
     @Autowired
     private PostRepository postRepository;
+
     @Autowired
     private BoardRepository boardRepository;
+
     @Autowired
     private SiteUserRepository siteUserRepository;
 
+    @Autowired
+    private SiteUserFixture siteUserFixture;
+
     @Value("${view.count.scheduling.delay}")
     private int SCHEDULING_DELAY_MS;
+
     private int THREAD_NUMS = 1000;
     private int THREAD_POOL_SIZE = 200;
     private int TIMEOUT_SECONDS = 10;
 
     private Post post;
     private Board board;
-    private SiteUser siteUser;
+    private SiteUser 테스트_유저;
 
     @BeforeEach
     void setUp() {
         board = createBoard();
         boardRepository.save(board);
-        siteUser = createSiteUser();
-        siteUserRepository.save(siteUser);
-        post = createPost(board, siteUser);
+        테스트_유저 = siteUserFixture.테스트_유저();
+        post = createPost(board, 테스트_유저);
         postRepository.save(post);
-    }
-
-    private SiteUser createSiteUser() {
-        return new SiteUser(
-                "test@example.com",
-                "nickname",
-                "profileImageUrl",
-                PreparationStatus.CONSIDERING,
-                Role.MENTEE
-        );
     }
 
     private Board createBoard() {

--- a/src/test/java/com/example/solidconnection/concurrency/PostViewCountConcurrencyTest.java
+++ b/src/test/java/com/example/solidconnection/concurrency/PostViewCountConcurrencyTest.java
@@ -52,14 +52,14 @@ class PostViewCountConcurrencyTest {
 
     private Post post;
     private Board board;
-    private SiteUser 테스트_유저;
+    private SiteUser user;
 
     @BeforeEach
     void setUp() {
         board = createBoard();
         boardRepository.save(board);
-        테스트_유저 = siteUserFixture.테스트_유저();
-        post = createPost(board, 테스트_유저);
+        user = siteUserFixture.사용자();
+        post = createPost(board, user);
         postRepository.save(post);
     }
 
@@ -85,7 +85,7 @@ class PostViewCountConcurrencyTest {
     @Test
     void 게시글을_조회할_때_조회수_동시성_문제를_해결한다() throws InterruptedException {
 
-        redisService.deleteKey(redisUtils.getValidatePostViewCountRedisKey(테스트_유저.getId(), post.getId()));
+        redisService.deleteKey(redisUtils.getValidatePostViewCountRedisKey(user.getId(), post.getId()));
 
         ExecutorService executorService = Executors.newFixedThreadPool(THREAD_POOL_SIZE);
         CountDownLatch doneSignal = new CountDownLatch(THREAD_NUMS);
@@ -115,7 +115,7 @@ class PostViewCountConcurrencyTest {
     @Test
     void 게시글을_조회할_때_조회수_조작_문제를_해결한다() throws InterruptedException {
 
-        redisService.deleteKey(redisUtils.getValidatePostViewCountRedisKey(테스트_유저.getId(), post.getId()));
+        redisService.deleteKey(redisUtils.getValidatePostViewCountRedisKey(user.getId(), post.getId()));
 
         ExecutorService executorService = Executors.newFixedThreadPool(THREAD_POOL_SIZE);
         CountDownLatch doneSignal = new CountDownLatch(THREAD_NUMS);
@@ -123,7 +123,7 @@ class PostViewCountConcurrencyTest {
         for (int i = 0; i < THREAD_NUMS; i++) {
             executorService.submit(() -> {
                 try {
-                    boolean isFirstTime = redisService.isPresent(redisUtils.getValidatePostViewCountRedisKey(테스트_유저.getId(), post.getId()));
+                    boolean isFirstTime = redisService.isPresent(redisUtils.getValidatePostViewCountRedisKey(user.getId(), post.getId()));
                     if (isFirstTime) {
                         redisService.increaseViewCount(redisUtils.getPostViewCountRedisKey(post.getId()));
                     }
@@ -136,7 +136,7 @@ class PostViewCountConcurrencyTest {
         for (int i = 0; i < THREAD_NUMS; i++) {
             executorService.submit(() -> {
                 try {
-                    boolean isFirstTime = redisService.isPresent(redisUtils.getValidatePostViewCountRedisKey(테스트_유저.getId(), post.getId()));
+                    boolean isFirstTime = redisService.isPresent(redisUtils.getValidatePostViewCountRedisKey(user.getId(), post.getId()));
                     if (isFirstTime) {
                         redisService.increaseViewCount(redisUtils.getPostViewCountRedisKey(post.getId()));
                     }

--- a/src/test/java/com/example/solidconnection/concurrency/ThunderingHerdTest.java
+++ b/src/test/java/com/example/solidconnection/concurrency/ThunderingHerdTest.java
@@ -34,11 +34,11 @@ class ThunderingHerdTest {
     private int THREAD_NUMS = 1000;
     private int THREAD_POOL_SIZE = 200;
     private int TIMEOUT_SECONDS = 10;
-    private SiteUser 테스트_유저;
+    private SiteUser user;
 
     @BeforeEach
     public void setUp() {
-        테스트_유저 = siteUserFixture.테스트_유저();
+        user = siteUserFixture.사용자();
     }
 
     @Test
@@ -54,9 +54,9 @@ class ThunderingHerdTest {
             executorService.submit(() -> {
                 try {
                     List<Runnable> tasks = Arrays.asList(
-                            () -> applicationQueryService.getApplicants(테스트_유저, "", ""),
-                            () -> applicationQueryService.getApplicants(테스트_유저, "ASIA", ""),
-                            () -> applicationQueryService.getApplicants(테스트_유저, "", "추오")
+                            () -> applicationQueryService.getApplicants(user, "", ""),
+                            () -> applicationQueryService.getApplicants(user, "ASIA", ""),
+                            () -> applicationQueryService.getApplicants(user, "", "추오")
                     );
                     Collections.shuffle(tasks);
                     tasks.forEach(Runnable::run);

--- a/src/test/java/com/example/solidconnection/concurrency/ThunderingHerdTest.java
+++ b/src/test/java/com/example/solidconnection/concurrency/ThunderingHerdTest.java
@@ -2,10 +2,8 @@ package com.example.solidconnection.concurrency;
 
 import com.example.solidconnection.application.service.ApplicationQueryService;
 import com.example.solidconnection.siteuser.domain.SiteUser;
-import com.example.solidconnection.siteuser.repository.SiteUserRepository;
+import com.example.solidconnection.siteuser.fixture.SiteUserFixture;
 import com.example.solidconnection.support.TestContainerSpringBootTest;
-import com.example.solidconnection.type.PreparationStatus;
-import com.example.solidconnection.type.Role;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -22,32 +20,25 @@ import java.util.concurrent.TimeUnit;
 
 @TestContainerSpringBootTest
 @DisplayName("ThunderingHerd 테스트")
-public class ThunderingHerdTest {
+class ThunderingHerdTest {
+
     @Autowired
     private ApplicationQueryService applicationQueryService;
+
     @Autowired
     private RedisTemplate<String, Object> redisTemplate;
+
     @Autowired
-    private SiteUserRepository siteUserRepository;
+    private SiteUserFixture siteUserFixture;
+
     private int THREAD_NUMS = 1000;
     private int THREAD_POOL_SIZE = 200;
     private int TIMEOUT_SECONDS = 10;
-    private SiteUser siteUser;
+    private SiteUser 테스트_유저;
 
     @BeforeEach
     public void setUp() {
-        siteUser = createSiteUser();
-        siteUserRepository.save(siteUser);
-    }
-
-    private SiteUser createSiteUser() {
-        return new SiteUser(
-                "test@example.com",
-                "nickname",
-                "profileImageUrl",
-                PreparationStatus.CONSIDERING,
-                Role.MENTEE
-        );
+        테스트_유저 = siteUserFixture.테스트_유저();
     }
 
     @Test
@@ -63,9 +54,9 @@ public class ThunderingHerdTest {
             executorService.submit(() -> {
                 try {
                     List<Runnable> tasks = Arrays.asList(
-                            () -> applicationQueryService.getApplicants(siteUser, "", ""),
-                            () -> applicationQueryService.getApplicants(siteUser, "ASIA", ""),
-                            () -> applicationQueryService.getApplicants(siteUser, "", "추오")
+                            () -> applicationQueryService.getApplicants(테스트_유저, "", ""),
+                            () -> applicationQueryService.getApplicants(테스트_유저, "ASIA", ""),
+                            () -> applicationQueryService.getApplicants(테스트_유저, "", "추오")
                     );
                     Collections.shuffle(tasks);
                     tasks.forEach(Runnable::run);

--- a/src/test/java/com/example/solidconnection/custom/resolver/AuthorizedUserResolverTest.java
+++ b/src/test/java/com/example/solidconnection/custom/resolver/AuthorizedUserResolverTest.java
@@ -1,14 +1,11 @@
 package com.example.solidconnection.custom.resolver;
 
-
 import com.example.solidconnection.custom.exception.CustomException;
 import com.example.solidconnection.custom.security.authentication.SiteUserAuthentication;
 import com.example.solidconnection.custom.security.userdetails.SiteUserDetails;
 import com.example.solidconnection.siteuser.domain.SiteUser;
-import com.example.solidconnection.siteuser.repository.SiteUserRepository;
+import com.example.solidconnection.siteuser.fixture.SiteUserFixture;
 import com.example.solidconnection.support.TestContainerSpringBootTest;
-import com.example.solidconnection.type.PreparationStatus;
-import com.example.solidconnection.type.Role;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -32,7 +29,7 @@ class AuthorizedUserResolverTest {
     private AuthorizedUserResolver authorizedUserResolver;
 
     @Autowired
-    private SiteUserRepository siteUserRepository;
+    private SiteUserFixture siteUserFixture;
 
     @BeforeEach
     void setUp() {
@@ -42,8 +39,8 @@ class AuthorizedUserResolverTest {
     @Test
     void security_context_에_저장된_인증된_사용자를_반환한다() {
         // given
-        SiteUser siteUser = createAndSaveSiteUser();
-        Authentication authentication = createAuthenticationWithUser(siteUser);
+        SiteUser 테스트_유저 = siteUserFixture.테스트_유저();
+        Authentication authentication = createAuthenticationWithUser(테스트_유저);
         SecurityContextHolder.getContext().setAuthentication(authentication);
 
         MethodParameter parameter = mock(MethodParameter.class);
@@ -55,7 +52,7 @@ class AuthorizedUserResolverTest {
         SiteUser resolveSiteUser = (SiteUser) authorizedUserResolver.resolveArgument(parameter, null, null, null);
 
         // then
-        assertThat(resolveSiteUser).isEqualTo(siteUser);
+        assertThat(resolveSiteUser).isEqualTo(테스트_유저);
     }
 
     @Nested
@@ -88,17 +85,6 @@ class AuthorizedUserResolverTest {
                     authorizedUserResolver.resolveArgument(parameter, null, null, null)
             ).isNull();
         }
-    }
-
-    private SiteUser createAndSaveSiteUser() {
-        SiteUser siteUser = new SiteUser(
-                "test@example.com",
-                "nickname",
-                "profileImageUrl",
-                PreparationStatus.CONSIDERING,
-                Role.MENTEE
-        );
-        return siteUserRepository.save(siteUser);
     }
 
     private SiteUserAuthentication createAuthenticationWithUser(SiteUser siteUser) {

--- a/src/test/java/com/example/solidconnection/custom/resolver/AuthorizedUserResolverTest.java
+++ b/src/test/java/com/example/solidconnection/custom/resolver/AuthorizedUserResolverTest.java
@@ -39,8 +39,8 @@ class AuthorizedUserResolverTest {
     @Test
     void security_context_에_저장된_인증된_사용자를_반환한다() {
         // given
-        SiteUser 테스트_유저 = siteUserFixture.테스트_유저();
-        Authentication authentication = createAuthenticationWithUser(테스트_유저);
+        SiteUser user = siteUserFixture.사용자();
+        Authentication authentication = createAuthenticationWithUser(user);
         SecurityContextHolder.getContext().setAuthentication(authentication);
 
         MethodParameter parameter = mock(MethodParameter.class);
@@ -52,7 +52,7 @@ class AuthorizedUserResolverTest {
         SiteUser resolveSiteUser = (SiteUser) authorizedUserResolver.resolveArgument(parameter, null, null, null);
 
         // then
-        assertThat(resolveSiteUser).isEqualTo(테스트_유저);
+        assertThat(resolveSiteUser).isEqualTo(user);
     }
 
     @Nested

--- a/src/test/java/com/example/solidconnection/custom/security/aspect/AdminAuthorizationAspectTest.java
+++ b/src/test/java/com/example/solidconnection/custom/security/aspect/AdminAuthorizationAspectTest.java
@@ -29,10 +29,10 @@ class AdminAuthorizationAspectTest {
     @Test
     void 어드민_사용자는_어드민_전용_메소드에_접근할_수_있다() {
         // given
-        SiteUser 테스트_어드민 = siteUserFixture.테스트_어드민();
+        SiteUser admin = siteUserFixture.관리자();
 
         // when
-        boolean response = testService.adminOnlyMethod(테스트_어드민);
+        boolean response = testService.adminOnlyMethod(admin);
 
         // then
         assertThat(response).isTrue();
@@ -53,11 +53,11 @@ class AdminAuthorizationAspectTest {
     void 어드민_어노테이션이_없는_메소드는_모두_접근_가능하다() {
         // given
         SiteUser user = siteUserFixture.사용자();
-        SiteUser 테스트_어드민 = siteUserFixture.테스트_어드민();
+        SiteUser admin = siteUserFixture.관리자();
 
         // when
         boolean menteeResponse = testService.publicMethod(user);
-        boolean adminResponse = testService.publicMethod(테스트_어드민);
+        boolean adminResponse = testService.publicMethod(admin);
 
         // then
         assertThat(menteeResponse).isTrue();

--- a/src/test/java/com/example/solidconnection/custom/security/aspect/AdminAuthorizationAspectTest.java
+++ b/src/test/java/com/example/solidconnection/custom/security/aspect/AdminAuthorizationAspectTest.java
@@ -41,10 +41,10 @@ class AdminAuthorizationAspectTest {
     @Test
     void 일반_사용자가_어드민_전용_메소드에_접근하면_예외_응답을_반환한다() {
         // given
-        SiteUser 테스트_유저 = siteUserFixture.테스트_유저();
+        SiteUser user = siteUserFixture.사용자();
 
         // when & then
-        assertThatCode(() -> testService.adminOnlyMethod(테스트_유저))
+        assertThatCode(() -> testService.adminOnlyMethod(user))
                 .isInstanceOf(CustomException.class)
                 .hasMessage(ACCESS_DENIED.getMessage());
     }
@@ -52,11 +52,11 @@ class AdminAuthorizationAspectTest {
     @Test
     void 어드민_어노테이션이_없는_메소드는_모두_접근_가능하다() {
         // given
-        SiteUser 테스트_유저 = siteUserFixture.테스트_유저();
+        SiteUser user = siteUserFixture.사용자();
         SiteUser 테스트_어드민 = siteUserFixture.테스트_어드민();
 
         // when
-        boolean menteeResponse = testService.publicMethod(테스트_유저);
+        boolean menteeResponse = testService.publicMethod(user);
         boolean adminResponse = testService.publicMethod(테스트_어드민);
 
         // then

--- a/src/test/java/com/example/solidconnection/custom/security/aspect/AdminAuthorizationAspectTest.java
+++ b/src/test/java/com/example/solidconnection/custom/security/aspect/AdminAuthorizationAspectTest.java
@@ -3,9 +3,8 @@ package com.example.solidconnection.custom.security.aspect;
 import com.example.solidconnection.custom.exception.CustomException;
 import com.example.solidconnection.custom.security.annotation.RequireAdminAccess;
 import com.example.solidconnection.siteuser.domain.SiteUser;
+import com.example.solidconnection.siteuser.fixture.SiteUserFixture;
 import com.example.solidconnection.support.TestContainerSpringBootTest;
-import com.example.solidconnection.type.PreparationStatus;
-import com.example.solidconnection.type.Role;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,13 +23,16 @@ class AdminAuthorizationAspectTest {
     @Autowired
     private TestService testService;
 
+    @Autowired
+    private SiteUserFixture siteUserFixture;
+
     @Test
     void 어드민_사용자는_어드민_전용_메소드에_접근할_수_있다() {
         // given
-        SiteUser adminUser = createSiteUser(Role.ADMIN);
+        SiteUser 테스트_어드민 = siteUserFixture.테스트_어드민();
 
         // when
-        boolean response = testService.adminOnlyMethod(adminUser);
+        boolean response = testService.adminOnlyMethod(테스트_어드민);
 
         // then
         assertThat(response).isTrue();
@@ -39,10 +41,10 @@ class AdminAuthorizationAspectTest {
     @Test
     void 일반_사용자가_어드민_전용_메소드에_접근하면_예외_응답을_반환한다() {
         // given
-        SiteUser mentorUser = createSiteUser(Role.MENTOR);
+        SiteUser 테스트_유저 = siteUserFixture.테스트_유저();
 
         // when & then
-        assertThatCode(() -> testService.adminOnlyMethod(mentorUser))
+        assertThatCode(() -> testService.adminOnlyMethod(테스트_유저))
                 .isInstanceOf(CustomException.class)
                 .hasMessage(ACCESS_DENIED.getMessage());
     }
@@ -50,26 +52,16 @@ class AdminAuthorizationAspectTest {
     @Test
     void 어드민_어노테이션이_없는_메소드는_모두_접근_가능하다() {
         // given
-        SiteUser menteeUser = createSiteUser(Role.MENTEE);
-        SiteUser adminUser = createSiteUser(Role.ADMIN);
+        SiteUser 테스트_유저 = siteUserFixture.테스트_유저();
+        SiteUser 테스트_어드민 = siteUserFixture.테스트_어드민();
 
         // when
-        boolean menteeResponse = testService.publicMethod(menteeUser);
-        boolean adminResponse = testService.publicMethod(adminUser);
+        boolean menteeResponse = testService.publicMethod(테스트_유저);
+        boolean adminResponse = testService.publicMethod(테스트_어드민);
 
         // then
         assertThat(menteeResponse).isTrue();
         assertThat(adminResponse).isTrue();
-    }
-
-    private SiteUser createSiteUser(Role role) {
-        return new SiteUser(
-                "test@example.com",
-                "nickname",
-                "profileImageUrl",
-                PreparationStatus.CONSIDERING,
-                role
-        );
     }
 
     @TestConfiguration

--- a/src/test/java/com/example/solidconnection/custom/security/provider/SiteUserAuthenticationProviderTest.java
+++ b/src/test/java/com/example/solidconnection/custom/security/provider/SiteUserAuthenticationProviderTest.java
@@ -38,11 +38,11 @@ class SiteUserAuthenticationProviderTest {
     @Autowired
     private SiteUserFixture siteUserFixture;
 
-    private SiteUser 테스트_유저;
+    private SiteUser user;
 
     @BeforeEach
     void setUp() {
-        테스트_유저 = siteUserFixture.테스트_유저();
+        user = siteUserFixture.사용자();
     }
 
     @Test
@@ -61,7 +61,7 @@ class SiteUserAuthenticationProviderTest {
     @Test
     void 유효한_토큰이면_정상적으로_인증_정보를_반환한다() {
         // given
-        String token = createValidToken(테스트_유저.getId());
+        String token = createValidToken(user.getId());
         SiteUserAuthentication auth = new SiteUserAuthentication(token);
 
         // when
@@ -103,7 +103,7 @@ class SiteUserAuthenticationProviderTest {
         @Test
         void 유효한_토큰이지만_해당되는_사용자가_없으면_예외_응답을_반환한다() {
             // given
-            long notExistingUserId = 테스트_유저.getId() + 100;
+            long notExistingUserId = user.getId() + 100;
             String token = createValidToken(notExistingUserId);
             SiteUserAuthentication auth = new SiteUserAuthentication(token);
 
@@ -125,7 +125,7 @@ class SiteUserAuthenticationProviderTest {
 
     private String createExpiredToken() {
         return Jwts.builder()
-                .setSubject(String.valueOf(테스트_유저.getId()))
+                .setSubject(String.valueOf(user.getId()))
                 .setIssuedAt(new Date())
                 .setExpiration(new Date(System.currentTimeMillis() - 1000))
                 .signWith(SignatureAlgorithm.HS256, jwtProperties.secret())

--- a/src/test/java/com/example/solidconnection/custom/security/provider/SiteUserAuthenticationProviderTest.java
+++ b/src/test/java/com/example/solidconnection/custom/security/provider/SiteUserAuthenticationProviderTest.java
@@ -5,10 +5,8 @@ import com.example.solidconnection.custom.exception.CustomException;
 import com.example.solidconnection.custom.security.authentication.SiteUserAuthentication;
 import com.example.solidconnection.custom.security.userdetails.SiteUserDetails;
 import com.example.solidconnection.siteuser.domain.SiteUser;
-import com.example.solidconnection.siteuser.repository.SiteUserRepository;
+import com.example.solidconnection.siteuser.fixture.SiteUserFixture;
 import com.example.solidconnection.support.TestContainerSpringBootTest;
-import com.example.solidconnection.type.PreparationStatus;
-import com.example.solidconnection.type.Role;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import org.junit.jupiter.api.BeforeEach;
@@ -38,14 +36,13 @@ class SiteUserAuthenticationProviderTest {
     private JwtProperties jwtProperties;
 
     @Autowired
-    private SiteUserRepository siteUserRepository;
+    private SiteUserFixture siteUserFixture;
 
-    private SiteUser siteUser;
+    private SiteUser 테스트_유저;
 
     @BeforeEach
     void setUp() {
-        siteUser = createSiteUser();
-        siteUserRepository.save(siteUser);
+        테스트_유저 = siteUserFixture.테스트_유저();
     }
 
     @Test
@@ -64,7 +61,7 @@ class SiteUserAuthenticationProviderTest {
     @Test
     void 유효한_토큰이면_정상적으로_인증_정보를_반환한다() {
         // given
-        String token = createValidToken(siteUser.getId());
+        String token = createValidToken(테스트_유저.getId());
         SiteUserAuthentication auth = new SiteUserAuthentication(token);
 
         // when
@@ -106,7 +103,7 @@ class SiteUserAuthenticationProviderTest {
         @Test
         void 유효한_토큰이지만_해당되는_사용자가_없으면_예외_응답을_반환한다() {
             // given
-            long notExistingUserId = siteUser.getId() + 100;
+            long notExistingUserId = 테스트_유저.getId() + 100;
             String token = createValidToken(notExistingUserId);
             SiteUserAuthentication auth = new SiteUserAuthentication(token);
 
@@ -128,7 +125,7 @@ class SiteUserAuthenticationProviderTest {
 
     private String createExpiredToken() {
         return Jwts.builder()
-                .setSubject(String.valueOf(siteUser.getId()))
+                .setSubject(String.valueOf(테스트_유저.getId()))
                 .setIssuedAt(new Date())
                 .setExpiration(new Date(System.currentTimeMillis() - 1000))
                 .signWith(SignatureAlgorithm.HS256, jwtProperties.secret())
@@ -142,15 +139,5 @@ class SiteUserAuthenticationProviderTest {
                 .setExpiration(new Date(System.currentTimeMillis() + 1000))
                 .signWith(SignatureAlgorithm.HS256, jwtProperties.secret())
                 .compact();
-    }
-
-    private SiteUser createSiteUser() {
-        return new SiteUser(
-                "test@example.com",
-                "nickname",
-                "profileImageUrl",
-                PreparationStatus.CONSIDERING,
-                Role.MENTEE
-        );
     }
 }

--- a/src/test/java/com/example/solidconnection/custom/security/userdetails/SiteUserDetailsServiceTest.java
+++ b/src/test/java/com/example/solidconnection/custom/security/userdetails/SiteUserDetailsServiceTest.java
@@ -34,8 +34,8 @@ class SiteUserDetailsServiceTest {
     @Test
     void 사용자_인증_정보를_반환한다() {
         // given
-        SiteUser 테스트_유저 = siteUserFixture.테스트_유저();
-        String username = getUserName(테스트_유저);
+        SiteUser user = siteUserFixture.사용자();
+        String username = getUserName(user);
 
         // when
         SiteUserDetails userDetails = (SiteUserDetails) userDetailsService.loadUserByUsername(username);
@@ -43,7 +43,7 @@ class SiteUserDetailsServiceTest {
         // then
         assertAll(
                 () -> assertThat(userDetails.getUsername()).isEqualTo(username),
-                () -> assertThat(userDetails.getSiteUser()).extracting("id").isEqualTo(테스트_유저.getId())
+                () -> assertThat(userDetails.getSiteUser()).extracting("id").isEqualTo(user.getId())
         );
     }
 
@@ -75,10 +75,10 @@ class SiteUserDetailsServiceTest {
         @Test
         void 탈퇴한_사용자이면_예외_응답을_반환한다() {
             // given
-            SiteUser 테스트_유저 = siteUserFixture.테스트_유저();
-            테스트_유저.setQuitedAt(LocalDate.now());
-            siteUserRepository.save(테스트_유저);
-            String username = getUserName(테스트_유저);
+            SiteUser user = siteUserFixture.사용자();
+            user.setQuitedAt(LocalDate.now());
+            siteUserRepository.save(user);
+            String username = getUserName(user);
 
             // when & then
             assertThatCode(() -> userDetailsService.loadUserByUsername(username))

--- a/src/test/java/com/example/solidconnection/custom/security/userdetails/SiteUserDetailsServiceTest.java
+++ b/src/test/java/com/example/solidconnection/custom/security/userdetails/SiteUserDetailsServiceTest.java
@@ -2,10 +2,9 @@ package com.example.solidconnection.custom.security.userdetails;
 
 import com.example.solidconnection.custom.exception.CustomException;
 import com.example.solidconnection.siteuser.domain.SiteUser;
+import com.example.solidconnection.siteuser.fixture.SiteUserFixture;
 import com.example.solidconnection.siteuser.repository.SiteUserRepository;
 import com.example.solidconnection.support.TestContainerSpringBootTest;
-import com.example.solidconnection.type.PreparationStatus;
-import com.example.solidconnection.type.Role;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -27,13 +26,16 @@ class SiteUserDetailsServiceTest {
     private SiteUserDetailsService userDetailsService;
 
     @Autowired
+    private SiteUserFixture siteUserFixture;
+
+    @Autowired
     private SiteUserRepository siteUserRepository;
 
     @Test
     void 사용자_인증_정보를_반환한다() {
         // given
-        SiteUser siteUser = siteUserRepository.save(createSiteUser());
-        String username = getUserName(siteUser);
+        SiteUser 테스트_유저 = siteUserFixture.테스트_유저();
+        String username = getUserName(테스트_유저);
 
         // when
         SiteUserDetails userDetails = (SiteUserDetails) userDetailsService.loadUserByUsername(username);
@@ -41,7 +43,7 @@ class SiteUserDetailsServiceTest {
         // then
         assertAll(
                 () -> assertThat(userDetails.getUsername()).isEqualTo(username),
-                () -> assertThat(userDetails.getSiteUser()).extracting("id").isEqualTo(siteUser.getId())
+                () -> assertThat(userDetails.getSiteUser()).extracting("id").isEqualTo(테스트_유저.getId())
         );
     }
 
@@ -73,26 +75,16 @@ class SiteUserDetailsServiceTest {
         @Test
         void 탈퇴한_사용자이면_예외_응답을_반환한다() {
             // given
-            SiteUser siteUser = createSiteUser();
-            siteUser.setQuitedAt(LocalDate.now());
-            siteUserRepository.save(siteUser);
-            String username = getUserName(siteUser);
+            SiteUser 테스트_유저 = siteUserFixture.테스트_유저();
+            테스트_유저.setQuitedAt(LocalDate.now());
+            siteUserRepository.save(테스트_유저);
+            String username = getUserName(테스트_유저);
 
             // when & then
             assertThatCode(() -> userDetailsService.loadUserByUsername(username))
                     .isInstanceOf(CustomException.class)
                     .hasMessageContaining(AUTHENTICATION_FAILED.getMessage());
         }
-    }
-
-    private SiteUser createSiteUser() {
-        return new SiteUser(
-                "test@example.com",
-                "nickname",
-                "profileImageUrl",
-                PreparationStatus.CONSIDERING,
-                Role.MENTEE
-        );
     }
 
     private String getUserName(SiteUser siteUser) {

--- a/src/test/java/com/example/solidconnection/custom/security/userdetails/SiteUserDetailsTest.java
+++ b/src/test/java/com/example/solidconnection/custom/security/userdetails/SiteUserDetailsTest.java
@@ -22,8 +22,8 @@ class SiteUserDetailsTest {
     @Test
     void 사용자_권한을_정상적으로_반환한다() {
         // given
-        SiteUser 테스트_유저 = siteUserFixture.테스트_유저();
-        SiteUserDetails siteUserDetails = new SiteUserDetails(테스트_유저);
+        SiteUser user = siteUserFixture.사용자();
+        SiteUserDetails siteUserDetails = new SiteUserDetails(user);
 
         // when
         Collection<? extends GrantedAuthority> authorities = siteUserDetails.getAuthorities();
@@ -31,6 +31,6 @@ class SiteUserDetailsTest {
         // then
         assertThat(authorities)
                 .extracting("authority")
-                .containsExactly("ROLE_" + 테스트_유저.getRole().name());
+                .containsExactly("ROLE_" + user.getRole().name());
     }
 }

--- a/src/test/java/com/example/solidconnection/custom/security/userdetails/SiteUserDetailsTest.java
+++ b/src/test/java/com/example/solidconnection/custom/security/userdetails/SiteUserDetailsTest.java
@@ -1,10 +1,8 @@
 package com.example.solidconnection.custom.security.userdetails;
 
 import com.example.solidconnection.siteuser.domain.SiteUser;
-import com.example.solidconnection.siteuser.repository.SiteUserRepository;
+import com.example.solidconnection.siteuser.fixture.SiteUserFixture;
 import com.example.solidconnection.support.TestContainerSpringBootTest;
-import com.example.solidconnection.type.PreparationStatus;
-import com.example.solidconnection.type.Role;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,13 +17,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 class SiteUserDetailsTest {
 
     @Autowired
-    private SiteUserRepository siteUserRepository;
+    private SiteUserFixture siteUserFixture;
 
     @Test
     void 사용자_권한을_정상적으로_반환한다() {
         // given
-        SiteUser siteUser = siteUserRepository.save(createSiteUser());
-        SiteUserDetails siteUserDetails = new SiteUserDetails(siteUser);
+        SiteUser 테스트_유저 = siteUserFixture.테스트_유저();
+        SiteUserDetails siteUserDetails = new SiteUserDetails(테스트_유저);
 
         // when
         Collection<? extends GrantedAuthority> authorities = siteUserDetails.getAuthorities();
@@ -33,16 +31,6 @@ class SiteUserDetailsTest {
         // then
         assertThat(authorities)
                 .extracting("authority")
-                .containsExactly("ROLE_" + siteUser.getRole().name());
-    }
-
-    private SiteUser createSiteUser() {
-        return new SiteUser(
-                "test@example.com",
-                "nickname",
-                "profileImageUrl",
-                PreparationStatus.CONSIDERING,
-                Role.MENTEE
-        );
+                .containsExactly("ROLE_" + 테스트_유저.getRole().name());
     }
 }

--- a/src/test/java/com/example/solidconnection/score/service/ScoreServiceTest.java
+++ b/src/test/java/com/example/solidconnection/score/service/ScoreServiceTest.java
@@ -55,23 +55,23 @@ class ScoreServiceTest extends BaseIntegrationTest {
     @Autowired
     private SiteUserFixture siteUserFixture;
 
-    private SiteUser 테스트_유저;
+    private SiteUser user;
 
     @BeforeEach
     void setUp() {
-        테스트_유저 = siteUserFixture.테스트_유저();
+        user = siteUserFixture.사용자();
     }
 
     @Test
     void GPA_점수_상태를_조회한다() {
         // given
         List<GpaScore> scores = List.of(
-                createGpaScore(테스트_유저, 3.5, 4.5),
-                createGpaScore(테스트_유저, 3.8, 4.5)
+                createGpaScore(user, 3.5, 4.5),
+                createGpaScore(user, 3.8, 4.5)
         );
 
         // when
-        GpaScoreStatusesResponse response = scoreService.getGpaScoreStatus(테스트_유저);
+        GpaScoreStatusesResponse response = scoreService.getGpaScoreStatus(user);
 
         // then
         assertThat(response.gpaScoreStatusResponseList())
@@ -86,7 +86,7 @@ class ScoreServiceTest extends BaseIntegrationTest {
     @Test
     void GPA_점수가_없는_경우_빈_리스트를_반환한다() {
         // when
-        GpaScoreStatusesResponse response = scoreService.getGpaScoreStatus(테스트_유저);
+        GpaScoreStatusesResponse response = scoreService.getGpaScoreStatus(user);
 
         // then
         assertThat(response.gpaScoreStatusResponseList()).isEmpty();
@@ -96,13 +96,13 @@ class ScoreServiceTest extends BaseIntegrationTest {
     void 어학_시험_점수_상태를_조회한다() {
         // given
         List<LanguageTestScore> scores = List.of(
-                createLanguageTestScore(테스트_유저, LanguageTestType.TOEIC, "100"),
-                createLanguageTestScore(테스트_유저, LanguageTestType.TOEFL_IBT, "7.5")
+                createLanguageTestScore(user, LanguageTestType.TOEIC, "100"),
+                createLanguageTestScore(user, LanguageTestType.TOEFL_IBT, "7.5")
         );
-        siteUserRepository.save(테스트_유저);
+        siteUserRepository.save(user);
 
         // when
-        LanguageTestScoreStatusesResponse response = scoreService.getLanguageTestScoreStatus(테스트_유저);
+        LanguageTestScoreStatusesResponse response = scoreService.getLanguageTestScoreStatus(user);
 
         // then
         assertThat(response.languageTestScoreStatusResponseList())
@@ -117,7 +117,7 @@ class ScoreServiceTest extends BaseIntegrationTest {
     @Test
     void 어학_시험_점수가_없는_경우_빈_리스트를_반환한다() {
         // when
-        LanguageTestScoreStatusesResponse response = scoreService.getLanguageTestScoreStatus(테스트_유저);
+        LanguageTestScoreStatusesResponse response = scoreService.getLanguageTestScoreStatus(user);
 
         // then
         assertThat(response.languageTestScoreStatusResponseList()).isEmpty();
@@ -132,7 +132,7 @@ class ScoreServiceTest extends BaseIntegrationTest {
         given(s3Service.uploadFile(file, ImgType.GPA)).willReturn(new UploadedFileUrlResponse(fileUrl));
 
         // when
-        long scoreId = scoreService.submitGpaScore(테스트_유저, request, file);
+        long scoreId = scoreService.submitGpaScore(user, request, file);
         GpaScore savedScore = gpaScoreRepository.findById(scoreId).orElseThrow();
 
         // then
@@ -154,7 +154,7 @@ class ScoreServiceTest extends BaseIntegrationTest {
         given(s3Service.uploadFile(file, ImgType.LANGUAGE_TEST)).willReturn(new UploadedFileUrlResponse(fileUrl));
 
         // when
-        long scoreId = scoreService.submitLanguageTestScore(테스트_유저, request, file);
+        long scoreId = scoreService.submitLanguageTestScore(user, request, file);
         LanguageTestScore savedScore = languageTestScoreRepository.findById(scoreId).orElseThrow();
 
         // then

--- a/src/test/java/com/example/solidconnection/score/service/ScoreServiceTest.java
+++ b/src/test/java/com/example/solidconnection/score/service/ScoreServiceTest.java
@@ -15,13 +15,13 @@ import com.example.solidconnection.score.dto.LanguageTestScoreStatusesResponse;
 import com.example.solidconnection.score.repository.GpaScoreRepository;
 import com.example.solidconnection.score.repository.LanguageTestScoreRepository;
 import com.example.solidconnection.siteuser.domain.SiteUser;
+import com.example.solidconnection.siteuser.fixture.SiteUserFixture;
 import com.example.solidconnection.siteuser.repository.SiteUserRepository;
 import com.example.solidconnection.support.integration.BaseIntegrationTest;
 import com.example.solidconnection.type.ImgType;
 import com.example.solidconnection.type.LanguageTestType;
-import com.example.solidconnection.type.PreparationStatus;
-import com.example.solidconnection.type.Role;
 import com.example.solidconnection.type.VerifyStatus;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -52,17 +52,26 @@ class ScoreServiceTest extends BaseIntegrationTest {
     @MockBean
     private S3Service s3Service;
 
+    @Autowired
+    private SiteUserFixture siteUserFixture;
+
+    private SiteUser 테스트_유저;
+
+    @BeforeEach
+    void setUp() {
+        테스트_유저 = siteUserFixture.테스트_유저();
+    }
+
     @Test
     void GPA_점수_상태를_조회한다() {
         // given
-        SiteUser testUser = createSiteUser();
         List<GpaScore> scores = List.of(
-                createGpaScore(testUser, 3.5, 4.5),
-                createGpaScore(testUser, 3.8, 4.5)
+                createGpaScore(테스트_유저, 3.5, 4.5),
+                createGpaScore(테스트_유저, 3.8, 4.5)
         );
 
         // when
-        GpaScoreStatusesResponse response = scoreService.getGpaScoreStatus(testUser);
+        GpaScoreStatusesResponse response = scoreService.getGpaScoreStatus(테스트_유저);
 
         // then
         assertThat(response.gpaScoreStatusResponseList())
@@ -76,11 +85,8 @@ class ScoreServiceTest extends BaseIntegrationTest {
 
     @Test
     void GPA_점수가_없는_경우_빈_리스트를_반환한다() {
-        // given
-        SiteUser testUser = createSiteUser();
-
         // when
-        GpaScoreStatusesResponse response = scoreService.getGpaScoreStatus(testUser);
+        GpaScoreStatusesResponse response = scoreService.getGpaScoreStatus(테스트_유저);
 
         // then
         assertThat(response.gpaScoreStatusResponseList()).isEmpty();
@@ -89,15 +95,14 @@ class ScoreServiceTest extends BaseIntegrationTest {
     @Test
     void 어학_시험_점수_상태를_조회한다() {
         // given
-        SiteUser testUser = createSiteUser();
         List<LanguageTestScore> scores = List.of(
-                createLanguageTestScore(testUser, LanguageTestType.TOEIC, "100"),
-                createLanguageTestScore(testUser, LanguageTestType.TOEFL_IBT, "7.5")
+                createLanguageTestScore(테스트_유저, LanguageTestType.TOEIC, "100"),
+                createLanguageTestScore(테스트_유저, LanguageTestType.TOEFL_IBT, "7.5")
         );
-        siteUserRepository.save(testUser);
+        siteUserRepository.save(테스트_유저);
 
         // when
-        LanguageTestScoreStatusesResponse response = scoreService.getLanguageTestScoreStatus(testUser);
+        LanguageTestScoreStatusesResponse response = scoreService.getLanguageTestScoreStatus(테스트_유저);
 
         // then
         assertThat(response.languageTestScoreStatusResponseList())
@@ -111,11 +116,8 @@ class ScoreServiceTest extends BaseIntegrationTest {
 
     @Test
     void 어학_시험_점수가_없는_경우_빈_리스트를_반환한다() {
-        // given
-        SiteUser testUser = createSiteUser();
-
         // when
-        LanguageTestScoreStatusesResponse response = scoreService.getLanguageTestScoreStatus(testUser);
+        LanguageTestScoreStatusesResponse response = scoreService.getLanguageTestScoreStatus(테스트_유저);
 
         // then
         assertThat(response.languageTestScoreStatusResponseList()).isEmpty();
@@ -124,14 +126,13 @@ class ScoreServiceTest extends BaseIntegrationTest {
     @Test
     void GPA_점수를_등록한다() {
         // given
-        SiteUser testUser = createSiteUser();
         GpaScoreRequest request = createGpaScoreRequest();
         MockMultipartFile file = createFile();
         String fileUrl = "/gpa-report.pdf";
         given(s3Service.uploadFile(file, ImgType.GPA)).willReturn(new UploadedFileUrlResponse(fileUrl));
 
         // when
-        long scoreId = scoreService.submitGpaScore(testUser, request, file);
+        long scoreId = scoreService.submitGpaScore(테스트_유저, request, file);
         GpaScore savedScore = gpaScoreRepository.findById(scoreId).orElseThrow();
 
         // then
@@ -147,14 +148,13 @@ class ScoreServiceTest extends BaseIntegrationTest {
     @Test
     void 어학_시험_점수를_등록한다() {
         // given
-        SiteUser testUser = createSiteUser();
         LanguageTestScoreRequest request = createLanguageTestScoreRequest();
         MockMultipartFile file = createFile();
         String fileUrl = "/gpa-report.pdf";
         given(s3Service.uploadFile(file, ImgType.LANGUAGE_TEST)).willReturn(new UploadedFileUrlResponse(fileUrl));
 
         // when
-        long scoreId = scoreService.submitLanguageTestScore(testUser, request, file);
+        long scoreId = scoreService.submitLanguageTestScore(테스트_유저, request, file);
         LanguageTestScore savedScore = languageTestScoreRepository.findById(scoreId).orElseThrow();
 
         // then
@@ -165,17 +165,6 @@ class ScoreServiceTest extends BaseIntegrationTest {
                 () -> assertThat(savedScore.getVerifyStatus()).isEqualTo(VerifyStatus.PENDING),
                 () -> assertThat(savedScore.getLanguageTest().getLanguageTestReportUrl()).isEqualTo(fileUrl)
         );
-    }
-
-    private SiteUser createSiteUser() {
-        SiteUser siteUser = new SiteUser(
-                "test@example.com",
-                "nickname",
-                "profileImageUrl",
-                PreparationStatus.CONSIDERING,
-                Role.MENTEE
-        );
-        return siteUserRepository.save(siteUser);
     }
 
     private GpaScore createGpaScore(SiteUser siteUser, double gpa, double gpaCriteria) {

--- a/src/test/java/com/example/solidconnection/siteuser/fixture/SiteUserFixture.java
+++ b/src/test/java/com/example/solidconnection/siteuser/fixture/SiteUserFixture.java
@@ -1,0 +1,93 @@
+package com.example.solidconnection.siteuser.fixture;
+
+import com.example.solidconnection.siteuser.domain.AuthType;
+import com.example.solidconnection.siteuser.domain.SiteUser;
+import com.example.solidconnection.type.Role;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.test.context.TestComponent;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@TestComponent
+@RequiredArgsConstructor
+public class SiteUserFixture {
+
+    private final SiteUserFixtureBuilder siteUserFixtureBuilder;
+    private final PasswordEncoder passwordEncoder;
+
+    public SiteUser 테스트_유저() {
+        return siteUserFixtureBuilder.siteUser()
+                .email("test@example.com")
+                .authType(AuthType.EMAIL)
+                .nickname("테스트유저")
+                .profileImageUrl("profileImageUrl")
+                .role(Role.MENTEE)
+                .password("password123")
+                .create();
+    }
+
+    public SiteUser 테스트_유저(int index, String nickname) {
+        return siteUserFixtureBuilder.siteUser()
+                .email("test" + index + " @example.com")
+                .authType(AuthType.EMAIL)
+                .nickname(nickname)
+                .profileImageUrl("profileImageUrl")
+                .role(Role.MENTEE)
+                .password("password123")
+                .create();
+    }
+
+    public SiteUser 테스트_유저(String email, AuthType authType) {
+        return siteUserFixtureBuilder.siteUser()
+                .email(email)
+                .authType(authType)
+                .nickname("테스트유저")
+                .profileImageUrl("profileImageUrl")
+                .role(Role.MENTEE)
+                .password("password123")
+                .create();
+    }
+
+    public SiteUser 테스트_유저(String email, String password) {
+        return siteUserFixtureBuilder.siteUser()
+                .email(email)
+                .authType(AuthType.EMAIL)
+                .nickname("테스트유저")
+                .profileImageUrl("profileImageUrl")
+                .role(Role.MENTEE)
+                .password(passwordEncoder.encode(password))
+                .create();
+    }
+
+    public SiteUser 중복_닉네임_테스트_유저() {
+        return siteUserFixtureBuilder.siteUser()
+                .email("duplicated@example.com")
+                .authType(AuthType.EMAIL)
+                .nickname("중복닉네임")
+                .profileImageUrl("profileImageUrl")
+                .role(Role.MENTEE)
+                .password("password123")
+                .create();
+    }
+
+    public SiteUser 커스텀_프로필_테스트_유저() {
+        return siteUserFixtureBuilder.siteUser()
+                .email("customProfile@example.com")
+                .authType(AuthType.EMAIL)
+                .nickname("커스텀프로필")
+                .profileImageUrl("profile/profileImageUrl")
+                .role(Role.MENTEE)
+                .password("customPassword123")
+                .create();
+    }
+
+    public SiteUser 테스트_어드민() {
+        return siteUserFixtureBuilder.siteUser()
+                .email("admin@example.com")
+                .authType(AuthType.EMAIL)
+                .nickname("테스트어드민")
+                .profileImageUrl("profileImageUrl")
+                .role(Role.ADMIN)
+                .password("admin123")
+                .create();
+    }
+}

--- a/src/test/java/com/example/solidconnection/siteuser/fixture/SiteUserFixture.java
+++ b/src/test/java/com/example/solidconnection/siteuser/fixture/SiteUserFixture.java
@@ -56,28 +56,6 @@ public class SiteUserFixture {
                 .create();
     }
 
-    public SiteUser 중복_닉네임_테스트_유저() {
-        return siteUserFixtureBuilder.siteUser()
-                .email("duplicated@example.com")
-                .authType(AuthType.EMAIL)
-                .nickname("중복닉네임")
-                .profileImageUrl("profileImageUrl")
-                .role(Role.MENTEE)
-                .password("password123")
-                .create();
-    }
-
-    public SiteUser 커스텀_프로필_테스트_유저() {
-        return siteUserFixtureBuilder.siteUser()
-                .email("customProfile@example.com")
-                .authType(AuthType.EMAIL)
-                .nickname("커스텀프로필")
-                .profileImageUrl("profile/profileImageUrl")
-                .role(Role.MENTEE)
-                .password("customPassword123")
-                .create();
-    }
-
     public SiteUser 테스트_어드민() {
         return siteUserFixtureBuilder.siteUser()
                 .email("admin@example.com")

--- a/src/test/java/com/example/solidconnection/siteuser/fixture/SiteUserFixture.java
+++ b/src/test/java/com/example/solidconnection/siteuser/fixture/SiteUserFixture.java
@@ -5,14 +5,12 @@ import com.example.solidconnection.siteuser.domain.SiteUser;
 import com.example.solidconnection.type.Role;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.test.context.TestComponent;
-import org.springframework.security.crypto.password.PasswordEncoder;
 
 @TestComponent
 @RequiredArgsConstructor
 public class SiteUserFixture {
 
     private final SiteUserFixtureBuilder siteUserFixtureBuilder;
-    private final PasswordEncoder passwordEncoder;
 
     public SiteUser 테스트_유저() {
         return siteUserFixtureBuilder.siteUser()
@@ -27,7 +25,7 @@ public class SiteUserFixture {
 
     public SiteUser 테스트_유저(int index, String nickname) {
         return siteUserFixtureBuilder.siteUser()
-                .email("test" + index + " @example.com")
+                .email("test" + index + "@example.com")
                 .authType(AuthType.EMAIL)
                 .nickname(nickname)
                 .profileImageUrl("profileImageUrl")
@@ -54,7 +52,7 @@ public class SiteUserFixture {
                 .nickname("테스트유저")
                 .profileImageUrl("profileImageUrl")
                 .role(Role.MENTEE)
-                .password(passwordEncoder.encode(password))
+                .password(password)
                 .create();
     }
 

--- a/src/test/java/com/example/solidconnection/siteuser/fixture/SiteUserFixture.java
+++ b/src/test/java/com/example/solidconnection/siteuser/fixture/SiteUserFixture.java
@@ -12,18 +12,18 @@ public class SiteUserFixture {
 
     private final SiteUserFixtureBuilder siteUserFixtureBuilder;
 
-    public SiteUser 테스트_유저() {
+    public SiteUser 사용자() {
         return siteUserFixtureBuilder.siteUser()
                 .email("test@example.com")
                 .authType(AuthType.EMAIL)
-                .nickname("테스트유저")
+                .nickname("사용자")
                 .profileImageUrl("profileImageUrl")
                 .role(Role.MENTEE)
                 .password("password123")
                 .create();
     }
 
-    public SiteUser 테스트_유저(int index, String nickname) {
+    public SiteUser 사용자(int index, String nickname) {
         return siteUserFixtureBuilder.siteUser()
                 .email("test" + index + "@example.com")
                 .authType(AuthType.EMAIL)
@@ -34,22 +34,22 @@ public class SiteUserFixture {
                 .create();
     }
 
-    public SiteUser 테스트_유저(String email, AuthType authType) {
+    public SiteUser 사용자(String email, AuthType authType) {
         return siteUserFixtureBuilder.siteUser()
                 .email(email)
                 .authType(authType)
-                .nickname("테스트유저")
+                .nickname("사용자")
                 .profileImageUrl("profileImageUrl")
                 .role(Role.MENTEE)
                 .password("password123")
                 .create();
     }
 
-    public SiteUser 테스트_유저(String email, String password) {
+    public SiteUser 사용자(String email, String password) {
         return siteUserFixtureBuilder.siteUser()
                 .email(email)
                 .authType(AuthType.EMAIL)
-                .nickname("테스트유저")
+                .nickname("사용자")
                 .profileImageUrl("profileImageUrl")
                 .role(Role.MENTEE)
                 .password(password)

--- a/src/test/java/com/example/solidconnection/siteuser/fixture/SiteUserFixture.java
+++ b/src/test/java/com/example/solidconnection/siteuser/fixture/SiteUserFixture.java
@@ -56,11 +56,11 @@ public class SiteUserFixture {
                 .create();
     }
 
-    public SiteUser 테스트_어드민() {
+    public SiteUser 관리자() {
         return siteUserFixtureBuilder.siteUser()
                 .email("admin@example.com")
                 .authType(AuthType.EMAIL)
-                .nickname("테스트어드민")
+                .nickname("관리자")
                 .profileImageUrl("profileImageUrl")
                 .role(Role.ADMIN)
                 .password("admin123")

--- a/src/test/java/com/example/solidconnection/siteuser/fixture/SiteUserFixtureBuilder.java
+++ b/src/test/java/com/example/solidconnection/siteuser/fixture/SiteUserFixtureBuilder.java
@@ -7,12 +7,14 @@ import com.example.solidconnection.type.PreparationStatus;
 import com.example.solidconnection.type.Role;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.test.context.TestComponent;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @TestComponent
 @RequiredArgsConstructor
 public class SiteUserFixtureBuilder {
 
     private final SiteUserRepository siteUserRepository;
+    private final PasswordEncoder passwordEncoder;
 
     private String email;
     private AuthType authType;
@@ -22,7 +24,7 @@ public class SiteUserFixtureBuilder {
     private String password;
 
     public SiteUserFixtureBuilder siteUser() {
-        return new SiteUserFixtureBuilder(siteUserRepository);
+        return new SiteUserFixtureBuilder(siteUserRepository, passwordEncoder);
     }
 
     public SiteUserFixtureBuilder email(String email) {
@@ -63,7 +65,7 @@ public class SiteUserFixtureBuilder {
                 PreparationStatus.CONSIDERING,
                 role,
                 authType,
-                password
+                passwordEncoder.encode(password)
         );
         return siteUserRepository.save(siteUser);
     }

--- a/src/test/java/com/example/solidconnection/siteuser/fixture/SiteUserFixtureBuilder.java
+++ b/src/test/java/com/example/solidconnection/siteuser/fixture/SiteUserFixtureBuilder.java
@@ -1,0 +1,70 @@
+package com.example.solidconnection.siteuser.fixture;
+
+import com.example.solidconnection.siteuser.domain.AuthType;
+import com.example.solidconnection.siteuser.domain.SiteUser;
+import com.example.solidconnection.siteuser.repository.SiteUserRepository;
+import com.example.solidconnection.type.PreparationStatus;
+import com.example.solidconnection.type.Role;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.test.context.TestComponent;
+
+@TestComponent
+@RequiredArgsConstructor
+public class SiteUserFixtureBuilder {
+
+    private final SiteUserRepository siteUserRepository;
+
+    private String email;
+    private AuthType authType;
+    private String nickname;
+    private String profileImageUrl;
+    private Role role;
+    private String password;
+
+    public SiteUserFixtureBuilder siteUser() {
+        return new SiteUserFixtureBuilder(siteUserRepository);
+    }
+
+    public SiteUserFixtureBuilder email(String email) {
+        this.email = email;
+        return this;
+    }
+
+    public SiteUserFixtureBuilder authType(AuthType authType) {
+        this.authType = authType;
+        return this;
+    }
+
+    public SiteUserFixtureBuilder nickname(String nickname) {
+        this.nickname = nickname;
+        return this;
+    }
+
+    public SiteUserFixtureBuilder profileImageUrl(String profileImageUrl) {
+        this.profileImageUrl = profileImageUrl;
+        return this;
+    }
+
+    public SiteUserFixtureBuilder role(Role role) {
+        this.role = role;
+        return this;
+    }
+
+    public SiteUserFixtureBuilder password(String password) {
+        this.password = password;
+        return this;
+    }
+
+    public SiteUser create() {
+        SiteUser siteUser = new SiteUser(
+                email,
+                nickname,
+                profileImageUrl,
+                PreparationStatus.CONSIDERING,
+                role,
+                authType,
+                password
+        );
+        return siteUserRepository.save(siteUser);
+    }
+}

--- a/src/test/java/com/example/solidconnection/siteuser/repository/SiteUserRepositoryTest.java
+++ b/src/test/java/com/example/solidconnection/siteuser/repository/SiteUserRepositoryTest.java
@@ -26,20 +26,20 @@ class SiteUserRepositoryTest {
         @Test
         void 이메일과_인증_유형이_동일한_사용자를_저장하면_예외_응답을_반환한다() {
             // given
-            siteUserFixture.테스트_유저("email", AuthType.KAKAO);
+            siteUserFixture.사용자("email", AuthType.KAKAO);
 
             // when, then
-            assertThatCode(() -> siteUserFixture.테스트_유저("email", AuthType.KAKAO))
+            assertThatCode(() -> siteUserFixture.사용자("email", AuthType.KAKAO))
                     .isInstanceOf(DataIntegrityViolationException.class);
         }
 
         @Test
         void 이메일이_같더라도_인증_유형이_다른_사용자는_정상_저장한다() {
             // given
-            siteUserFixture.테스트_유저("email", AuthType.KAKAO);
+            siteUserFixture.사용자("email", AuthType.KAKAO);
 
             // when, then
-            assertThatCode(() -> siteUserFixture.테스트_유저("email", AuthType.APPLE))
+            assertThatCode(() -> siteUserFixture.사용자("email", AuthType.APPLE))
                     .doesNotThrowAnyException();
         }
     }

--- a/src/test/java/com/example/solidconnection/siteuser/repository/SiteUserRepositoryTest.java
+++ b/src/test/java/com/example/solidconnection/siteuser/repository/SiteUserRepositoryTest.java
@@ -1,10 +1,9 @@
 package com.example.solidconnection.siteuser.repository;
 
 import com.example.solidconnection.siteuser.domain.AuthType;
-import com.example.solidconnection.siteuser.domain.SiteUser;
-import com.example.solidconnection.support.TestContainerDataJpaTest;
-import com.example.solidconnection.type.PreparationStatus;
-import com.example.solidconnection.type.Role;
+import com.example.solidconnection.siteuser.fixture.SiteUserFixture;
+import com.example.solidconnection.support.TestContainerSpringBootTest;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,11 +11,14 @@ import org.springframework.dao.DataIntegrityViolationException;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 
-@TestContainerDataJpaTest
+// @TestContainerDataJpaTest + @Import 쓰기 vs @TestContainerSpringBootTest 검토 필요
+@TestContainerSpringBootTest
+//@Import({SiteUserFixture.class, SiteUserFixtureBuilder.class, PasswordEncoder.class})
+@DisplayName("유저 레포지토리 테스트")
 class SiteUserRepositoryTest {
 
     @Autowired
-    private SiteUserRepository siteUserRepository;
+    private SiteUserFixture siteUserFixture;
 
     @Nested
     class 이메일과_인증_유형이_동일한_사용자는_저장할_수_없다 {
@@ -24,36 +26,21 @@ class SiteUserRepositoryTest {
         @Test
         void 이메일과_인증_유형이_동일한_사용자를_저장하면_예외_응답을_반환한다() {
             // given
-            SiteUser user1 = createSiteUser("email", AuthType.KAKAO);
-            SiteUser user2 = createSiteUser("email", AuthType.KAKAO);
-            siteUserRepository.save(user1);
+            siteUserFixture.테스트_유저("email", AuthType.KAKAO);
 
             // when, then
-            assertThatCode(() -> siteUserRepository.save(user2))
+            assertThatCode(() -> siteUserFixture.테스트_유저("email", AuthType.KAKAO))
                     .isInstanceOf(DataIntegrityViolationException.class);
         }
 
         @Test
         void 이메일이_같더라도_인증_유형이_다른_사용자는_정상_저장한다() {
             // given
-            SiteUser user1 = createSiteUser("email", AuthType.KAKAO);
-            SiteUser user2 = createSiteUser("email", AuthType.APPLE);
-            siteUserRepository.save(user1);
+            siteUserFixture.테스트_유저("email", AuthType.KAKAO);
 
             // when, then
-            assertThatCode(() -> siteUserRepository.save(user2))
+            assertThatCode(() -> siteUserFixture.테스트_유저("email", AuthType.APPLE))
                     .doesNotThrowAnyException();
         }
-    }
-
-    private SiteUser createSiteUser(String email, AuthType authType) {
-        return new SiteUser(
-                email,
-                "nickname",
-                "profileImageUrl",
-                PreparationStatus.CONSIDERING,
-                Role.MENTEE,
-                authType
-        );
     }
 }

--- a/src/test/java/com/example/solidconnection/siteuser/repository/SiteUserRepositoryTest.java
+++ b/src/test/java/com/example/solidconnection/siteuser/repository/SiteUserRepositoryTest.java
@@ -1,9 +1,10 @@
 package com.example.solidconnection.siteuser.repository;
 
 import com.example.solidconnection.siteuser.domain.AuthType;
-import com.example.solidconnection.siteuser.fixture.SiteUserFixture;
-import com.example.solidconnection.support.TestContainerSpringBootTest;
-import org.junit.jupiter.api.DisplayName;
+import com.example.solidconnection.siteuser.domain.SiteUser;
+import com.example.solidconnection.support.TestContainerDataJpaTest;
+import com.example.solidconnection.type.PreparationStatus;
+import com.example.solidconnection.type.Role;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,14 +12,11 @@ import org.springframework.dao.DataIntegrityViolationException;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 
-// @TestContainerDataJpaTest + @Import 쓰기 vs @TestContainerSpringBootTest 검토 필요
-@TestContainerSpringBootTest
-//@Import({SiteUserFixture.class, SiteUserFixtureBuilder.class, PasswordEncoder.class})
-@DisplayName("유저 레포지토리 테스트")
+@TestContainerDataJpaTest
 class SiteUserRepositoryTest {
 
     @Autowired
-    private SiteUserFixture siteUserFixture;
+    private SiteUserRepository siteUserRepository;
 
     @Nested
     class 이메일과_인증_유형이_동일한_사용자는_저장할_수_없다 {
@@ -26,21 +24,36 @@ class SiteUserRepositoryTest {
         @Test
         void 이메일과_인증_유형이_동일한_사용자를_저장하면_예외_응답을_반환한다() {
             // given
-            siteUserFixture.사용자("email", AuthType.KAKAO);
+            SiteUser user1 = createSiteUser("email", AuthType.KAKAO);
+            SiteUser user2 = createSiteUser("email", AuthType.KAKAO);
+            siteUserRepository.save(user1);
 
             // when, then
-            assertThatCode(() -> siteUserFixture.사용자("email", AuthType.KAKAO))
+            assertThatCode(() -> siteUserRepository.save(user2))
                     .isInstanceOf(DataIntegrityViolationException.class);
         }
 
         @Test
         void 이메일이_같더라도_인증_유형이_다른_사용자는_정상_저장한다() {
             // given
-            siteUserFixture.사용자("email", AuthType.KAKAO);
+            SiteUser user1 = createSiteUser("email", AuthType.KAKAO);
+            SiteUser user2 = createSiteUser("email", AuthType.APPLE);
+            siteUserRepository.save(user1);
 
             // when, then
-            assertThatCode(() -> siteUserFixture.사용자("email", AuthType.APPLE))
+            assertThatCode(() -> siteUserRepository.save(user2))
                     .doesNotThrowAnyException();
         }
+    }
+
+    private SiteUser createSiteUser(String email, AuthType authType) {
+        return new SiteUser(
+                email,
+                "nickname",
+                "profileImageUrl",
+                PreparationStatus.CONSIDERING,
+                Role.MENTEE,
+                authType
+        );
     }
 }

--- a/src/test/java/com/example/solidconnection/siteuser/service/MyPageServiceTest.java
+++ b/src/test/java/com/example/solidconnection/siteuser/service/MyPageServiceTest.java
@@ -138,16 +138,16 @@ class MyPageServiceTest {
         @Test
         void 프로필을_처음_수정하는_것이_아니라면_이전_이미지를_삭제한다() {
             // given
-            SiteUser 커스텀_프로필_테스트_유저 = createSiteUserWithCustomProfile();
+            SiteUser 커스텀_프로필_사용자 = createSiteUserWithCustomProfile();
             MockMultipartFile imageFile = createValidImageFile();
             given(s3Service.uploadFile(any(), eq(ImgType.PROFILE)))
                     .willReturn(new UploadedFileUrlResponse("newProfileImageUrl"));
 
             // when
-            myPageService.updateMyPageInfo(커스텀_프로필_테스트_유저, imageFile, "newNickname");
+            myPageService.updateMyPageInfo(커스텀_프로필_사용자, imageFile, "newNickname");
 
             // then
-            then(s3Service).should().deleteExProfile(커스텀_프로필_테스트_유저);
+            then(s3Service).should().deleteExProfile(커스텀_프로필_사용자);
         }
     }
 

--- a/src/test/java/com/example/solidconnection/siteuser/service/MyPageServiceTest.java
+++ b/src/test/java/com/example/solidconnection/siteuser/service/MyPageServiceTest.java
@@ -65,28 +65,28 @@ class MyPageServiceTest {
     @Autowired
     private SiteUserFixtureBuilder siteUserFixtureBuilder;
 
-    private SiteUser 테스트_유저;
+    private SiteUser user;
 
     @BeforeEach
     void setUp() {
-        테스트_유저 = siteUserFixture.테스트_유저();
+        user = siteUserFixture.사용자();
     }
 
     @Test
     void 마이페이지_정보를_조회한다() {
         // given
-        int likedUniversityCount = createLikedUniversities(테스트_유저);
+        int likedUniversityCount = createLikedUniversities(user);
 
         // when
-        MyPageResponse response = myPageService.getMyPageInfo(테스트_유저);
+        MyPageResponse response = myPageService.getMyPageInfo(user);
 
         // then
         Assertions.assertAll(
-                () -> assertThat(response.nickname()).isEqualTo(테스트_유저.getNickname()),
-                () -> assertThat(response.profileImageUrl()).isEqualTo(테스트_유저.getProfileImageUrl()),
-                () -> assertThat(response.role()).isEqualTo(테스트_유저.getRole()),
-                () -> assertThat(response.email()).isEqualTo(테스트_유저.getEmail()),
-                () -> assertThat(response.likedPostCount()).isEqualTo(테스트_유저.getPostLikeList().size()),
+                () -> assertThat(response.nickname()).isEqualTo(user.getNickname()),
+                () -> assertThat(response.profileImageUrl()).isEqualTo(user.getProfileImageUrl()),
+                () -> assertThat(response.role()).isEqualTo(user.getRole()),
+                () -> assertThat(response.email()).isEqualTo(user.getEmail()),
+                () -> assertThat(response.likedPostCount()).isEqualTo(user.getPostLikeList().size()),
                 () -> assertThat(response.likedUniversityCount()).isEqualTo(likedUniversityCount)
         );
     }
@@ -94,10 +94,10 @@ class MyPageServiceTest {
     @Test
     void 관심_대학교_목록을_조회한다() {
         // given
-        int likedUniversityCount = createLikedUniversities(테스트_유저);
+        int likedUniversityCount = createLikedUniversities(user);
 
         // when
-        List<UniversityInfoForApplyPreviewResponse> response = myPageService.getWishUniversity(테스트_유저);
+        List<UniversityInfoForApplyPreviewResponse> response = myPageService.getWishUniversity(user);
 
         // then
         assertThat(response).hasSize(likedUniversityCount);
@@ -115,10 +115,10 @@ class MyPageServiceTest {
                     .willReturn(new UploadedFileUrlResponse(expectedUrl));
 
             // when
-            myPageService.updateMyPageInfo(테스트_유저, imageFile, "newNickname");
+            myPageService.updateMyPageInfo(user, imageFile, "newNickname");
 
             // then
-            assertThat(테스트_유저.getProfileImageUrl()).isEqualTo(expectedUrl);
+            assertThat(user.getProfileImageUrl()).isEqualTo(expectedUrl);
         }
 
         @Test
@@ -129,7 +129,7 @@ class MyPageServiceTest {
                     .willReturn(new UploadedFileUrlResponse("newProfileImageUrl"));
 
             // when
-            myPageService.updateMyPageInfo(테스트_유저, imageFile, "newNickname");
+            myPageService.updateMyPageInfo(user, imageFile, "newNickname");
 
             // then
             then(s3Service).should(never()).deleteExProfile(any());
@@ -167,10 +167,10 @@ class MyPageServiceTest {
             String newNickname = "newNickname";
 
             // when
-            myPageService.updateMyPageInfo(테스트_유저, imageFile, newNickname);
+            myPageService.updateMyPageInfo(user, imageFile, newNickname);
 
             // then
-            SiteUser updatedUser = siteUserRepository.findById(테스트_유저.getId()).get();
+            SiteUser updatedUser = siteUserRepository.findById(user.getId()).get();
             assertThat(updatedUser.getNicknameModifiedAt()).isNotNull();
             assertThat(updatedUser.getNickname()).isEqualTo(newNickname);
         }
@@ -178,10 +178,10 @@ class MyPageServiceTest {
         @Test
         void 중복된_닉네임으로_변경하면_예외_응답을_반환한다() {
             // given
-            SiteUser existingUser = siteUserFixture.테스트_유저(1, "existing nickname");
+            SiteUser existingUser = siteUserFixture.사용자(1, "existing nickname");
 
             // when & then
-            assertThatCode(() -> myPageService.updateMyPageInfo(테스트_유저, null, existingUser.getNickname()))
+            assertThatCode(() -> myPageService.updateMyPageInfo(user, null, existingUser.getNickname()))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(NICKNAME_ALREADY_EXISTED.getMessage());
         }
@@ -191,10 +191,10 @@ class MyPageServiceTest {
             // given
             MockMultipartFile imageFile = createValidImageFile();
             LocalDateTime modifiedAt = LocalDateTime.now().minusDays(MIN_DAYS_BETWEEN_NICKNAME_CHANGES - 1);
-            테스트_유저.setNicknameModifiedAt(modifiedAt);
+            user.setNicknameModifiedAt(modifiedAt);
 
             // when & then
-            assertThatCode(() -> myPageService.updateMyPageInfo(테스트_유저, imageFile, "nickname12"))
+            assertThatCode(() -> myPageService.updateMyPageInfo(user, imageFile, "nickname12"))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(createExpectedErrorMessage(modifiedAt));
         }

--- a/src/test/java/com/example/solidconnection/siteuser/service/MyPageServiceTest.java
+++ b/src/test/java/com/example/solidconnection/siteuser/service/MyPageServiceTest.java
@@ -228,7 +228,7 @@ class MyPageServiceTest {
         return CAN_NOT_CHANGE_NICKNAME_YET.getMessage() + " : " + formatLastModifiedAt;
     }
 
-    public SiteUser createSiteUserWithCustomProfile() {
+    private SiteUser createSiteUserWithCustomProfile() {
         return siteUserFixtureBuilder.siteUser()
                 .email("customProfile@example.com")
                 .authType(AuthType.EMAIL)

--- a/src/test/java/com/example/solidconnection/siteuser/service/SiteUserServiceTest.java
+++ b/src/test/java/com/example/solidconnection/siteuser/service/SiteUserServiceTest.java
@@ -22,11 +22,11 @@ class SiteUserServiceTest {
     @Autowired
     private SiteUserFixture siteUserFixture;
 
-    private SiteUser 테스트_유저;
+    private SiteUser user;
 
     @BeforeEach
     void setUp() {
-        테스트_유저 = siteUserFixture.테스트_유저();
+        user = siteUserFixture.사용자();
     }
 
     @Nested
@@ -35,7 +35,7 @@ class SiteUserServiceTest {
         @Test
         void 존재하는_닉네임이면_true를_반환한다() {
             // when
-            NicknameExistsResponse response = siteUserService.checkNicknameExists(테스트_유저.getNickname());
+            NicknameExistsResponse response = siteUserService.checkNicknameExists(user.getNickname());
 
             // then
             assertThat(response.exists()).isTrue();

--- a/src/test/java/com/example/solidconnection/siteuser/service/SiteUserServiceTest.java
+++ b/src/test/java/com/example/solidconnection/siteuser/service/SiteUserServiceTest.java
@@ -2,10 +2,8 @@ package com.example.solidconnection.siteuser.service;
 
 import com.example.solidconnection.siteuser.domain.SiteUser;
 import com.example.solidconnection.siteuser.dto.NicknameExistsResponse;
-import com.example.solidconnection.siteuser.repository.SiteUserRepository;
-import com.example.solidconnection.support.integration.BaseIntegrationTest;
-import com.example.solidconnection.type.PreparationStatus;
-import com.example.solidconnection.type.Role;
+import com.example.solidconnection.siteuser.fixture.SiteUserFixture;
+import com.example.solidconnection.support.TestContainerSpringBootTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -14,20 +12,21 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@TestContainerSpringBootTest
 @DisplayName("유저 서비스 테스트")
-class SiteUserServiceTest extends BaseIntegrationTest {
+class SiteUserServiceTest {
 
     @Autowired
     private SiteUserService siteUserService;
 
     @Autowired
-    private SiteUserRepository siteUserRepository;
+    private SiteUserFixture siteUserFixture;
 
-    private SiteUser siteUser;
+    private SiteUser 테스트_유저;
 
     @BeforeEach
     void setUp() {
-        siteUser = createSiteUser();
+        테스트_유저 = siteUserFixture.테스트_유저();
     }
 
     @Nested
@@ -36,7 +35,7 @@ class SiteUserServiceTest extends BaseIntegrationTest {
         @Test
         void 존재하는_닉네임이면_true를_반환한다() {
             // when
-            NicknameExistsResponse response = siteUserService.checkNicknameExists(siteUser.getNickname());
+            NicknameExistsResponse response = siteUserService.checkNicknameExists(테스트_유저.getNickname());
 
             // then
             assertThat(response.exists()).isTrue();
@@ -50,16 +49,5 @@ class SiteUserServiceTest extends BaseIntegrationTest {
             // then
             assertThat(response.exists()).isFalse();
         }
-    }
-
-    private SiteUser createSiteUser() {
-        SiteUser siteUser = new SiteUser(
-                "test@example.com",
-                "nickname",
-                "profileImageUrl",
-                PreparationStatus.CONSIDERING,
-                Role.MENTEE
-        );
-        return siteUserRepository.save(siteUser);
     }
 }

--- a/src/test/java/com/example/solidconnection/university/service/UniversityLikeServiceTest.java
+++ b/src/test/java/com/example/solidconnection/university/service/UniversityLikeServiceTest.java
@@ -41,12 +41,12 @@ class UniversityLikeServiceTest {
     @Autowired
     private UniversityInfoForApplyFixture universityInfoForApplyFixture;
 
-    private SiteUser 테스트_유저;
+    private SiteUser user;
     private UniversityInfoForApply 괌대학_A_지원_정보;
 
     @BeforeEach
     void setUp() {
-        테스트_유저 = siteUserFixture.테스트_유저();
+        user = siteUserFixture.사용자();
         괌대학_A_지원_정보 = universityInfoForApplyFixture.괌대학_A_지원_정보();
     }
 
@@ -56,13 +56,13 @@ class UniversityLikeServiceTest {
         @Test
         void 성공적으로_좋아요를_등록한다() {
             // when
-            LikeResultResponse response = universityLikeService.likeUniversity(테스트_유저, 괌대학_A_지원_정보.getId());
+            LikeResultResponse response = universityLikeService.likeUniversity(user, 괌대학_A_지원_정보.getId());
 
             // then
             assertAll(
                     () -> assertThat(response.result()).isEqualTo(LIKE_SUCCESS_MESSAGE),
                     () -> assertThat(likedUniversityRepository.findBySiteUserAndUniversityInfoForApply(
-                            테스트_유저, 괌대학_A_지원_정보
+                            user, 괌대학_A_지원_정보
                     )).isPresent()
             );
         }
@@ -70,10 +70,10 @@ class UniversityLikeServiceTest {
         @Test
         void 이미_좋아요한_대학이면_예외_응답을_반환한다() {
             // given
-            saveLikedUniversity(테스트_유저, 괌대학_A_지원_정보);
+            saveLikedUniversity(user, 괌대학_A_지원_정보);
 
             // when & then
-            assertThatCode(() -> universityLikeService.likeUniversity(테스트_유저, 괌대학_A_지원_정보.getId()))
+            assertThatCode(() -> universityLikeService.likeUniversity(user, 괌대학_A_지원_정보.getId()))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(ALREADY_LIKED_UNIVERSITY.getMessage());
         }
@@ -85,16 +85,16 @@ class UniversityLikeServiceTest {
         @Test
         void 성공적으로_좋아요를_취소한다() {
             // given
-            saveLikedUniversity(테스트_유저, 괌대학_A_지원_정보);
+            saveLikedUniversity(user, 괌대학_A_지원_정보);
 
             // when
-            LikeResultResponse response = universityLikeService.cancelLikeUniversity(테스트_유저, 괌대학_A_지원_정보.getId());
+            LikeResultResponse response = universityLikeService.cancelLikeUniversity(user, 괌대학_A_지원_정보.getId());
 
             // then
             assertAll(
                     () -> assertThat(response.result()).isEqualTo(LIKE_CANCELED_MESSAGE),
                     () -> assertThat(likedUniversityRepository.findBySiteUserAndUniversityInfoForApply(
-                            테스트_유저, 괌대학_A_지원_정보
+                            user, 괌대학_A_지원_정보
                     )).isEmpty()
             );
         }
@@ -102,7 +102,7 @@ class UniversityLikeServiceTest {
         @Test
         void 좋아요하지_않은_대학이면_예외_응답을_반환한다() {
             // when & then
-            assertThatCode(() -> universityLikeService.cancelLikeUniversity(테스트_유저, 괌대학_A_지원_정보.getId()))
+            assertThatCode(() -> universityLikeService.cancelLikeUniversity(user, 괌대학_A_지원_정보.getId()))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(NOT_LIKED_UNIVERSITY.getMessage());
         }
@@ -114,7 +114,7 @@ class UniversityLikeServiceTest {
         Long invalidUniversityId = 9999L;
 
         // when & then
-        assertThatCode(() -> universityLikeService.likeUniversity(테스트_유저, invalidUniversityId))
+        assertThatCode(() -> universityLikeService.likeUniversity(user, invalidUniversityId))
                 .isInstanceOf(CustomException.class)
                 .hasMessage(UNIVERSITY_INFO_FOR_APPLY_NOT_FOUND.getMessage());
     }
@@ -122,10 +122,10 @@ class UniversityLikeServiceTest {
     @Test
     void 좋아요한_대학인지_확인한다() {
         // given
-        saveLikedUniversity(테스트_유저, 괌대학_A_지원_정보);
+        saveLikedUniversity(user, 괌대학_A_지원_정보);
 
         // when
-        IsLikeResponse response = universityLikeService.getIsLiked(테스트_유저, 괌대학_A_지원_정보.getId());
+        IsLikeResponse response = universityLikeService.getIsLiked(user, 괌대학_A_지원_정보.getId());
 
         // then
         assertThat(response.isLike()).isTrue();
@@ -134,7 +134,7 @@ class UniversityLikeServiceTest {
     @Test
     void 좋아요하지_않은_대학인지_확인한다() {
         // when
-        IsLikeResponse response = universityLikeService.getIsLiked(테스트_유저, 괌대학_A_지원_정보.getId());
+        IsLikeResponse response = universityLikeService.getIsLiked(user, 괌대학_A_지원_정보.getId());
 
         // then
         assertThat(response.isLike()).isFalse();
@@ -146,7 +146,7 @@ class UniversityLikeServiceTest {
         Long invalidUniversityId = 9999L;
 
         // when & then
-        assertThatCode(() -> universityLikeService.getIsLiked(테스트_유저, invalidUniversityId))
+        assertThatCode(() -> universityLikeService.getIsLiked(user, invalidUniversityId))
                 .isInstanceOf(CustomException.class)
                 .hasMessage(UNIVERSITY_INFO_FOR_APPLY_NOT_FOUND.getMessage());
     }

--- a/src/test/java/com/example/solidconnection/university/service/UniversityLikeServiceTest.java
+++ b/src/test/java/com/example/solidconnection/university/service/UniversityLikeServiceTest.java
@@ -2,11 +2,9 @@ package com.example.solidconnection.university.service;
 
 import com.example.solidconnection.custom.exception.CustomException;
 import com.example.solidconnection.siteuser.domain.SiteUser;
+import com.example.solidconnection.siteuser.fixture.SiteUserFixture;
 import com.example.solidconnection.siteuser.repository.LikedUniversityRepository;
-import com.example.solidconnection.siteuser.repository.SiteUserRepository;
 import com.example.solidconnection.support.TestContainerSpringBootTest;
-import com.example.solidconnection.type.PreparationStatus;
-import com.example.solidconnection.type.Role;
 import com.example.solidconnection.university.domain.LikedUniversity;
 import com.example.solidconnection.university.domain.UniversityInfoForApply;
 import com.example.solidconnection.university.dto.IsLikeResponse;
@@ -38,17 +36,17 @@ class UniversityLikeServiceTest {
     private LikedUniversityRepository likedUniversityRepository;
 
     @Autowired
-    private SiteUserRepository siteUserRepository;
+    private SiteUserFixture siteUserFixture;
 
     @Autowired
     private UniversityInfoForApplyFixture universityInfoForApplyFixture;
 
-    private SiteUser testUser;
+    private SiteUser 테스트_유저;
     private UniversityInfoForApply 괌대학_A_지원_정보;
 
     @BeforeEach
     void setUp() {
-        testUser = createSiteUser();
+        테스트_유저 = siteUserFixture.테스트_유저();
         괌대학_A_지원_정보 = universityInfoForApplyFixture.괌대학_A_지원_정보();
     }
 
@@ -58,13 +56,13 @@ class UniversityLikeServiceTest {
         @Test
         void 성공적으로_좋아요를_등록한다() {
             // when
-            LikeResultResponse response = universityLikeService.likeUniversity(testUser, 괌대학_A_지원_정보.getId());
+            LikeResultResponse response = universityLikeService.likeUniversity(테스트_유저, 괌대학_A_지원_정보.getId());
 
             // then
             assertAll(
                     () -> assertThat(response.result()).isEqualTo(LIKE_SUCCESS_MESSAGE),
                     () -> assertThat(likedUniversityRepository.findBySiteUserAndUniversityInfoForApply(
-                            testUser, 괌대학_A_지원_정보
+                            테스트_유저, 괌대학_A_지원_정보
                     )).isPresent()
             );
         }
@@ -72,10 +70,10 @@ class UniversityLikeServiceTest {
         @Test
         void 이미_좋아요한_대학이면_예외_응답을_반환한다() {
             // given
-            saveLikedUniversity(testUser, 괌대학_A_지원_정보);
+            saveLikedUniversity(테스트_유저, 괌대학_A_지원_정보);
 
             // when & then
-            assertThatCode(() -> universityLikeService.likeUniversity(testUser, 괌대학_A_지원_정보.getId()))
+            assertThatCode(() -> universityLikeService.likeUniversity(테스트_유저, 괌대학_A_지원_정보.getId()))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(ALREADY_LIKED_UNIVERSITY.getMessage());
         }
@@ -87,16 +85,16 @@ class UniversityLikeServiceTest {
         @Test
         void 성공적으로_좋아요를_취소한다() {
             // given
-            saveLikedUniversity(testUser, 괌대학_A_지원_정보);
+            saveLikedUniversity(테스트_유저, 괌대학_A_지원_정보);
 
             // when
-            LikeResultResponse response = universityLikeService.cancelLikeUniversity(testUser, 괌대학_A_지원_정보.getId());
+            LikeResultResponse response = universityLikeService.cancelLikeUniversity(테스트_유저, 괌대학_A_지원_정보.getId());
 
             // then
             assertAll(
                     () -> assertThat(response.result()).isEqualTo(LIKE_CANCELED_MESSAGE),
                     () -> assertThat(likedUniversityRepository.findBySiteUserAndUniversityInfoForApply(
-                            testUser, 괌대학_A_지원_정보
+                            테스트_유저, 괌대학_A_지원_정보
                     )).isEmpty()
             );
         }
@@ -104,7 +102,7 @@ class UniversityLikeServiceTest {
         @Test
         void 좋아요하지_않은_대학이면_예외_응답을_반환한다() {
             // when & then
-            assertThatCode(() -> universityLikeService.cancelLikeUniversity(testUser, 괌대학_A_지원_정보.getId()))
+            assertThatCode(() -> universityLikeService.cancelLikeUniversity(테스트_유저, 괌대학_A_지원_정보.getId()))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(NOT_LIKED_UNIVERSITY.getMessage());
         }
@@ -116,7 +114,7 @@ class UniversityLikeServiceTest {
         Long invalidUniversityId = 9999L;
 
         // when & then
-        assertThatCode(() -> universityLikeService.likeUniversity(testUser, invalidUniversityId))
+        assertThatCode(() -> universityLikeService.likeUniversity(테스트_유저, invalidUniversityId))
                 .isInstanceOf(CustomException.class)
                 .hasMessage(UNIVERSITY_INFO_FOR_APPLY_NOT_FOUND.getMessage());
     }
@@ -124,10 +122,10 @@ class UniversityLikeServiceTest {
     @Test
     void 좋아요한_대학인지_확인한다() {
         // given
-        saveLikedUniversity(testUser, 괌대학_A_지원_정보);
+        saveLikedUniversity(테스트_유저, 괌대학_A_지원_정보);
 
         // when
-        IsLikeResponse response = universityLikeService.getIsLiked(testUser, 괌대학_A_지원_정보.getId());
+        IsLikeResponse response = universityLikeService.getIsLiked(테스트_유저, 괌대학_A_지원_정보.getId());
 
         // then
         assertThat(response.isLike()).isTrue();
@@ -136,7 +134,7 @@ class UniversityLikeServiceTest {
     @Test
     void 좋아요하지_않은_대학인지_확인한다() {
         // when
-        IsLikeResponse response = universityLikeService.getIsLiked(testUser, 괌대학_A_지원_정보.getId());
+        IsLikeResponse response = universityLikeService.getIsLiked(테스트_유저, 괌대학_A_지원_정보.getId());
 
         // then
         assertThat(response.isLike()).isFalse();
@@ -148,21 +146,9 @@ class UniversityLikeServiceTest {
         Long invalidUniversityId = 9999L;
 
         // when & then
-        assertThatCode(() -> universityLikeService.getIsLiked(testUser, invalidUniversityId))
+        assertThatCode(() -> universityLikeService.getIsLiked(테스트_유저, invalidUniversityId))
                 .isInstanceOf(CustomException.class)
                 .hasMessage(UNIVERSITY_INFO_FOR_APPLY_NOT_FOUND.getMessage());
-    }
-
-    // todo : 추후 Fixture로 대체 필요
-    private SiteUser createSiteUser() {
-        SiteUser siteUser = new SiteUser(
-                "test@example.com",
-                "nickname",
-                "profileImageUrl",
-                PreparationStatus.CONSIDERING,
-                Role.MENTEE
-        );
-        return siteUserRepository.save(siteUser);
     }
 
     private void saveLikedUniversity(SiteUser siteUser, UniversityInfoForApply universityInfoForApply) {

--- a/src/test/java/com/example/solidconnection/university/service/UniversityRecommendServiceTest.java
+++ b/src/test/java/com/example/solidconnection/university/service/UniversityRecommendServiceTest.java
@@ -7,10 +7,8 @@ import com.example.solidconnection.region.fixture.RegionFixture;
 import com.example.solidconnection.repositories.InterestedCountyRepository;
 import com.example.solidconnection.repositories.InterestedRegionRepository;
 import com.example.solidconnection.siteuser.domain.SiteUser;
-import com.example.solidconnection.siteuser.repository.SiteUserRepository;
+import com.example.solidconnection.siteuser.fixture.SiteUserFixture;
 import com.example.solidconnection.support.TestContainerSpringBootTest;
-import com.example.solidconnection.type.PreparationStatus;
-import com.example.solidconnection.type.Role;
 import com.example.solidconnection.university.domain.UniversityInfoForApply;
 import com.example.solidconnection.university.dto.UniversityInfoForApplyPreviewResponse;
 import com.example.solidconnection.university.dto.UniversityRecommendsResponse;
@@ -33,9 +31,6 @@ class UniversityRecommendServiceTest {
     private UniversityRecommendService universityRecommendService;
 
     @Autowired
-    private SiteUserRepository siteUserRepository;
-
-    @Autowired
     private InterestedRegionRepository interestedRegionRepository;
 
     @Autowired
@@ -43,6 +38,9 @@ class UniversityRecommendServiceTest {
 
     @Autowired
     private GeneralUniversityRecommendService generalUniversityRecommendService;
+
+    @Autowired
+    private SiteUserFixture siteUserFixture;
 
     @Autowired
     private RegionFixture regionFixture;
@@ -53,41 +51,37 @@ class UniversityRecommendServiceTest {
     @Autowired
     private UniversityInfoForApplyFixture universityInfoForApplyFixture;
 
-    private SiteUser testUser;
+    private SiteUser 테스트_유저;
     private UniversityInfoForApply 괌대학_A_지원_정보;
     private UniversityInfoForApply 괌대학_B_지원_정보;
     private UniversityInfoForApply 네바다주립대학_라스베이거스_지원_정보;
     private UniversityInfoForApply 메모리얼대학_세인트존스_A_지원_정보;
     private UniversityInfoForApply 서던덴마크대학교_지원_정보;
     private UniversityInfoForApply 코펜하겐IT대학_지원_정보;
-    private UniversityInfoForApply 그라츠대학_지원_정보;
-    private UniversityInfoForApply 그라츠공과대학_지원_정보;
-    private UniversityInfoForApply 린츠_카톨릭대학_지원_정보;
-    private UniversityInfoForApply 메이지대학_지원_정보;
 
     @BeforeEach
     void setUp() {
-        testUser = createSiteUser();
+        테스트_유저 = siteUserFixture.테스트_유저();
         괌대학_A_지원_정보 = universityInfoForApplyFixture.괌대학_A_지원_정보();
         괌대학_B_지원_정보 = universityInfoForApplyFixture.괌대학_B_지원_정보();
         네바다주립대학_라스베이거스_지원_정보 = universityInfoForApplyFixture.네바다주립대학_라스베이거스_지원_정보();
         메모리얼대학_세인트존스_A_지원_정보 = universityInfoForApplyFixture.메모리얼대학_세인트존스_A_지원_정보();
         서던덴마크대학교_지원_정보 = universityInfoForApplyFixture.서던덴마크대학교_지원_정보();
         코펜하겐IT대학_지원_정보 = universityInfoForApplyFixture.코펜하겐IT대학_지원_정보();
-        그라츠대학_지원_정보 = universityInfoForApplyFixture.그라츠대학_지원_정보();
-        그라츠공과대학_지원_정보 = universityInfoForApplyFixture.그라츠공과대학_지원_정보();
-        린츠_카톨릭대학_지원_정보 = universityInfoForApplyFixture.린츠_카톨릭대학_지원_정보();
-        메이지대학_지원_정보 = universityInfoForApplyFixture.메이지대학_지원_정보();
+        universityInfoForApplyFixture.그라츠대학_지원_정보();
+        universityInfoForApplyFixture.그라츠공과대학_지원_정보();
+        universityInfoForApplyFixture.린츠_카톨릭대학_지원_정보();
+        universityInfoForApplyFixture.메이지대학_지원_정보();
         generalUniversityRecommendService.init();
     }
 
     @Test
     void 관심_지역_설정한_사용자의_맞춤_추천_대학을_조회한다() {
         // given
-        interestedRegionRepository.save(new InterestedRegion(testUser, regionFixture.영미권()));
+        interestedRegionRepository.save(new InterestedRegion(테스트_유저, regionFixture.영미권()));
 
         // when
-        UniversityRecommendsResponse response = universityRecommendService.getPersonalRecommends(testUser);
+        UniversityRecommendsResponse response = universityRecommendService.getPersonalRecommends(테스트_유저);
 
         // then
         assertThat(response.recommendedUniversities())
@@ -103,10 +97,10 @@ class UniversityRecommendServiceTest {
     @Test
     void 관심_국가_설정한_사용자의_맞춤_추천_대학을_조회한다() {
         // given
-        interestedCountyRepository.save(new InterestedCountry(testUser, countryFixture.덴마크()));
+        interestedCountyRepository.save(new InterestedCountry(테스트_유저, countryFixture.덴마크()));
 
         // when
-        UniversityRecommendsResponse response = universityRecommendService.getPersonalRecommends(testUser);
+        UniversityRecommendsResponse response = universityRecommendService.getPersonalRecommends(테스트_유저);
 
         // then
         assertThat(response.recommendedUniversities())
@@ -120,11 +114,11 @@ class UniversityRecommendServiceTest {
     @Test
     void 관심_지역과_국가_모두_설정한_사용자의_맞춤_추천_대학을_조회한다() {
         // given
-        interestedRegionRepository.save(new InterestedRegion(testUser, regionFixture.영미권()));
-        interestedCountyRepository.save(new InterestedCountry(testUser, countryFixture.덴마크()));
+        interestedRegionRepository.save(new InterestedRegion(테스트_유저, regionFixture.영미권()));
+        interestedCountyRepository.save(new InterestedCountry(테스트_유저, countryFixture.덴마크()));
 
         // when
-        UniversityRecommendsResponse response = universityRecommendService.getPersonalRecommends(testUser);
+        UniversityRecommendsResponse response = universityRecommendService.getPersonalRecommends(테스트_유저);
 
         // then
         assertThat(response.recommendedUniversities())
@@ -142,7 +136,7 @@ class UniversityRecommendServiceTest {
     @Test
     void 관심사_미설정_사용자는_일반_추천_대학을_조회한다() {
         // when
-        UniversityRecommendsResponse response = universityRecommendService.getPersonalRecommends(testUser);
+        UniversityRecommendsResponse response = universityRecommendService.getPersonalRecommends(테스트_유저);
 
         // then
         assertThat(response.recommendedUniversities())
@@ -167,17 +161,5 @@ class UniversityRecommendServiceTest {
                                 .map(UniversityInfoForApplyPreviewResponse::from)
                                 .toList()
                 );
-    }
-
-    // todo : 추후 Fixture로 대체 필요
-    private SiteUser createSiteUser() {
-        SiteUser siteUser = new SiteUser(
-                "test@example.com",
-                "nickname",
-                "profileImageUrl",
-                PreparationStatus.CONSIDERING,
-                Role.MENTEE
-        );
-        return siteUserRepository.save(siteUser);
     }
 }

--- a/src/test/java/com/example/solidconnection/university/service/UniversityRecommendServiceTest.java
+++ b/src/test/java/com/example/solidconnection/university/service/UniversityRecommendServiceTest.java
@@ -51,7 +51,7 @@ class UniversityRecommendServiceTest {
     @Autowired
     private UniversityInfoForApplyFixture universityInfoForApplyFixture;
 
-    private SiteUser 테스트_유저;
+    private SiteUser user;
     private UniversityInfoForApply 괌대학_A_지원_정보;
     private UniversityInfoForApply 괌대학_B_지원_정보;
     private UniversityInfoForApply 네바다주립대학_라스베이거스_지원_정보;
@@ -61,7 +61,7 @@ class UniversityRecommendServiceTest {
 
     @BeforeEach
     void setUp() {
-        테스트_유저 = siteUserFixture.테스트_유저();
+        user = siteUserFixture.사용자();
         괌대학_A_지원_정보 = universityInfoForApplyFixture.괌대학_A_지원_정보();
         괌대학_B_지원_정보 = universityInfoForApplyFixture.괌대학_B_지원_정보();
         네바다주립대학_라스베이거스_지원_정보 = universityInfoForApplyFixture.네바다주립대학_라스베이거스_지원_정보();
@@ -78,10 +78,10 @@ class UniversityRecommendServiceTest {
     @Test
     void 관심_지역_설정한_사용자의_맞춤_추천_대학을_조회한다() {
         // given
-        interestedRegionRepository.save(new InterestedRegion(테스트_유저, regionFixture.영미권()));
+        interestedRegionRepository.save(new InterestedRegion(user, regionFixture.영미권()));
 
         // when
-        UniversityRecommendsResponse response = universityRecommendService.getPersonalRecommends(테스트_유저);
+        UniversityRecommendsResponse response = universityRecommendService.getPersonalRecommends(user);
 
         // then
         assertThat(response.recommendedUniversities())
@@ -97,10 +97,10 @@ class UniversityRecommendServiceTest {
     @Test
     void 관심_국가_설정한_사용자의_맞춤_추천_대학을_조회한다() {
         // given
-        interestedCountyRepository.save(new InterestedCountry(테스트_유저, countryFixture.덴마크()));
+        interestedCountyRepository.save(new InterestedCountry(user, countryFixture.덴마크()));
 
         // when
-        UniversityRecommendsResponse response = universityRecommendService.getPersonalRecommends(테스트_유저);
+        UniversityRecommendsResponse response = universityRecommendService.getPersonalRecommends(user);
 
         // then
         assertThat(response.recommendedUniversities())
@@ -114,11 +114,11 @@ class UniversityRecommendServiceTest {
     @Test
     void 관심_지역과_국가_모두_설정한_사용자의_맞춤_추천_대학을_조회한다() {
         // given
-        interestedRegionRepository.save(new InterestedRegion(테스트_유저, regionFixture.영미권()));
-        interestedCountyRepository.save(new InterestedCountry(테스트_유저, countryFixture.덴마크()));
+        interestedRegionRepository.save(new InterestedRegion(user, regionFixture.영미권()));
+        interestedCountyRepository.save(new InterestedCountry(user, countryFixture.덴마크()));
 
         // when
-        UniversityRecommendsResponse response = universityRecommendService.getPersonalRecommends(테스트_유저);
+        UniversityRecommendsResponse response = universityRecommendService.getPersonalRecommends(user);
 
         // then
         assertThat(response.recommendedUniversities())
@@ -136,7 +136,7 @@ class UniversityRecommendServiceTest {
     @Test
     void 관심사_미설정_사용자는_일반_추천_대학을_조회한다() {
         // when
-        UniversityRecommendsResponse response = universityRecommendService.getPersonalRecommends(테스트_유저);
+        UniversityRecommendsResponse response = universityRecommendService.getPersonalRecommends(user);
 
         // then
         assertThat(response.recommendedUniversities())


### PR DESCRIPTION
## 관련 이슈

- resolves: #318

## 작업 내용

유저 관련 통합 테스트 데이터 fixture 메서드로 변경했습니다

쪼개기가 애매한 거 같아서 어쩌다보니 pr이 조금 커졌네요...
<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

#275 때같은 문제가 이제 발생하지 않겠네요

## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

## 리뷰 요구사항 (선택)

1. 우선 첫 커밋만 확인해서 이런식으로 Fixture 만드는 거 괜찮은지만 먼저 피드백 해주시면 좋을 거 같습니다!

뒷 부분은 그냥 단순 노동이었습니다. 😅

2. 추가로 이야기해볼 만한 건 SiteUserRepositoryTest에서 @TestContainerDataJpaTest를 쓰고 있었는데 얘는 @ComponentScan이 안되는 거 같더라구요. 그래서 주석으로 달아두었는데

@TestContainerDataJpaTest + @Import 쓰기 vs @TestContainerSpringBootTest 중 어떤 걸로 해야할지 고민이 되었습니다!
