### PR TITLE
refactor/Siteuser 도메인 리팩터링

### DIFF
--- a/src/main/java/com/example/solidconnection/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/solidconnection/common/exception/ErrorCode.java
@@ -96,6 +96,9 @@ public enum ErrorCode {
     USER_DO_NOT_HAVE_GPA(HttpStatus.BAD_REQUEST.value(), "해당 유저의 학점을 찾을 수 없음"),
     REJECTED_REASON_REQUIRED(HttpStatus.BAD_REQUEST.value(), "거절 사유가 필요합니다."),
 
+    // database
+    DATA_INTEGRITY_VIOLATION(HttpStatus.CONFLICT.value(), "데이터베이스 무결성 제약조건 위반이 발생했습니다."),
+
     // general
     JSON_PARSING_FAILED(HttpStatus.BAD_REQUEST.value(), "JSON 파싱을 할 수 없습니다."),
     JWT_EXCEPTION(HttpStatus.BAD_REQUEST.value(), "JWT 토큰을 처리할 수 없습니다."),

--- a/src/main/java/com/example/solidconnection/siteuser/controller/MyPageController.java
+++ b/src/main/java/com/example/solidconnection/siteuser/controller/MyPageController.java
@@ -1,10 +1,13 @@
 package com.example.solidconnection.siteuser.controller;
 
+import com.example.solidconnection.common.exception.CustomException;
+import com.example.solidconnection.common.exception.ErrorCode;
 import com.example.solidconnection.common.resolver.AuthorizedUser;
 import com.example.solidconnection.siteuser.domain.SiteUser;
 import com.example.solidconnection.siteuser.dto.MyPageResponse;
 import com.example.solidconnection.siteuser.service.MyPageService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -12,6 +15,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+
+import static com.example.solidconnection.common.exception.ErrorCode.DATA_INTEGRITY_VIOLATION;
 
 @RequiredArgsConstructor
 @RequestMapping("/my")
@@ -34,7 +39,21 @@ class MyPageController {
             @RequestParam(value = "file", required = false) MultipartFile imageFile,
             @RequestParam(value = "nickname", required = false) String nickname
     ) {
-        myPageService.updateMyPageInfo(siteUser, imageFile, nickname);
-        return ResponseEntity.ok().build();
+        try {
+            myPageService.updateMyPageInfo(siteUser, imageFile, nickname);
+            return ResponseEntity.ok().build();
+        } catch (DataIntegrityViolationException e) {
+            throw new CustomException(determineErrorCode(e));
+        }
+    }
+
+    private ErrorCode determineErrorCode(DataIntegrityViolationException e) {
+        String message = e.getMostSpecificCause().getMessage().toLowerCase();
+
+        if (message.contains("unique") && message.contains("nickname")) {
+            return ErrorCode.NICKNAME_ALREADY_EXISTED;
+        }
+
+        return ErrorCode.DATA_INTEGRITY_VIOLATION;
     }
 }

--- a/src/main/java/com/example/solidconnection/siteuser/domain/SiteUser.java
+++ b/src/main/java/com/example/solidconnection/siteuser/domain/SiteUser.java
@@ -51,7 +51,7 @@ public class SiteUser {
     private AuthType authType;
 
     @Setter
-    @Column(nullable = false, length = 100)
+    @Column(nullable = false, length = 100, unique = true)
     private String nickname;
 
     @Setter

--- a/src/main/java/com/example/solidconnection/siteuser/repository/SiteUserRepository.java
+++ b/src/main/java/com/example/solidconnection/siteuser/repository/SiteUserRepository.java
@@ -3,11 +3,13 @@ package com.example.solidconnection.siteuser.repository;
 import com.example.solidconnection.siteuser.domain.AuthType;
 import com.example.solidconnection.siteuser.domain.SiteUser;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -22,4 +24,12 @@ public interface SiteUserRepository extends JpaRepository<SiteUser, Long> {
 
     @Query("SELECT u FROM SiteUser u WHERE u.quitedAt <= :cutoffDate")
     List<SiteUser> findUsersToBeRemoved(@Param("cutoffDate") LocalDate cutoffDate);
+
+    @Modifying
+    @Query("UPDATE SiteUser s SET s.nickname = :nickname, s.nicknameModifiedAt = :modifiedAt WHERE s.id = :id")
+    void updateNickname(@Param("id") Long id, @Param("nickname") String nickname, @Param("modifiedAt") LocalDateTime modifiedAt);
+
+    @Modifying
+    @Query("UPDATE SiteUser s SET s.profileImageUrl = :profileImageUrl WHERE s.id = :id")
+    void updateProfileImage(@Param("id") Long id, @Param("profileImageUrl") String profileImageUrl);
 }

--- a/src/main/java/com/example/solidconnection/siteuser/service/MyPageService.java
+++ b/src/main/java/com/example/solidconnection/siteuser/service/MyPageService.java
@@ -48,8 +48,7 @@ public class MyPageService {
     public void updateMyPageInfo(SiteUser siteUser, MultipartFile imageFile, String nickname) {
         if (nickname != null) {
             validateNicknameNotChangedRecently(siteUser.getNicknameModifiedAt());
-            siteUser.setNickname(nickname);
-            siteUser.setNicknameModifiedAt(LocalDateTime.now());
+            siteUserRepository.updateNickname(siteUser.getId(), nickname, LocalDateTime.now());
         }
 
         if (imageFile != null && !imageFile.isEmpty()) {
@@ -58,9 +57,8 @@ public class MyPageService {
                 s3Service.deleteExProfile(siteUser);
             }
             String profileImageUrl = uploadedFile.fileUrl();
-            siteUser.setProfileImageUrl(profileImageUrl);
+            siteUserRepository.updateProfileImage(siteUser.getId(), profileImageUrl);
         }
-        siteUserRepository.save(siteUser);
     }
 
     private void validateNicknameNotChangedRecently(LocalDateTime lastModifiedAt) {

--- a/src/main/java/com/example/solidconnection/siteuser/service/MyPageService.java
+++ b/src/main/java/com/example/solidconnection/siteuser/service/MyPageService.java
@@ -20,7 +20,6 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 import static com.example.solidconnection.common.exception.ErrorCode.CAN_NOT_CHANGE_NICKNAME_YET;
-import static com.example.solidconnection.common.exception.ErrorCode.NICKNAME_ALREADY_EXISTED;
 
 @RequiredArgsConstructor
 @Service
@@ -48,7 +47,6 @@ public class MyPageService {
     @Transactional
     public void updateMyPageInfo(SiteUser siteUser, MultipartFile imageFile, String nickname) {
         if (nickname != null) {
-            validateNicknameUnique(nickname);
             validateNicknameNotChangedRecently(siteUser.getNicknameModifiedAt());
             siteUser.setNickname(nickname);
             siteUser.setNicknameModifiedAt(LocalDateTime.now());
@@ -63,12 +61,6 @@ public class MyPageService {
             siteUser.setProfileImageUrl(profileImageUrl);
         }
         siteUserRepository.save(siteUser);
-    }
-
-    private void validateNicknameUnique(String nickname) {
-        if (siteUserRepository.existsByNickname(nickname)) {
-            throw new CustomException(NICKNAME_ALREADY_EXISTED);
-        }
     }
 
     private void validateNicknameNotChangedRecently(LocalDateTime lastModifiedAt) {

--- a/src/main/resources/db/migration/V13__set_unique_constraint_to_nickname.sql
+++ b/src/main/resources/db/migration/V13__set_unique_constraint_to_nickname.sql
@@ -1,0 +1,3 @@
+ALTER TABLE site_user
+ADD CONSTRAINT uk_site_user_nickname
+UNIQUE (nickname);


### PR DESCRIPTION
## 관련 이슈

- resolves: #333 

## 작업 내용

- `SiteUser` 엔티티의 `nickname` 컬럼에 `unique` 제약 조건을 추가하였고, 이에 따라 데이터베이스 컬럼 제약 조건을 수정하는 sql문을 작성하였습니다.
- `unique` 제약 조건 위반으로 인해 발생할 수 있는 `DataIntegrityViolationException` 예외를 처리하는 로직을 `try-catch` 문으로 작성하였습니다.
- 프로필 사진과 닉네임을 업데이트하는 로직을 수정하였습니다. 엔티티를 저장하는 것이 아닌 특정 컬럼의 값을 업데이트하는 쿼리를 작성하여 수정하였습니다.

## 특이 사항

회원가입 시 닉네임 중복을 검사하는 로직이 존재합니다. 해당 부분 수정 후 draft 상태 변경하겠습니다.

## 리뷰 요구사항 (선택)

- 코드 컨벤션을 잘 준수하고 있는지.
