### PR TITLE
refactor: University 도메인 리팩터링

### DIFF
--- a/src/main/java/com/example/solidconnection/application/dto/UniversityApplicantsResponse.java
+++ b/src/main/java/com/example/solidconnection/application/dto/UniversityApplicantsResponse.java
@@ -2,7 +2,7 @@ package com.example.solidconnection.application.dto;
 
 import com.example.solidconnection.application.domain.Application;
 import com.example.solidconnection.siteuser.domain.SiteUser;
-import com.example.solidconnection.university.domain.UniversityInfoForApply;
+import com.example.solidconnection.university.domain.UnivApplyInfo;
 
 import java.util.List;
 
@@ -12,12 +12,12 @@ public record UniversityApplicantsResponse(
         String region,
         String country,
         List<ApplicantResponse> applicants) {
-    public static UniversityApplicantsResponse of(UniversityInfoForApply universityInfoForApply, List<Application> applications, SiteUser siteUser) {
+    public static UniversityApplicantsResponse of(UnivApplyInfo univApplyInfo, List<Application> applications, SiteUser siteUser) {
         return new UniversityApplicantsResponse(
-                universityInfoForApply.getKoreanName(),
-                universityInfoForApply.getStudentCapacity(),
-                universityInfoForApply.getUniversity().getRegion().getKoreanName(),
-                universityInfoForApply.getUniversity().getCountry().getKoreanName(),
+                univApplyInfo.getKoreanName(),
+                univApplyInfo.getStudentCapacity(),
+                univApplyInfo.getUniversity().getRegion().getKoreanName(),
+                univApplyInfo.getUniversity().getCountry().getKoreanName(),
                 applications.stream()
                             .map(application -> ApplicantResponse.of(application, isUsers(application, siteUser)))
                             .toList());

--- a/src/main/java/com/example/solidconnection/application/repository/ApplicationRepository.java
+++ b/src/main/java/com/example/solidconnection/application/repository/ApplicationRepository.java
@@ -4,7 +4,6 @@ import com.example.solidconnection.application.domain.Application;
 import com.example.solidconnection.application.domain.VerifyStatus;
 import com.example.solidconnection.common.exception.CustomException;
 import com.example.solidconnection.siteuser.domain.SiteUser;
-import com.example.solidconnection.university.domain.UniversityInfoForApply;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;

--- a/src/main/java/com/example/solidconnection/application/service/ApplicationSubmissionService.java
+++ b/src/main/java/com/example/solidconnection/application/service/ApplicationSubmissionService.java
@@ -12,7 +12,6 @@ import com.example.solidconnection.score.domain.LanguageTestScore;
 import com.example.solidconnection.score.repository.GpaScoreRepository;
 import com.example.solidconnection.score.repository.LanguageTestScoreRepository;
 import com.example.solidconnection.siteuser.domain.SiteUser;
-import com.example.solidconnection.university.repository.UniversityInfoForApplyRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -33,7 +32,6 @@ public class ApplicationSubmissionService {
     public static final int APPLICATION_UPDATE_COUNT_LIMIT = 3;
 
     private final ApplicationRepository applicationRepository;
-    private final UniversityInfoForApplyRepository universityInfoForApplyRepository;
     private final GpaScoreRepository gpaScoreRepository;
     private final LanguageTestScoreRepository languageTestScoreRepository;
 

--- a/src/main/java/com/example/solidconnection/siteuser/repository/LikedUniversityRepository.java
+++ b/src/main/java/com/example/solidconnection/siteuser/repository/LikedUniversityRepository.java
@@ -2,7 +2,7 @@ package com.example.solidconnection.siteuser.repository;
 
 import com.example.solidconnection.siteuser.domain.SiteUser;
 import com.example.solidconnection.university.domain.LikedUniversity;
-import com.example.solidconnection.university.domain.UniversityInfoForApply;
+import com.example.solidconnection.university.domain.UnivApplyInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -14,5 +14,5 @@ public interface LikedUniversityRepository extends JpaRepository<LikedUniversity
 
     int countBySiteUser_Id(long siteUserId);
 
-    Optional<LikedUniversity> findBySiteUserAndUniversityInfoForApply(SiteUser siteUser, UniversityInfoForApply universityInfoForApply);
+    Optional<LikedUniversity> findBySiteUserAndUnivApplyInfo(SiteUser siteUser, UnivApplyInfo univApplyInfo);
 }

--- a/src/main/java/com/example/solidconnection/siteuser/service/MyPageService.java
+++ b/src/main/java/com/example/solidconnection/siteuser/service/MyPageService.java
@@ -97,7 +97,7 @@ public class MyPageService {
     public List<UniversityInfoForApplyPreviewResponse> getWishUniversity(SiteUser siteUser) {
         List<LikedUniversity> likedUniversities = likedUniversityRepository.findAllBySiteUser_Id(siteUser.getId());
         return likedUniversities.stream()
-                .map(likedUniversity -> UniversityInfoForApplyPreviewResponse.from(likedUniversity.getUniversityInfoForApply()))
+                .map(likedUniversity -> UniversityInfoForApplyPreviewResponse.from(likedUniversity.getUnivApplyInfo()))
                 .toList();
     }
 }

--- a/src/main/java/com/example/solidconnection/university/domain/LanguageRequirement.java
+++ b/src/main/java/com/example/solidconnection/university/domain/LanguageRequirement.java
@@ -8,6 +8,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -32,5 +33,6 @@ public class LanguageRequirement {
     private String minScore;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    private UniversityInfoForApply universityInfoForApply;
+    @JoinColumn(name = "university_info_for_apply_id")
+    private UnivApplyInfo univApplyInfo;
 }

--- a/src/main/java/com/example/solidconnection/university/domain/LikedUniversity.java
+++ b/src/main/java/com/example/solidconnection/university/domain/LikedUniversity.java
@@ -5,7 +5,10 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,6 +19,12 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
+@Table(uniqueConstraints = {
+        @UniqueConstraint(
+                name = "uk_liked_university_site_user_id_university_info_for_apply_id",
+                columnNames = {"site_user_id", "university_info_for_apply_id"}
+        )
+})
 public class LikedUniversity {
 
     @Id
@@ -23,7 +32,8 @@ public class LikedUniversity {
     private Long id;
 
     @ManyToOne
-    private UniversityInfoForApply universityInfoForApply;
+    @JoinColumn(name = "university_info_for_apply_id")
+    private UnivApplyInfo univApplyInfo;
 
     @ManyToOne
     private SiteUser siteUser;

--- a/src/main/java/com/example/solidconnection/university/domain/UnivApplyInfo.java
+++ b/src/main/java/com/example/solidconnection/university/domain/UnivApplyInfo.java
@@ -10,6 +10,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
@@ -24,7 +25,8 @@ import java.util.Set;
 @AllArgsConstructor(access = AccessLevel.PUBLIC)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-public class UniversityInfoForApply {
+@Table(name = "university_info_for_apply")
+public class UnivApplyInfo {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -74,7 +76,7 @@ public class UniversityInfoForApply {
     @Column(length = 1000)
     private String details;
 
-    @OneToMany(mappedBy = "universityInfoForApply", fetch = FetchType.EAGER)
+    @OneToMany(mappedBy = "univApplyInfo", fetch = FetchType.EAGER)
     private Set<LanguageRequirement> languageRequirements = new HashSet<>();
 
     @ManyToOne(fetch = FetchType.EAGER)

--- a/src/main/java/com/example/solidconnection/university/dto/UniversityDetailResponse.java
+++ b/src/main/java/com/example/solidconnection/university/dto/UniversityDetailResponse.java
@@ -1,7 +1,7 @@
 package com.example.solidconnection.university.dto;
 
 import com.example.solidconnection.university.domain.University;
-import com.example.solidconnection.university.domain.UniversityInfoForApply;
+import com.example.solidconnection.university.domain.UnivApplyInfo;
 
 import java.util.List;
 
@@ -35,11 +35,11 @@ public record UniversityDetailResponse(
 
     public static UniversityDetailResponse of(
             University university,
-            UniversityInfoForApply universityInfoForApply) {
+            UnivApplyInfo univApplyInfo) {
         return new UniversityDetailResponse(
-                universityInfoForApply.getId(),
-                universityInfoForApply.getTerm(),
-                universityInfoForApply.getKoreanName(),
+                univApplyInfo.getId(),
+                univApplyInfo.getTerm(),
+                univApplyInfo.getKoreanName(),
                 university.getEnglishName(),
                 university.getFormatName(),
                 university.getRegion().getKoreanName(),
@@ -48,21 +48,21 @@ public record UniversityDetailResponse(
                 university.getLogoImageUrl(),
                 university.getBackgroundImageUrl(),
                 university.getDetailsForLocal(),
-                universityInfoForApply.getStudentCapacity(),
-                universityInfoForApply.getTuitionFeeType().getKoreanName(),
-                universityInfoForApply.getSemesterAvailableForDispatch().getKoreanName(),
-                universityInfoForApply.getLanguageRequirements().stream()
+                univApplyInfo.getStudentCapacity(),
+                univApplyInfo.getTuitionFeeType().getKoreanName(),
+                univApplyInfo.getSemesterAvailableForDispatch().getKoreanName(),
+                univApplyInfo.getLanguageRequirements().stream()
                         .map(LanguageRequirementResponse::from)
                         .toList(),
-                universityInfoForApply.getDetailsForLanguage(),
-                universityInfoForApply.getGpaRequirement(),
-                universityInfoForApply.getGpaRequirementCriteria(),
-                universityInfoForApply.getSemesterRequirement(),
-                universityInfoForApply.getDetailsForApply(),
-                universityInfoForApply.getDetailsForMajor(),
-                universityInfoForApply.getDetailsForAccommodation(),
-                universityInfoForApply.getDetailsForEnglishCourse(),
-                universityInfoForApply.getDetails(),
+                univApplyInfo.getDetailsForLanguage(),
+                univApplyInfo.getGpaRequirement(),
+                univApplyInfo.getGpaRequirementCriteria(),
+                univApplyInfo.getSemesterRequirement(),
+                univApplyInfo.getDetailsForApply(),
+                univApplyInfo.getDetailsForMajor(),
+                univApplyInfo.getDetailsForAccommodation(),
+                univApplyInfo.getDetailsForEnglishCourse(),
+                univApplyInfo.getDetails(),
                 university.getAccommodationUrl(),
                 university.getEnglishCourseUrl()
         );

--- a/src/main/java/com/example/solidconnection/university/dto/UniversityInfoForApplyPreviewResponse.java
+++ b/src/main/java/com/example/solidconnection/university/dto/UniversityInfoForApplyPreviewResponse.java
@@ -1,6 +1,6 @@
 package com.example.solidconnection.university.dto;
 
-import com.example.solidconnection.university.domain.UniversityInfoForApply;
+import com.example.solidconnection.university.domain.UnivApplyInfo;
 
 import java.util.Collections;
 import java.util.List;
@@ -16,22 +16,22 @@ public record UniversityInfoForApplyPreviewResponse(
         int studentCapacity,
         List<LanguageRequirementResponse> languageRequirements) {
 
-    public static UniversityInfoForApplyPreviewResponse from(UniversityInfoForApply universityInfoForApply) {
+    public static UniversityInfoForApplyPreviewResponse from(UnivApplyInfo univApplyInfo) {
         List<LanguageRequirementResponse> languageRequirementResponses = new java.util.ArrayList<>(
-                universityInfoForApply.getLanguageRequirements().stream()
+                univApplyInfo.getLanguageRequirements().stream()
                         .map(LanguageRequirementResponse::from)
                         .toList());
         Collections.sort(languageRequirementResponses);
 
         return new UniversityInfoForApplyPreviewResponse(
-                universityInfoForApply.getId(),
-                universityInfoForApply.getTerm(),
-                universityInfoForApply.getKoreanName(),
-                universityInfoForApply.getUniversity().getRegion().getKoreanName(),
-                universityInfoForApply.getUniversity().getCountry().getKoreanName(),
-                universityInfoForApply.getUniversity().getLogoImageUrl(),
-                universityInfoForApply.getUniversity().getBackgroundImageUrl(),
-                universityInfoForApply.getStudentCapacity(),
+                univApplyInfo.getId(),
+                univApplyInfo.getTerm(),
+                univApplyInfo.getKoreanName(),
+                univApplyInfo.getUniversity().getRegion().getKoreanName(),
+                univApplyInfo.getUniversity().getCountry().getKoreanName(),
+                univApplyInfo.getUniversity().getLogoImageUrl(),
+                univApplyInfo.getUniversity().getBackgroundImageUrl(),
+                univApplyInfo.getStudentCapacity(),
                 languageRequirementResponses
         );
     }

--- a/src/main/java/com/example/solidconnection/university/repository/LanguageRequirementRepository.java
+++ b/src/main/java/com/example/solidconnection/university/repository/LanguageRequirementRepository.java
@@ -1,18 +1,9 @@
 package com.example.solidconnection.university.repository;
 
 import com.example.solidconnection.university.domain.LanguageRequirement;
-import com.example.solidconnection.university.domain.LanguageTestType;
-import com.example.solidconnection.university.domain.UniversityInfoForApply;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
-
-import java.util.Optional;
 
 @Repository
 public interface LanguageRequirementRepository extends JpaRepository<LanguageRequirement, Long> {
-
-    @Query("SELECT lr FROM LanguageRequirement lr WHERE lr.minScore <= :myScore AND lr.languageTestType = :testType AND lr.universityInfoForApply = :universityInfoForApply ORDER BY lr.minScore ASC")
-    Optional<LanguageRequirement> findByUniversityInfoForApplyAndLanguageTestTypeAndLessThanMyScore(@Param("universityInfoForApply") UniversityInfoForApply universityInfoForApply, @Param("testType") LanguageTestType testType, @Param("myScore") String myScore);
 }

--- a/src/main/java/com/example/solidconnection/university/repository/UniversityInfoForApplyRepository.java
+++ b/src/main/java/com/example/solidconnection/university/repository/UniversityInfoForApplyRepository.java
@@ -2,8 +2,8 @@ package com.example.solidconnection.university.repository;
 
 import com.example.solidconnection.common.exception.CustomException;
 import com.example.solidconnection.siteuser.domain.SiteUser;
+import com.example.solidconnection.university.domain.UnivApplyInfo;
 import com.example.solidconnection.university.domain.University;
-import com.example.solidconnection.university.domain.UniversityInfoForApply;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -13,26 +13,25 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.example.solidconnection.common.exception.ErrorCode.UNIVERSITY_INFO_FOR_APPLY_NOT_FOUND;
-import static com.example.solidconnection.common.exception.ErrorCode.UNIVERSITY_INFO_FOR_APPLY_NOT_FOUND_FOR_TERM;
 
 @Repository
-public interface UniversityInfoForApplyRepository extends JpaRepository<UniversityInfoForApply, Long> {
+public interface UniversityInfoForApplyRepository extends JpaRepository<UnivApplyInfo, Long> {
 
-    Optional<UniversityInfoForApply> findByIdAndTerm(Long id, String term);
+    Optional<UnivApplyInfo> findByIdAndTerm(Long id, String term);
 
-    Optional<UniversityInfoForApply> findFirstByKoreanNameAndTerm(String koreanName, String term);
+    Optional<UnivApplyInfo> findFirstByKoreanNameAndTerm(String koreanName, String term);
 
     @Query("""
             SELECT uifa 
-            FROM UniversityInfoForApply uifa 
+            FROM UnivApplyInfo uifa 
             WHERE uifa.university IN :universities 
                 AND uifa.term = :term
             """)
-    List<UniversityInfoForApply> findByUniversitiesAndTerm(@Param("universities") List<University> universities, @Param("term") String term);
+    List<UnivApplyInfo> findByUniversitiesAndTerm(@Param("universities") List<University> universities, @Param("term") String term);
 
     @Query("""
             SELECT uifa
-            FROM UniversityInfoForApply uifa
+            FROM UnivApplyInfo uifa
             JOIN University u ON uifa.university = u
             WHERE (u.country.code IN (
                       SELECT c.code
@@ -48,7 +47,7 @@ public interface UniversityInfoForApplyRepository extends JpaRepository<Universi
                   ))
                   AND uifa.term = :term
             """)
-    List<UniversityInfoForApply> findUniversityInfoForAppliesBySiteUsersInterestedCountryOrRegionAndTerm(@Param("siteUser") SiteUser siteUser, @Param("term") String term);
+    List<UnivApplyInfo> findUniversityInfoForAppliesBySiteUsersInterestedCountryOrRegionAndTerm(@Param("siteUser") SiteUser siteUser, @Param("term") String term);
 
     @Query(value = """
                 SELECT *
@@ -57,30 +56,30 @@ public interface UniversityInfoForApplyRepository extends JpaRepository<Universi
                 ORDER BY RAND() 
                 LIMIT :limitNum
             """, nativeQuery = true)
-    List<UniversityInfoForApply> findRandomByTerm(@Param("term") String term, @Param("limitNum") int limitNum);
+    List<UnivApplyInfo> findRandomByTerm(@Param("term") String term, @Param("limitNum") int limitNum);
 
-    default UniversityInfoForApply getUniversityInfoForApplyById(Long id) {
+    default UnivApplyInfo getUniversityInfoForApplyById(Long id) {
         return findById(id)
                 .orElseThrow(() -> new CustomException(UNIVERSITY_INFO_FOR_APPLY_NOT_FOUND));
     }
 
     @Query("""
             SELECT DISTINCT uifa
-            FROM UniversityInfoForApply uifa
+            FROM UnivApplyInfo uifa
             JOIN FETCH uifa.university u
             JOIN FETCH u.country c
             JOIN FETCH u.region r
             WHERE uifa.id IN :ids
             """)
-    List<UniversityInfoForApply> findAllByUniversityIds(@Param("ids") List<Long> ids);
+    List<UnivApplyInfo> findAllByUniversityIds(@Param("ids") List<Long> ids);
 
     @Query("""
             SELECT DISTINCT uifa
-            FROM UniversityInfoForApply uifa
+            FROM UnivApplyInfo uifa
             JOIN FETCH uifa.university u
             JOIN FETCH u.country c
             JOIN FETCH u.region r
             WHERE u.id IN :universityIds
             """)
-    List<UniversityInfoForApply> findByUniversityIdsWithUniversityAndLocation(@Param("universityIds") List<Long> universityIds);
+    List<UnivApplyInfo> findByUniversityIdsWithUniversityAndLocation(@Param("universityIds") List<Long> universityIds);
 }

--- a/src/main/java/com/example/solidconnection/university/repository/custom/UniversityFilterRepository.java
+++ b/src/main/java/com/example/solidconnection/university/repository/custom/UniversityFilterRepository.java
@@ -1,15 +1,14 @@
 package com.example.solidconnection.university.repository.custom;
 
 import com.example.solidconnection.university.domain.LanguageTestType;
-import com.example.solidconnection.university.domain.University;
-import com.example.solidconnection.university.domain.UniversityInfoForApply;
+import com.example.solidconnection.university.domain.UnivApplyInfo;
 
 import java.util.List;
 
 public interface UniversityFilterRepository {
 
-    List<UniversityInfoForApply> findByRegionCodeAndKeywords(String regionCode, List<String> keywords);
+    List<UnivApplyInfo> findByRegionCodeAndKeywords(String regionCode, List<String> keywords);
 
-    List<UniversityInfoForApply> findByRegionCodeAndKeywordsAndLanguageTestTypeAndTestScoreAndTerm(
+    List<UnivApplyInfo> findByRegionCodeAndKeywordsAndLanguageTestTypeAndTestScoreAndTerm(
             String regionCode, List<String> keywords, LanguageTestType testType, String testScore, String term);
 }

--- a/src/main/java/com/example/solidconnection/university/repository/custom/UniversityFilterRepositoryImpl.java
+++ b/src/main/java/com/example/solidconnection/university/repository/custom/UniversityFilterRepositoryImpl.java
@@ -3,9 +3,9 @@ package com.example.solidconnection.university.repository.custom;
 import com.example.solidconnection.location.country.domain.QCountry;
 import com.example.solidconnection.location.region.domain.QRegion;
 import com.example.solidconnection.university.domain.LanguageTestType;
+import com.example.solidconnection.university.domain.QUnivApplyInfo;
 import com.example.solidconnection.university.domain.QUniversity;
-import com.example.solidconnection.university.domain.QUniversityInfoForApply;
-import com.example.solidconnection.university.domain.UniversityInfoForApply;
+import com.example.solidconnection.university.domain.UnivApplyInfo;
 import com.example.solidconnection.university.domain.QLanguageRequirement;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
@@ -28,19 +28,19 @@ public class UniversityFilterRepositoryImpl implements UniversityFilterRepositor
     }
 
     @Override
-    public List<UniversityInfoForApply> findByRegionCodeAndKeywords(String regionCode, List<String> keywords) {
-        QUniversityInfoForApply universityInfoForApply = QUniversityInfoForApply.universityInfoForApply;
+    public List<UnivApplyInfo> findByRegionCodeAndKeywords(String regionCode, List<String> keywords) {
+        QUnivApplyInfo univApplyInfo = QUnivApplyInfo.univApplyInfo;
         QUniversity university = QUniversity.university;
         QCountry country = QCountry.country;
         QRegion region = QRegion.region;
         QLanguageRequirement languageRequirement = QLanguageRequirement.languageRequirement;
 
         return queryFactory
-                .selectFrom(universityInfoForApply)
-                .join(universityInfoForApply.university, university).fetchJoin()
+                .selectFrom(univApplyInfo)
+                .join(univApplyInfo.university, university).fetchJoin()
                 .join(university.country, country).fetchJoin()
                 .join(country.region, region).fetchJoin()
-                .leftJoin(universityInfoForApply.languageRequirements, languageRequirement).fetchJoin()
+                .leftJoin(univApplyInfo.languageRequirements, languageRequirement).fetchJoin()
                 .where(
                         regionCodeEq(region, regionCode)
                                 .and(countryOrUniversityContainsKeyword(country, university, keywords))
@@ -74,40 +74,40 @@ public class UniversityFilterRepositoryImpl implements UniversityFilterRepositor
     }
 
     @Override
-    public List<UniversityInfoForApply> findByRegionCodeAndKeywordsAndLanguageTestTypeAndTestScoreAndTerm(
+    public List<UnivApplyInfo> findByRegionCodeAndKeywordsAndLanguageTestTypeAndTestScoreAndTerm(
             String regionCode, List<String> keywords, LanguageTestType testType, String testScore, String term) {
         QUniversity university = QUniversity.university;
         QCountry country = QCountry.country;
         QRegion region = QRegion.region;
-        QUniversityInfoForApply universityInfoForApply = QUniversityInfoForApply.universityInfoForApply;
+        QUnivApplyInfo univApplyInfo = QUnivApplyInfo.univApplyInfo;
 
-        List<UniversityInfoForApply> filteredUniversityInfoForApply = queryFactory
-                .selectFrom(universityInfoForApply)
-                .join(universityInfoForApply.university, university)
+        List<UnivApplyInfo> filteredUnivApplyInfo = queryFactory
+                .selectFrom(univApplyInfo)
+                .join(univApplyInfo.university, university)
                 .join(university.country, country)
                 .join(university.region, region)
                 .where(regionCodeEq(region, regionCode)
                         .and(countryOrUniversityContainsKeyword(country, university, keywords))
-                        .and(universityInfoForApply.term.eq(term)))
+                        .and(univApplyInfo.term.eq(term)))
                 .fetch();
 
         if (testScore == null || testScore.isEmpty()) {
             if (testType != null) {
-                return filteredUniversityInfoForApply.stream()
+                return filteredUnivApplyInfo.stream()
                         .filter(uifa -> uifa.getLanguageRequirements().stream()
                                 .anyMatch(lr -> lr.getLanguageTestType().equals(testType)))
                         .toList();
             }
-            return filteredUniversityInfoForApply;
+            return filteredUnivApplyInfo;
         }
 
-        return filteredUniversityInfoForApply.stream()
+        return filteredUnivApplyInfo.stream()
                 .filter(uifa -> compareMyTestScoreToMinPassScore(uifa, testType, testScore) >= 0)
                 .toList();
     }
 
-    private int compareMyTestScoreToMinPassScore(UniversityInfoForApply universityInfoForApply, LanguageTestType testType, String testScore) {
-        return universityInfoForApply.getLanguageRequirements().stream()
+    private int compareMyTestScoreToMinPassScore(UnivApplyInfo univApplyInfo, LanguageTestType testType, String testScore) {
+        return univApplyInfo.getLanguageRequirements().stream()
                 .filter(languageRequirement -> languageRequirement.getLanguageTestType().equals(testType))
                 .findFirst()
                 .map(requirement -> testType.compare(testScore, requirement.getMinScore()))

--- a/src/main/java/com/example/solidconnection/university/service/GeneralUniversityRecommendService.java
+++ b/src/main/java/com/example/solidconnection/university/service/GeneralUniversityRecommendService.java
@@ -1,6 +1,6 @@
 package com.example.solidconnection.university.service;
 
-import com.example.solidconnection.university.domain.UniversityInfoForApply;
+import com.example.solidconnection.university.domain.UnivApplyInfo;
 import com.example.solidconnection.university.repository.UniversityInfoForApplyRepository;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -23,7 +23,7 @@ public class GeneralUniversityRecommendService {
     private final UniversityInfoForApplyRepository universityInfoForApplyRepository;
 
     @Getter
-    private List<UniversityInfoForApply> recommendUniversities;
+    private List<UnivApplyInfo> recommendUniversities;
 
     @Value("${university.term}")
     public String term;

--- a/src/main/java/com/example/solidconnection/university/service/UniversityLikeService.java
+++ b/src/main/java/com/example/solidconnection/university/service/UniversityLikeService.java
@@ -4,7 +4,7 @@ import com.example.solidconnection.common.exception.CustomException;
 import com.example.solidconnection.siteuser.domain.SiteUser;
 import com.example.solidconnection.siteuser.repository.LikedUniversityRepository;
 import com.example.solidconnection.university.domain.LikedUniversity;
-import com.example.solidconnection.university.domain.UniversityInfoForApply;
+import com.example.solidconnection.university.domain.UnivApplyInfo;
 import com.example.solidconnection.university.dto.IsLikeResponse;
 import com.example.solidconnection.university.dto.LikeResultResponse;
 import com.example.solidconnection.university.repository.UniversityInfoForApplyRepository;
@@ -36,15 +36,15 @@ public class UniversityLikeService {
      * */
     @Transactional
     public LikeResultResponse likeUniversity(SiteUser siteUser, Long universityInfoForApplyId) {
-        UniversityInfoForApply universityInfoForApply = universityInfoForApplyRepository.getUniversityInfoForApplyById(universityInfoForApplyId);
+        UnivApplyInfo univApplyInfo = universityInfoForApplyRepository.getUniversityInfoForApplyById(universityInfoForApplyId);
 
-        Optional<LikedUniversity> optionalLikedUniversity = likedUniversityRepository.findBySiteUserAndUniversityInfoForApply(siteUser, universityInfoForApply);
+        Optional<LikedUniversity> optionalLikedUniversity = likedUniversityRepository.findBySiteUserAndUnivApplyInfo(siteUser, univApplyInfo);
         if (optionalLikedUniversity.isPresent()) {
             throw new CustomException(ALREADY_LIKED_UNIVERSITY);
         }
 
         LikedUniversity likedUniversity = LikedUniversity.builder()
-                .universityInfoForApply(universityInfoForApply)
+                .univApplyInfo(univApplyInfo)
                 .siteUser(siteUser)
                 .build();
         likedUniversityRepository.save(likedUniversity);
@@ -56,9 +56,9 @@ public class UniversityLikeService {
      * */
     @Transactional
     public LikeResultResponse cancelLikeUniversity(SiteUser siteUser, long universityInfoForApplyId) throws CustomException {
-        UniversityInfoForApply universityInfoForApply = universityInfoForApplyRepository.getUniversityInfoForApplyById(universityInfoForApplyId);
+        UnivApplyInfo univApplyInfo = universityInfoForApplyRepository.getUniversityInfoForApplyById(universityInfoForApplyId);
 
-        Optional<LikedUniversity> optionalLikedUniversity = likedUniversityRepository.findBySiteUserAndUniversityInfoForApply(siteUser, universityInfoForApply);
+        Optional<LikedUniversity> optionalLikedUniversity = likedUniversityRepository.findBySiteUserAndUnivApplyInfo(siteUser, univApplyInfo);
         if (optionalLikedUniversity.isEmpty()) {
             throw new CustomException(NOT_LIKED_UNIVERSITY);
         }
@@ -72,8 +72,8 @@ public class UniversityLikeService {
      * */
     @Transactional(readOnly = true)
     public IsLikeResponse getIsLiked(SiteUser siteUser, Long universityInfoForApplyId) {
-        UniversityInfoForApply universityInfoForApply = universityInfoForApplyRepository.getUniversityInfoForApplyById(universityInfoForApplyId);
-        boolean isLike = likedUniversityRepository.findBySiteUserAndUniversityInfoForApply(siteUser, universityInfoForApply).isPresent();
+        UnivApplyInfo univApplyInfo = universityInfoForApplyRepository.getUniversityInfoForApplyById(universityInfoForApplyId);
+        boolean isLike = likedUniversityRepository.findBySiteUserAndUnivApplyInfo(siteUser, univApplyInfo).isPresent();
         return new IsLikeResponse(isLike);
     }
 }

--- a/src/main/java/com/example/solidconnection/university/service/UniversityQueryService.java
+++ b/src/main/java/com/example/solidconnection/university/service/UniversityQueryService.java
@@ -3,7 +3,7 @@ package com.example.solidconnection.university.service;
 import com.example.solidconnection.cache.annotation.ThunderingHerdCaching;
 import com.example.solidconnection.university.domain.LanguageTestType;
 import com.example.solidconnection.university.domain.University;
-import com.example.solidconnection.university.domain.UniversityInfoForApply;
+import com.example.solidconnection.university.domain.UnivApplyInfo;
 import com.example.solidconnection.university.dto.UniversityDetailResponse;
 import com.example.solidconnection.university.dto.UniversityInfoForApplyPreviewResponse;
 import com.example.solidconnection.university.dto.UniversityInfoForApplyPreviewResponses;
@@ -33,11 +33,11 @@ public class UniversityQueryService {
     @Transactional(readOnly = true)
     @ThunderingHerdCaching(key = "university:{0}", cacheManager = "customCacheManager", ttlSec = 86400)
     public UniversityDetailResponse getUniversityDetail(Long universityInfoForApplyId) {
-        UniversityInfoForApply universityInfoForApply
+        UnivApplyInfo univApplyInfo
                 = universityInfoForApplyRepository.getUniversityInfoForApplyById(universityInfoForApplyId);
-        University university = universityInfoForApply.getUniversity();
+        University university = univApplyInfo.getUniversity();
 
-        return UniversityDetailResponse.of(university, universityInfoForApply);
+        return UniversityDetailResponse.of(university, univApplyInfo);
     }
 
     /*

--- a/src/main/java/com/example/solidconnection/university/service/UniversityRecommendService.java
+++ b/src/main/java/com/example/solidconnection/university/service/UniversityRecommendService.java
@@ -2,7 +2,7 @@ package com.example.solidconnection.university.service;
 
 import com.example.solidconnection.cache.annotation.ThunderingHerdCaching;
 import com.example.solidconnection.siteuser.domain.SiteUser;
-import com.example.solidconnection.university.domain.UniversityInfoForApply;
+import com.example.solidconnection.university.domain.UnivApplyInfo;
 import com.example.solidconnection.university.dto.UniversityInfoForApplyPreviewResponse;
 import com.example.solidconnection.university.dto.UniversityRecommendsResponse;
 import com.example.solidconnection.university.repository.UniversityInfoForApplyRepository;
@@ -36,9 +36,9 @@ public class UniversityRecommendService {
     @Transactional(readOnly = true)
     public UniversityRecommendsResponse getPersonalRecommends(SiteUser siteUser) {
         // 맞춤 추천 대학교를 불러온다.
-        List<UniversityInfoForApply> personalRecommends = universityInfoForApplyRepository
+        List<UnivApplyInfo> personalRecommends = universityInfoForApplyRepository
                 .findUniversityInfoForAppliesBySiteUsersInterestedCountryOrRegionAndTerm(siteUser, term);
-        List<UniversityInfoForApply> trimmedRecommendUniversities
+        List<UnivApplyInfo> trimmedRecommendUniversities
                 = personalRecommends.subList(0, Math.min(RECOMMEND_UNIVERSITY_NUM, personalRecommends.size()));
         Collections.shuffle(trimmedRecommendUniversities);
 
@@ -52,8 +52,8 @@ public class UniversityRecommendService {
                 .toList());
     }
 
-    private List<UniversityInfoForApply> getGeneralRecommendsExcludingSelected(List<UniversityInfoForApply> alreadyPicked) {
-        List<UniversityInfoForApply> generalRecommend = new ArrayList<>(generalUniversityRecommendService.getRecommendUniversities());
+    private List<UnivApplyInfo> getGeneralRecommendsExcludingSelected(List<UnivApplyInfo> alreadyPicked) {
+        List<UnivApplyInfo> generalRecommend = new ArrayList<>(generalUniversityRecommendService.getRecommendUniversities());
         generalRecommend.removeAll(alreadyPicked);
         Collections.shuffle(generalRecommend);
         return generalRecommend.subList(0, RECOMMEND_UNIVERSITY_NUM - alreadyPicked.size());
@@ -65,7 +65,7 @@ public class UniversityRecommendService {
     @Transactional(readOnly = true)
     @ThunderingHerdCaching(key = "university:recommend:general", cacheManager = "customCacheManager", ttlSec = 86400)
     public UniversityRecommendsResponse getGeneralRecommends() {
-        List<UniversityInfoForApply> generalRecommends = new ArrayList<>(generalUniversityRecommendService.getRecommendUniversities());
+        List<UnivApplyInfo> generalRecommends = new ArrayList<>(generalUniversityRecommendService.getRecommendUniversities());
         return new UniversityRecommendsResponse(generalRecommends.stream()
                 .map(UniversityInfoForApplyPreviewResponse::from)
                 .toList());

--- a/src/main/resources/db/migration/V15__add_unique_constraint_to_liked_university.sql
+++ b/src/main/resources/db/migration/V15__add_unique_constraint_to_liked_university.sql
@@ -1,0 +1,3 @@
+ALTER TABLE liked_university
+ADD CONSTRAINT uk_liked_university_site_user_id_university_info_for_apply_id
+UNIQUE (site_user_id, university_info_for_apply_id);

--- a/src/test/java/com/example/solidconnection/application/fixture/ApplicationFixture.java
+++ b/src/test/java/com/example/solidconnection/application/fixture/ApplicationFixture.java
@@ -4,7 +4,7 @@ import com.example.solidconnection.application.domain.Application;
 import com.example.solidconnection.application.domain.Gpa;
 import com.example.solidconnection.application.domain.LanguageTest;
 import com.example.solidconnection.siteuser.domain.SiteUser;
-import com.example.solidconnection.university.domain.UniversityInfoForApply;
+import com.example.solidconnection.university.domain.UnivApplyInfo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.test.context.TestComponent;
 

--- a/src/test/java/com/example/solidconnection/application/fixture/ApplicationFixtureBuilder.java
+++ b/src/test/java/com/example/solidconnection/application/fixture/ApplicationFixtureBuilder.java
@@ -6,7 +6,6 @@ import com.example.solidconnection.application.domain.LanguageTest;
 import com.example.solidconnection.application.domain.VerifyStatus;
 import com.example.solidconnection.application.repository.ApplicationRepository;
 import com.example.solidconnection.siteuser.domain.SiteUser;
-import com.example.solidconnection.university.domain.UniversityInfoForApply;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.test.context.TestComponent;
 

--- a/src/test/java/com/example/solidconnection/application/service/ApplicationQueryServiceTest.java
+++ b/src/test/java/com/example/solidconnection/application/service/ApplicationQueryServiceTest.java
@@ -15,8 +15,8 @@ import com.example.solidconnection.score.fixture.LanguageTestScoreFixture;
 import com.example.solidconnection.siteuser.domain.SiteUser;
 import com.example.solidconnection.siteuser.fixture.SiteUserFixture;
 import com.example.solidconnection.support.TestContainerSpringBootTest;
-import com.example.solidconnection.university.domain.UniversityInfoForApply;
-import com.example.solidconnection.university.fixture.UniversityInfoForApplyFixture;
+import com.example.solidconnection.university.domain.UnivApplyInfo;
+import com.example.solidconnection.university.fixture.UnivApplyInfoFixture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -45,7 +45,7 @@ class ApplicationQueryServiceTest {
     private RegionFixture regionFixture;
 
     @Autowired
-    private UniversityInfoForApplyFixture universityInfoForApplyFixture;
+    private UnivApplyInfoFixture univApplyInfoFixture;
 
     @Autowired
     private GpaScoreFixture gpaScoreFixture;
@@ -71,9 +71,9 @@ class ApplicationQueryServiceTest {
     private LanguageTestScore languageTestScore2;
     private LanguageTestScore languageTestScore3;
 
-    private UniversityInfoForApply 괌대학_A_지원_정보;
-    private UniversityInfoForApply 괌대학_B_지원_정보;
-    private UniversityInfoForApply 서던덴마크대학교_지원_정보;
+    private UnivApplyInfo 괌대학_A_지원_정보;
+    private UnivApplyInfo 괌대학_B_지원_정보;
+    private UnivApplyInfo 서던덴마크대학교_지원_정보;
 
     @BeforeEach
     void setUp() {
@@ -89,9 +89,9 @@ class ApplicationQueryServiceTest {
         gpaScore3 = gpaScoreFixture.GPA_점수(VerifyStatus.APPROVED, user3);
         languageTestScore3 = languageTestScoreFixture.어학_점수(VerifyStatus.APPROVED, user3);
 
-        괌대학_A_지원_정보 = universityInfoForApplyFixture.괌대학_A_지원_정보();
-        괌대학_B_지원_정보 = universityInfoForApplyFixture.괌대학_B_지원_정보();
-        서던덴마크대학교_지원_정보 = universityInfoForApplyFixture.서던덴마크대학교_지원_정보();
+        괌대학_A_지원_정보 = univApplyInfoFixture.괌대학_A_지원_정보();
+        괌대학_B_지원_정보 = univApplyInfoFixture.괌대학_B_지원_정보();
+        서던덴마크대학교_지원_정보 = univApplyInfoFixture.서던덴마크대학교_지원_정보();
     }
 
     @Nested

--- a/src/test/java/com/example/solidconnection/application/service/ApplicationSubmissionServiceTest.java
+++ b/src/test/java/com/example/solidconnection/application/service/ApplicationSubmissionServiceTest.java
@@ -14,8 +14,8 @@ import com.example.solidconnection.score.fixture.LanguageTestScoreFixture;
 import com.example.solidconnection.siteuser.domain.SiteUser;
 import com.example.solidconnection.siteuser.fixture.SiteUserFixture;
 import com.example.solidconnection.support.TestContainerSpringBootTest;
-import com.example.solidconnection.university.domain.UniversityInfoForApply;
-import com.example.solidconnection.university.fixture.UniversityInfoForApplyFixture;
+import com.example.solidconnection.university.domain.UnivApplyInfo;
+import com.example.solidconnection.university.fixture.UnivApplyInfoFixture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -44,7 +44,7 @@ class ApplicationSubmissionServiceTest {
     private SiteUserFixture siteUserFixture;
 
     @Autowired
-    private UniversityInfoForApplyFixture universityInfoForApplyFixture;
+    private UnivApplyInfoFixture univApplyInfoFixture;
 
     @Autowired
     private GpaScoreFixture gpaScoreFixture;
@@ -56,16 +56,16 @@ class ApplicationSubmissionServiceTest {
     private String term;
 
     private SiteUser user;
-    private UniversityInfoForApply 괌대학_A_지원_정보;
-    private UniversityInfoForApply 괌대학_B_지원_정보;
-    private UniversityInfoForApply 서던덴마크대학교_지원_정보;
+    private UnivApplyInfo 괌대학_A_지원_정보;
+    private UnivApplyInfo 괌대학_B_지원_정보;
+    private UnivApplyInfo 서던덴마크대학교_지원_정보;
 
     @BeforeEach
     void setUp() {
         user = siteUserFixture.사용자();
-        괌대학_A_지원_정보 = universityInfoForApplyFixture.괌대학_A_지원_정보();
-        괌대학_B_지원_정보 = universityInfoForApplyFixture.괌대학_B_지원_정보();
-        서던덴마크대학교_지원_정보 = universityInfoForApplyFixture.서던덴마크대학교_지원_정보();
+        괌대학_A_지원_정보 = univApplyInfoFixture.괌대학_A_지원_정보();
+        괌대학_B_지원_정보 = univApplyInfoFixture.괌대학_B_지원_정보();
+        서던덴마크대학교_지원_정보 = univApplyInfoFixture.서던덴마크대학교_지원_정보();
     }
 
     @Test

--- a/src/test/java/com/example/solidconnection/siteuser/service/MyPageServiceTest.java
+++ b/src/test/java/com/example/solidconnection/siteuser/service/MyPageServiceTest.java
@@ -15,7 +15,7 @@ import com.example.solidconnection.siteuser.repository.SiteUserRepository;
 import com.example.solidconnection.support.TestContainerSpringBootTest;
 import com.example.solidconnection.university.domain.LikedUniversity;
 import com.example.solidconnection.university.dto.UniversityInfoForApplyPreviewResponse;
-import com.example.solidconnection.university.fixture.UniversityInfoForApplyFixture;
+import com.example.solidconnection.university.fixture.UnivApplyInfoFixture;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -60,7 +60,7 @@ class MyPageServiceTest {
     private SiteUserFixture siteUserFixture;
 
     @Autowired
-    private UniversityInfoForApplyFixture universityInfoForApplyFixture;
+    private UnivApplyInfoFixture univApplyInfoFixture;
 
     @Autowired
     private SiteUserFixtureBuilder siteUserFixtureBuilder;
@@ -193,9 +193,9 @@ class MyPageServiceTest {
     }
 
     private int createLikedUniversities(SiteUser testUser) {
-        LikedUniversity likedUniversity1 = new LikedUniversity(null, universityInfoForApplyFixture.괌대학_A_지원_정보(), testUser);
-        LikedUniversity likedUniversity2 = new LikedUniversity(null, universityInfoForApplyFixture.메이지대학_지원_정보(), testUser);
-        LikedUniversity likedUniversity3 = new LikedUniversity(null, universityInfoForApplyFixture.코펜하겐IT대학_지원_정보(), testUser);
+        LikedUniversity likedUniversity1 = new LikedUniversity(null, univApplyInfoFixture.괌대학_A_지원_정보(), testUser);
+        LikedUniversity likedUniversity2 = new LikedUniversity(null, univApplyInfoFixture.메이지대학_지원_정보(), testUser);
+        LikedUniversity likedUniversity3 = new LikedUniversity(null, univApplyInfoFixture.코펜하겐IT대학_지원_정보(), testUser);
 
         likedUniversityRepository.save(likedUniversity1);
         likedUniversityRepository.save(likedUniversity2);

--- a/src/test/java/com/example/solidconnection/university/fixture/LanguageRequirementFixture.java
+++ b/src/test/java/com/example/solidconnection/university/fixture/LanguageRequirementFixture.java
@@ -2,7 +2,7 @@ package com.example.solidconnection.university.fixture;
 
 import com.example.solidconnection.university.domain.LanguageRequirement;
 import com.example.solidconnection.university.domain.LanguageTestType;
-import com.example.solidconnection.university.domain.UniversityInfoForApply;
+import com.example.solidconnection.university.domain.UnivApplyInfo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.test.context.TestComponent;
 
@@ -12,7 +12,7 @@ public class LanguageRequirementFixture {
 
     private final LanguageRequirementFixtureBuilder languageRequirementFixtureBuilder;
 
-    public LanguageRequirement 토플_80(UniversityInfoForApply universityInfo) {
+    public LanguageRequirement 토플_80(UnivApplyInfo universityInfo) {
         return languageRequirementFixtureBuilder
                 .languageTestType(LanguageTestType.TOEFL_IBT)
                 .minScore("80")
@@ -20,7 +20,7 @@ public class LanguageRequirementFixture {
                 .create();
     }
 
-    public LanguageRequirement 토플_70(UniversityInfoForApply universityInfo) {
+    public LanguageRequirement 토플_70(UnivApplyInfo universityInfo) {
         return languageRequirementFixtureBuilder
                 .languageTestType(LanguageTestType.TOEFL_IBT)
                 .minScore("70")
@@ -28,7 +28,7 @@ public class LanguageRequirementFixture {
                 .create();
     }
 
-    public LanguageRequirement 토익_800(UniversityInfoForApply universityInfo) {
+    public LanguageRequirement 토익_800(UnivApplyInfo universityInfo) {
         return languageRequirementFixtureBuilder
                 .languageTestType(LanguageTestType.TOEIC)
                 .minScore("800")
@@ -36,7 +36,7 @@ public class LanguageRequirementFixture {
                 .create();
     }
 
-    public LanguageRequirement 토익_900(UniversityInfoForApply universityInfo) {
+    public LanguageRequirement 토익_900(UnivApplyInfo universityInfo) {
         return languageRequirementFixtureBuilder
                 .languageTestType(LanguageTestType.TOEIC)
                 .minScore("900")
@@ -44,7 +44,7 @@ public class LanguageRequirementFixture {
                 .create();
     }
 
-    public LanguageRequirement JLPT_N2(UniversityInfoForApply universityInfo) {
+    public LanguageRequirement JLPT_N2(UnivApplyInfo universityInfo) {
         return languageRequirementFixtureBuilder
                 .languageTestType(LanguageTestType.JLPT)
                 .minScore("N2")

--- a/src/test/java/com/example/solidconnection/university/fixture/LanguageRequirementFixtureBuilder.java
+++ b/src/test/java/com/example/solidconnection/university/fixture/LanguageRequirementFixtureBuilder.java
@@ -2,7 +2,7 @@ package com.example.solidconnection.university.fixture;
 
 import com.example.solidconnection.university.domain.LanguageRequirement;
 import com.example.solidconnection.university.domain.LanguageTestType;
-import com.example.solidconnection.university.domain.UniversityInfoForApply;
+import com.example.solidconnection.university.domain.UnivApplyInfo;
 import com.example.solidconnection.university.repository.LanguageRequirementRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.test.context.TestComponent;
@@ -15,7 +15,7 @@ public class LanguageRequirementFixtureBuilder {
 
     private LanguageTestType languageTestType;
     private String minScore;
-    private UniversityInfoForApply universityInfoForApply;
+    private UnivApplyInfo univApplyInfo;
 
     public LanguageRequirementFixtureBuilder languageTestType(LanguageTestType languageTestType) {
         this.languageTestType = languageTestType;
@@ -27,8 +27,8 @@ public class LanguageRequirementFixtureBuilder {
         return this;
     }
 
-    public LanguageRequirementFixtureBuilder universityInfoForApply(UniversityInfoForApply universityInfoForApply) {
-        this.universityInfoForApply = universityInfoForApply;
+    public LanguageRequirementFixtureBuilder universityInfoForApply(UnivApplyInfo univApplyInfo) {
+        this.univApplyInfo = univApplyInfo;
         return this;
     }
 
@@ -37,9 +37,9 @@ public class LanguageRequirementFixtureBuilder {
                 null,
                 languageTestType,
                 minScore,
-                universityInfoForApply
+                univApplyInfo
         );
-        universityInfoForApply.addLanguageRequirements(languageRequirement);
+        univApplyInfo.addLanguageRequirements(languageRequirement);
         return languageRequirementRepository.save(languageRequirement);
     }
 }

--- a/src/test/java/com/example/solidconnection/university/fixture/UnivApplyInfoFixture.java
+++ b/src/test/java/com/example/solidconnection/university/fixture/UnivApplyInfoFixture.java
@@ -1,94 +1,94 @@
 package com.example.solidconnection.university.fixture;
 
-import com.example.solidconnection.university.domain.UniversityInfoForApply;
+import com.example.solidconnection.university.domain.UnivApplyInfo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.TestComponent;
 
 @TestComponent
 @RequiredArgsConstructor
-public class UniversityInfoForApplyFixture {
+public class UnivApplyInfoFixture {
 
-    private final UniversityInfoForApplyFixtureBuilder universityInfoForApplyFixtureBuilder;
+    private final UnivApplyInfoFixtureBuilder univApplyInfoFixtureBuilder;
     private final UniversityFixture universityFixture;
 
     @Value("${university.term}")
     public String term;
 
-    public UniversityInfoForApply 괌대학_A_지원_정보() {
-        return universityInfoForApplyFixtureBuilder.universityInfoForApply()
+    public UnivApplyInfo 괌대학_A_지원_정보() {
+        return univApplyInfoFixtureBuilder.universityInfoForApply()
                 .term(term)
                 .koreanName("괌대학(A형)")
                 .university(universityFixture.괌_대학())
                 .create();
     }
 
-    public UniversityInfoForApply 괌대학_B_지원_정보() {
-        return universityInfoForApplyFixtureBuilder.universityInfoForApply()
+    public UnivApplyInfo 괌대학_B_지원_정보() {
+        return univApplyInfoFixtureBuilder.universityInfoForApply()
                 .term(term)
                 .koreanName("괌대학(B형)")
                 .university(universityFixture.괌_대학())
                 .create();
     }
 
-    public UniversityInfoForApply 네바다주립대학_라스베이거스_지원_정보() {
-        return universityInfoForApplyFixtureBuilder.universityInfoForApply()
+    public UnivApplyInfo 네바다주립대학_라스베이거스_지원_정보() {
+        return univApplyInfoFixtureBuilder.universityInfoForApply()
                 .term(term)
                 .koreanName("네바다주립대학 라스베이거스(B형)")
                 .university(universityFixture.네바다주립_대학_라스베이거스())
                 .create();
     }
 
-    public UniversityInfoForApply 메모리얼대학_세인트존스_A_지원_정보() {
-        return universityInfoForApplyFixtureBuilder.universityInfoForApply()
+    public UnivApplyInfo 메모리얼대학_세인트존스_A_지원_정보() {
+        return univApplyInfoFixtureBuilder.universityInfoForApply()
                 .term(term)
                 .koreanName("메모리얼 대학 세인트존스(A형)")
                 .university(universityFixture.메모리얼_대학_세인트존스())
                 .create();
     }
 
-    public UniversityInfoForApply 서던덴마크대학교_지원_정보() {
-        return universityInfoForApplyFixtureBuilder.universityInfoForApply()
+    public UnivApplyInfo 서던덴마크대학교_지원_정보() {
+        return univApplyInfoFixtureBuilder.universityInfoForApply()
                 .term(term)
                 .koreanName("서던덴마크대학교")
                 .university(universityFixture.서던덴마크_대학())
                 .create();
     }
 
-    public UniversityInfoForApply 코펜하겐IT대학_지원_정보() {
-        return universityInfoForApplyFixtureBuilder.universityInfoForApply()
+    public UnivApplyInfo 코펜하겐IT대학_지원_정보() {
+        return univApplyInfoFixtureBuilder.universityInfoForApply()
                 .term(term)
                 .koreanName("코펜하겐 IT대학")
                 .university(universityFixture.코펜하겐IT_대학())
                 .create();
     }
 
-    public UniversityInfoForApply 그라츠대학_지원_정보() {
-        return universityInfoForApplyFixtureBuilder.universityInfoForApply()
+    public UnivApplyInfo 그라츠대학_지원_정보() {
+        return univApplyInfoFixtureBuilder.universityInfoForApply()
                 .term(term)
                 .koreanName("그라츠 대학")
                 .university(universityFixture.그라츠_대학())
                 .create();
     }
 
-    public UniversityInfoForApply 그라츠공과대학_지원_정보() {
-        return universityInfoForApplyFixtureBuilder.universityInfoForApply()
+    public UnivApplyInfo 그라츠공과대학_지원_정보() {
+        return univApplyInfoFixtureBuilder.universityInfoForApply()
                 .term(term)
                 .koreanName("그라츠공과대학")
                 .university(universityFixture.그라츠공과_대학())
                 .create();
     }
 
-    public UniversityInfoForApply 린츠_카톨릭대학_지원_정보() {
-        return universityInfoForApplyFixtureBuilder.universityInfoForApply()
+    public UnivApplyInfo 린츠_카톨릭대학_지원_정보() {
+        return univApplyInfoFixtureBuilder.universityInfoForApply()
                 .term(term)
                 .koreanName("린츠 카톨릭 대학교")
                 .university(universityFixture.린츠_카톨릭_대학())
                 .create();
     }
 
-    public UniversityInfoForApply 메이지대학_지원_정보() {
-        return universityInfoForApplyFixtureBuilder.universityInfoForApply()
+    public UnivApplyInfo 메이지대학_지원_정보() {
+        return univApplyInfoFixtureBuilder.universityInfoForApply()
                 .term(term)
                 .koreanName("메이지대학")
                 .university(universityFixture.메이지_대학())

--- a/src/test/java/com/example/solidconnection/university/fixture/UnivApplyInfoFixtureBuilder.java
+++ b/src/test/java/com/example/solidconnection/university/fixture/UnivApplyInfoFixtureBuilder.java
@@ -1,7 +1,7 @@
 package com.example.solidconnection.university.fixture;
 
 import com.example.solidconnection.university.domain.University;
-import com.example.solidconnection.university.domain.UniversityInfoForApply;
+import com.example.solidconnection.university.domain.UnivApplyInfo;
 import com.example.solidconnection.university.repository.UniversityInfoForApplyRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.test.context.TestComponent;
@@ -13,7 +13,7 @@ import static com.example.solidconnection.university.domain.TuitionFeeType.HOME_
 
 @TestComponent
 @RequiredArgsConstructor
-public class UniversityInfoForApplyFixtureBuilder {
+public class UnivApplyInfoFixtureBuilder {
 
     private final UniversityInfoForApplyRepository universityInfoForApplyRepository;
 
@@ -21,33 +21,33 @@ public class UniversityInfoForApplyFixtureBuilder {
     private String koreanName;
     private University university;
 
-    public UniversityInfoForApplyFixtureBuilder universityInfoForApply() {
-        return new UniversityInfoForApplyFixtureBuilder(universityInfoForApplyRepository);
+    public UnivApplyInfoFixtureBuilder universityInfoForApply() {
+        return new UnivApplyInfoFixtureBuilder(universityInfoForApplyRepository);
     }
 
-    public UniversityInfoForApplyFixtureBuilder term(String term) {
+    public UnivApplyInfoFixtureBuilder term(String term) {
         this.term = term;
         return this;
     }
 
-    public UniversityInfoForApplyFixtureBuilder koreanName(String koreanName) {
+    public UnivApplyInfoFixtureBuilder koreanName(String koreanName) {
         this.koreanName = koreanName;
         return this;
     }
 
-    public UniversityInfoForApplyFixtureBuilder university(University university) {
+    public UnivApplyInfoFixtureBuilder university(University university) {
         this.university = university;
         return this;
     }
 
-    public UniversityInfoForApply create() {
-        UniversityInfoForApply universityInfoForApply = new UniversityInfoForApply(
+    public UnivApplyInfo create() {
+        UnivApplyInfo univApplyInfo = new UnivApplyInfo(
                 null, term, koreanName, 1, HOME_UNIVERSITY_PAYMENT, ONE_SEMESTER,
                 "1", "detailsForLanguage", "gpaRequirement",
                 "gpaRequirementCriteria", "detailsForApply", "detailsForMajor",
                 "detailsForAccommodation", "detailsForEnglishCourse", "details",
                 new HashSet<>(), university
         );
-        return universityInfoForApplyRepository.save(universityInfoForApply);
+        return universityInfoForApplyRepository.save(univApplyInfo);
     }
 }

--- a/src/test/java/com/example/solidconnection/university/repository/UniversityLikeRepositoryTest.java
+++ b/src/test/java/com/example/solidconnection/university/repository/UniversityLikeRepositoryTest.java
@@ -1,0 +1,89 @@
+package com.example.solidconnection.university.repository;
+
+import com.example.solidconnection.siteuser.domain.SiteUser;
+import com.example.solidconnection.siteuser.fixture.SiteUserFixture;
+import com.example.solidconnection.siteuser.repository.LikedUniversityRepository;
+import com.example.solidconnection.support.TestContainerSpringBootTest;
+import com.example.solidconnection.university.domain.LikedUniversity;
+import com.example.solidconnection.university.domain.UnivApplyInfo;
+import com.example.solidconnection.university.fixture.UnivApplyInfoFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
+
+@TestContainerSpringBootTest
+@DisplayName("대학교 좋아요 레파지토리 테스트")
+public class UniversityLikeRepositoryTest {
+
+    @Autowired
+    private LikedUniversityRepository likedUniversityRepository;
+
+    @Autowired
+    private SiteUserFixture siteUserFixture;
+
+    @Autowired
+    private UnivApplyInfoFixture univApplyInfoFixture;
+
+    @Nested
+    class 사용자와_좋아요한_대학은_복합_유니크_제약조건을_갖는다 {
+
+        @Test
+        void 같은_사용자가_같은_대학에_중복으로_좋아요하면_예외_응답을_반환한다() {
+            // given
+            SiteUser user = siteUserFixture.사용자();
+            UnivApplyInfo university = univApplyInfoFixture.괌대학_A_지원_정보();
+
+            LikedUniversity firstLike = createLikedUniversity(user, university);
+            likedUniversityRepository.save(firstLike);
+
+            LikedUniversity secondLike = createLikedUniversity(user, university);
+
+            // when & then
+            assertThatCode(() -> likedUniversityRepository.save(secondLike))
+                    .isInstanceOf(DataIntegrityViolationException.class);
+        }
+
+        @Test
+        void 다른_사용자가_같은_대학에_좋아요하면_정상_저장된다() {
+            // given
+            SiteUser user1 = siteUserFixture.사용자(1, "user1");
+            SiteUser user2 = siteUserFixture.사용자(2, "user2");
+            UnivApplyInfo university = univApplyInfoFixture.괌대학_A_지원_정보();
+
+            LikedUniversity firstLike = createLikedUniversity(user1, university);
+            likedUniversityRepository.save(firstLike);
+
+            LikedUniversity secondLike = createLikedUniversity(user2, university);
+
+            // when & then
+            assertThatCode(() -> likedUniversityRepository.save(secondLike)).doesNotThrowAnyException();
+        }
+
+        @Test
+        void 같은_사용자가_다른_대학에_좋아요하면_정상_저장된다() {
+            // given
+            SiteUser user = siteUserFixture.사용자();
+            UnivApplyInfo university1 = univApplyInfoFixture.괌대학_A_지원_정보();
+            UnivApplyInfo university2 = univApplyInfoFixture.메이지대학_지원_정보();
+
+            LikedUniversity firstLike = createLikedUniversity(user, university1);
+            likedUniversityRepository.save(firstLike);
+
+            LikedUniversity secondLike = createLikedUniversity(user, university2);
+
+            // when & then
+            assertThatCode(() -> likedUniversityRepository.save(secondLike)).doesNotThrowAnyException();
+        }
+    }
+
+    private LikedUniversity createLikedUniversity(SiteUser siteUser, UnivApplyInfo univApplyInfo) {
+        return LikedUniversity.builder()
+                .siteUser(siteUser)
+                .univApplyInfo(univApplyInfo)
+                .build();
+    }
+}

--- a/src/test/java/com/example/solidconnection/university/service/GeneralUniversityRecommendServiceTest.java
+++ b/src/test/java/com/example/solidconnection/university/service/GeneralUniversityRecommendServiceTest.java
@@ -1,8 +1,8 @@
 package com.example.solidconnection.university.service;
 
 import com.example.solidconnection.support.TestContainerSpringBootTest;
-import com.example.solidconnection.university.domain.UniversityInfoForApply;
-import com.example.solidconnection.university.fixture.UniversityInfoForApplyFixture;
+import com.example.solidconnection.university.domain.UnivApplyInfo;
+import com.example.solidconnection.university.fixture.UnivApplyInfoFixture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,30 +23,30 @@ class GeneralUniversityRecommendServiceTest {
     private GeneralUniversityRecommendService generalUniversityRecommendService;
 
     @Autowired
-    private UniversityInfoForApplyFixture universityInfoForApplyFixture;
+    private UnivApplyInfoFixture univApplyInfoFixture;
 
     @Value("${university.term}")
     private String term;
 
     @BeforeEach
     void setUp() {
-        universityInfoForApplyFixture.괌대학_A_지원_정보();
-        universityInfoForApplyFixture.괌대학_B_지원_정보();
-        universityInfoForApplyFixture.네바다주립대학_라스베이거스_지원_정보();
-        universityInfoForApplyFixture.메모리얼대학_세인트존스_A_지원_정보();
-        universityInfoForApplyFixture.서던덴마크대학교_지원_정보();
-        universityInfoForApplyFixture.코펜하겐IT대학_지원_정보();
-        universityInfoForApplyFixture.그라츠대학_지원_정보();
-        universityInfoForApplyFixture.그라츠공과대학_지원_정보();
-        universityInfoForApplyFixture.린츠_카톨릭대학_지원_정보();
-        universityInfoForApplyFixture.메이지대학_지원_정보();
+        univApplyInfoFixture.괌대학_A_지원_정보();
+        univApplyInfoFixture.괌대학_B_지원_정보();
+        univApplyInfoFixture.네바다주립대학_라스베이거스_지원_정보();
+        univApplyInfoFixture.메모리얼대학_세인트존스_A_지원_정보();
+        univApplyInfoFixture.서던덴마크대학교_지원_정보();
+        univApplyInfoFixture.코펜하겐IT대학_지원_정보();
+        univApplyInfoFixture.그라츠대학_지원_정보();
+        univApplyInfoFixture.그라츠공과대학_지원_정보();
+        univApplyInfoFixture.린츠_카톨릭대학_지원_정보();
+        univApplyInfoFixture.메이지대학_지원_정보();
         generalUniversityRecommendService.init();
     }
 
     @Test
     void 모집_시기의_대학들_중에서_랜덤하게_N개를_추천_목록으로_구성한다() {
         // given
-        List<UniversityInfoForApply> universities = generalUniversityRecommendService.getRecommendUniversities();
+        List<UnivApplyInfo> universities = generalUniversityRecommendService.getRecommendUniversities();
 
         // when & then
         assertAll(

--- a/src/test/java/com/example/solidconnection/university/service/UniversityLikeServiceTest.java
+++ b/src/test/java/com/example/solidconnection/university/service/UniversityLikeServiceTest.java
@@ -6,10 +6,10 @@ import com.example.solidconnection.siteuser.fixture.SiteUserFixture;
 import com.example.solidconnection.siteuser.repository.LikedUniversityRepository;
 import com.example.solidconnection.support.TestContainerSpringBootTest;
 import com.example.solidconnection.university.domain.LikedUniversity;
-import com.example.solidconnection.university.domain.UniversityInfoForApply;
+import com.example.solidconnection.university.domain.UnivApplyInfo;
 import com.example.solidconnection.university.dto.IsLikeResponse;
 import com.example.solidconnection.university.dto.LikeResultResponse;
-import com.example.solidconnection.university.fixture.UniversityInfoForApplyFixture;
+import com.example.solidconnection.university.fixture.UnivApplyInfoFixture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -39,15 +39,15 @@ class UniversityLikeServiceTest {
     private SiteUserFixture siteUserFixture;
 
     @Autowired
-    private UniversityInfoForApplyFixture universityInfoForApplyFixture;
+    private UnivApplyInfoFixture univApplyInfoFixture;
 
     private SiteUser user;
-    private UniversityInfoForApply 괌대학_A_지원_정보;
+    private UnivApplyInfo 괌대학_A_지원_정보;
 
     @BeforeEach
     void setUp() {
         user = siteUserFixture.사용자();
-        괌대학_A_지원_정보 = universityInfoForApplyFixture.괌대학_A_지원_정보();
+        괌대학_A_지원_정보 = univApplyInfoFixture.괌대학_A_지원_정보();
     }
 
     @Nested
@@ -61,7 +61,7 @@ class UniversityLikeServiceTest {
             // then
             assertAll(
                     () -> assertThat(response.result()).isEqualTo(LIKE_SUCCESS_MESSAGE),
-                    () -> assertThat(likedUniversityRepository.findBySiteUserAndUniversityInfoForApply(
+                    () -> assertThat(likedUniversityRepository.findBySiteUserAndUnivApplyInfo(
                             user, 괌대학_A_지원_정보
                     )).isPresent()
             );
@@ -93,7 +93,7 @@ class UniversityLikeServiceTest {
             // then
             assertAll(
                     () -> assertThat(response.result()).isEqualTo(LIKE_CANCELED_MESSAGE),
-                    () -> assertThat(likedUniversityRepository.findBySiteUserAndUniversityInfoForApply(
+                    () -> assertThat(likedUniversityRepository.findBySiteUserAndUnivApplyInfo(
                             user, 괌대학_A_지원_정보
                     )).isEmpty()
             );
@@ -151,10 +151,10 @@ class UniversityLikeServiceTest {
                 .hasMessage(UNIVERSITY_INFO_FOR_APPLY_NOT_FOUND.getMessage());
     }
 
-    private void saveLikedUniversity(SiteUser siteUser, UniversityInfoForApply universityInfoForApply) {
+    private void saveLikedUniversity(SiteUser siteUser, UnivApplyInfo univApplyInfo) {
         LikedUniversity likedUniversity = LikedUniversity.builder()
                 .siteUser(siteUser)
-                .universityInfoForApply(universityInfoForApply)
+                .univApplyInfo(univApplyInfo)
                 .build();
         likedUniversityRepository.save(likedUniversity);
     }

--- a/src/test/java/com/example/solidconnection/university/service/UniversityQueryServiceTest.java
+++ b/src/test/java/com/example/solidconnection/university/service/UniversityQueryServiceTest.java
@@ -3,12 +3,12 @@ package com.example.solidconnection.university.service;
 import com.example.solidconnection.common.exception.CustomException;
 import com.example.solidconnection.support.TestContainerSpringBootTest;
 import com.example.solidconnection.university.domain.LanguageTestType;
-import com.example.solidconnection.university.domain.UniversityInfoForApply;
+import com.example.solidconnection.university.domain.UnivApplyInfo;
 import com.example.solidconnection.university.dto.UniversityDetailResponse;
 import com.example.solidconnection.university.dto.UniversityInfoForApplyPreviewResponse;
 import com.example.solidconnection.university.dto.UniversityInfoForApplyPreviewResponses;
 import com.example.solidconnection.university.fixture.LanguageRequirementFixture;
-import com.example.solidconnection.university.fixture.UniversityInfoForApplyFixture;
+import com.example.solidconnection.university.fixture.UnivApplyInfoFixture;
 import com.example.solidconnection.university.repository.UniversityInfoForApplyRepository;
 import com.example.solidconnection.university.repository.custom.UniversityFilterRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -38,7 +38,7 @@ class UniversityQueryServiceTest {
     private UniversityInfoForApplyRepository universityInfoForApplyRepository;
 
     @Autowired
-    private UniversityInfoForApplyFixture universityInfoForApplyFixture;
+    private UnivApplyInfoFixture univApplyInfoFixture;
 
     @Autowired
     private LanguageRequirementFixture languageRequirementFixture;
@@ -46,7 +46,7 @@ class UniversityQueryServiceTest {
     @Test
     void 대학_상세정보를_정상_조회한다() {
         // given
-        UniversityInfoForApply 괌대학_A_지원_정보 = universityInfoForApplyFixture.괌대학_A_지원_정보();
+        UnivApplyInfo 괌대학_A_지원_정보 = univApplyInfoFixture.괌대학_A_지원_정보();
 
         // when
         UniversityDetailResponse response = universityQueryService.getUniversityDetail(괌대학_A_지원_정보.getId());
@@ -58,7 +58,7 @@ class UniversityQueryServiceTest {
     @Test
     void 대학_상세정보_조회시_캐시가_적용된다() {
         // given
-        UniversityInfoForApply 괌대학_A_지원_정보 = universityInfoForApplyFixture.괌대학_A_지원_정보();
+        UnivApplyInfo 괌대학_A_지원_정보 = univApplyInfoFixture.괌대학_A_지원_정보();
 
         // when
         UniversityDetailResponse firstResponse = universityQueryService.getUniversityDetail(괌대학_A_지원_정보.getId());
@@ -85,12 +85,12 @@ class UniversityQueryServiceTest {
     @Test
     void 전체_대학을_조회한다() {
         // given
-        UniversityInfoForApply 괌대학_A_지원_정보 = universityInfoForApplyFixture.괌대학_A_지원_정보();
-        UniversityInfoForApply 괌대학_B_지원_정보 = universityInfoForApplyFixture.괌대학_B_지원_정보();
-        UniversityInfoForApply 네바다주립대학_라스베이거스_지원_정보 = universityInfoForApplyFixture.네바다주립대학_라스베이거스_지원_정보();
-        UniversityInfoForApply 서던덴마크대학교_지원_정보 = universityInfoForApplyFixture.서던덴마크대학교_지원_정보();
-        UniversityInfoForApply 그라츠대학_지원_정보 = universityInfoForApplyFixture.그라츠대학_지원_정보();
-        UniversityInfoForApply 메이지대학_지원_정보 = universityInfoForApplyFixture.메이지대학_지원_정보();
+        UnivApplyInfo 괌대학_A_지원_정보 = univApplyInfoFixture.괌대학_A_지원_정보();
+        UnivApplyInfo 괌대학_B_지원_정보 = univApplyInfoFixture.괌대학_B_지원_정보();
+        UnivApplyInfo 네바다주립대학_라스베이거스_지원_정보 = univApplyInfoFixture.네바다주립대학_라스베이거스_지원_정보();
+        UnivApplyInfo 서던덴마크대학교_지원_정보 = univApplyInfoFixture.서던덴마크대학교_지원_정보();
+        UnivApplyInfo 그라츠대학_지원_정보 = univApplyInfoFixture.그라츠대학_지원_정보();
+        UnivApplyInfo 메이지대학_지원_정보 = univApplyInfoFixture.메이지대학_지원_정보();
 
         // when
         UniversityInfoForApplyPreviewResponses response = universityQueryService.searchUniversity(
@@ -111,7 +111,7 @@ class UniversityQueryServiceTest {
     @Test
     void 대학_조회시_캐시가_적용된다() {
         // given
-        universityInfoForApplyFixture.괌대학_A_지원_정보();
+        univApplyInfoFixture.괌대학_A_지원_정보();
         String regionCode = "AMERICAS";
         List<String> keywords = List.of("괌");
         LanguageTestType testType = LanguageTestType.TOEFL_IBT;
@@ -134,10 +134,10 @@ class UniversityQueryServiceTest {
     @Test
     void 지역으로_대학을_필터링한다() {
         // given
-        UniversityInfoForApply 괌대학_A_지원_정보 = universityInfoForApplyFixture.괌대학_A_지원_정보();
-        universityInfoForApplyFixture.코펜하겐IT대학_지원_정보();
-        universityInfoForApplyFixture.그라츠공과대학_지원_정보();
-        universityInfoForApplyFixture.메이지대학_지원_정보();
+        UnivApplyInfo 괌대학_A_지원_정보 = univApplyInfoFixture.괌대학_A_지원_정보();
+        univApplyInfoFixture.코펜하겐IT대학_지원_정보();
+        univApplyInfoFixture.그라츠공과대학_지원_정보();
+        univApplyInfoFixture.메이지대학_지원_정보();
 
         // when
         UniversityInfoForApplyPreviewResponses response = universityQueryService.searchUniversity(
@@ -151,9 +151,9 @@ class UniversityQueryServiceTest {
     @Test
     void 키워드로_대학을_필터링한다() {
         // given
-        universityInfoForApplyFixture.괌대학_A_지원_정보();
-        UniversityInfoForApply 그라츠대학_지원_정보 = universityInfoForApplyFixture.그라츠대학_지원_정보();
-        UniversityInfoForApply 메이지대학_지원_정보 = universityInfoForApplyFixture.메이지대학_지원_정보();
+        univApplyInfoFixture.괌대학_A_지원_정보();
+        UnivApplyInfo 그라츠대학_지원_정보 = univApplyInfoFixture.그라츠대학_지원_정보();
+        UnivApplyInfo 메이지대학_지원_정보 = univApplyInfoFixture.메이지대학_지원_정보();
 
         // when
         UniversityInfoForApplyPreviewResponses response = universityQueryService.searchUniversity(
@@ -170,10 +170,10 @@ class UniversityQueryServiceTest {
     @Test
     void 어학시험_조건으로_대학을_필터링한다() {
         // given
-        UniversityInfoForApply 괌대학_A_지원_정보 = universityInfoForApplyFixture.괌대학_A_지원_정보();
+        UnivApplyInfo 괌대학_A_지원_정보 = univApplyInfoFixture.괌대학_A_지원_정보();
         languageRequirementFixture.토플_80(괌대학_A_지원_정보);
         languageRequirementFixture.토익_800(괌대학_A_지원_정보);
-        UniversityInfoForApply 괌대학_B_지원_정보 = universityInfoForApplyFixture.괌대학_B_지원_정보();
+        UnivApplyInfo 괌대학_B_지원_정보 = univApplyInfoFixture.괌대학_B_지원_정보();
         languageRequirementFixture.토플_70(괌대학_B_지원_정보);
         languageRequirementFixture.토익_900(괌대학_B_지원_정보);
 
@@ -189,10 +189,10 @@ class UniversityQueryServiceTest {
     @Test
     void 모든_조건으로_대학을_필터링한다() {
         // given
-        UniversityInfoForApply 괌대학_A_지원_정보 = universityInfoForApplyFixture.괌대학_A_지원_정보();
+        UnivApplyInfo 괌대학_A_지원_정보 = univApplyInfoFixture.괌대학_A_지원_정보();
         languageRequirementFixture.토플_80(괌대학_A_지원_정보);
         languageRequirementFixture.토익_800(괌대학_A_지원_정보);
-        UniversityInfoForApply 서던덴마크대학교_지원_정보 = universityInfoForApplyFixture.서던덴마크대학교_지원_정보();
+        UnivApplyInfo 서던덴마크대학교_지원_정보 = univApplyInfoFixture.서던덴마크대학교_지원_정보();
         languageRequirementFixture.토플_70(서던덴마크대학교_지원_정보);
 
         // when

--- a/src/test/java/com/example/solidconnection/university/service/UniversityRecommendServiceTest.java
+++ b/src/test/java/com/example/solidconnection/university/service/UniversityRecommendServiceTest.java
@@ -9,10 +9,10 @@ import com.example.solidconnection.location.region.repository.InterestedRegionRe
 import com.example.solidconnection.siteuser.domain.SiteUser;
 import com.example.solidconnection.siteuser.fixture.SiteUserFixture;
 import com.example.solidconnection.support.TestContainerSpringBootTest;
-import com.example.solidconnection.university.domain.UniversityInfoForApply;
+import com.example.solidconnection.university.domain.UnivApplyInfo;
 import com.example.solidconnection.university.dto.UniversityInfoForApplyPreviewResponse;
 import com.example.solidconnection.university.dto.UniversityRecommendsResponse;
-import com.example.solidconnection.university.fixture.UniversityInfoForApplyFixture;
+import com.example.solidconnection.university.fixture.UnivApplyInfoFixture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -49,29 +49,29 @@ class UniversityRecommendServiceTest {
     private CountryFixture countryFixture;
 
     @Autowired
-    private UniversityInfoForApplyFixture universityInfoForApplyFixture;
+    private UnivApplyInfoFixture univApplyInfoFixture;
 
     private SiteUser user;
-    private UniversityInfoForApply 괌대학_A_지원_정보;
-    private UniversityInfoForApply 괌대학_B_지원_정보;
-    private UniversityInfoForApply 네바다주립대학_라스베이거스_지원_정보;
-    private UniversityInfoForApply 메모리얼대학_세인트존스_A_지원_정보;
-    private UniversityInfoForApply 서던덴마크대학교_지원_정보;
-    private UniversityInfoForApply 코펜하겐IT대학_지원_정보;
+    private UnivApplyInfo 괌대학_A_지원_정보;
+    private UnivApplyInfo 괌대학_B_지원_정보;
+    private UnivApplyInfo 네바다주립대학_라스베이거스_지원_정보;
+    private UnivApplyInfo 메모리얼대학_세인트존스_A_지원_정보;
+    private UnivApplyInfo 서던덴마크대학교_지원_정보;
+    private UnivApplyInfo 코펜하겐IT대학_지원_정보;
 
     @BeforeEach
     void setUp() {
         user = siteUserFixture.사용자();
-        괌대학_A_지원_정보 = universityInfoForApplyFixture.괌대학_A_지원_정보();
-        괌대학_B_지원_정보 = universityInfoForApplyFixture.괌대학_B_지원_정보();
-        네바다주립대학_라스베이거스_지원_정보 = universityInfoForApplyFixture.네바다주립대학_라스베이거스_지원_정보();
-        메모리얼대학_세인트존스_A_지원_정보 = universityInfoForApplyFixture.메모리얼대학_세인트존스_A_지원_정보();
-        서던덴마크대학교_지원_정보 = universityInfoForApplyFixture.서던덴마크대학교_지원_정보();
-        코펜하겐IT대학_지원_정보 = universityInfoForApplyFixture.코펜하겐IT대학_지원_정보();
-        universityInfoForApplyFixture.그라츠대학_지원_정보();
-        universityInfoForApplyFixture.그라츠공과대학_지원_정보();
-        universityInfoForApplyFixture.린츠_카톨릭대학_지원_정보();
-        universityInfoForApplyFixture.메이지대학_지원_정보();
+        괌대학_A_지원_정보 = univApplyInfoFixture.괌대학_A_지원_정보();
+        괌대학_B_지원_정보 = univApplyInfoFixture.괌대학_B_지원_정보();
+        네바다주립대학_라스베이거스_지원_정보 = univApplyInfoFixture.네바다주립대학_라스베이거스_지원_정보();
+        메모리얼대학_세인트존스_A_지원_정보 = univApplyInfoFixture.메모리얼대학_세인트존스_A_지원_정보();
+        서던덴마크대학교_지원_정보 = univApplyInfoFixture.서던덴마크대학교_지원_정보();
+        코펜하겐IT대학_지원_정보 = univApplyInfoFixture.코펜하겐IT대학_지원_정보();
+        univApplyInfoFixture.그라츠대학_지원_정보();
+        univApplyInfoFixture.그라츠공과대학_지원_정보();
+        univApplyInfoFixture.린츠_카톨릭대학_지원_정보();
+        univApplyInfoFixture.메이지대학_지원_정보();
         generalUniversityRecommendService.init();
     }
 


### PR DESCRIPTION
## 관련 이슈

- resolves: #334

## 작업 내용

- `UniversityInfoForApply` 엔티티명을 `UnivApplyInfo` 로 변경하였습니다.
- `UniversityInfoForApplyFixture`,  `UniversityInfoForApplyFixtureBuilder` 또한 동일한 규칙으로 이름을 변경하였습니다.
- 데이터베이스 레벨에서 같은 사용자가 같은 대학에 중복으로 좋아요가 가능했던 문제를 복합 unique 제약 조건을 통해 해결하였습니다. 또한 관련 테스트 코드를 작성하였습니다.
- 복합 unique 제약 조건 설정을 데이터베이스에 반영하기 위한 sql 문을 작성하였습니다.

## 특이 사항

- 이전에 `University` 엔티티를 조회할 때 N+1 문제가 발생하였는데, 다시 확인해보니 N+1 문제가 발생하지 않았습니다. 아래 쿼리는 `/universities/recommend` 에 접근 시 발생하는 쿼리입니다. N+1 문제가 발생되어야 했던 부분입니다.

```text
Hibernate: 
    select
        s1_0.id,
        s1_0.auth_type,
        s1_0.email,
        s1_0.nickname,
        s1_0.nickname_modified_at,
        s1_0.password,
        s1_0.preparation_stage,
        s1_0.profile_image_url,
        s1_0.quited_at,
        s1_0.role 
    from
        site_user s1_0 
    where
        s1_0.id=?
Hibernate: 
    select
        u1_0.id,
        u1_0.details,
        u1_0.details_for_accommodation,
        u1_0.details_for_apply,
        u1_0.details_for_english_course,
        u1_0.details_for_language,
        u1_0.details_for_major,
        u1_0.gpa_requirement,
        u1_0.gpa_requirement_criteria,
        u1_0.korean_name,
        u1_0.semester_available_for_dispatch,
        u1_0.semester_requirement,
        u1_0.student_capacity,
        u1_0.term,
        u1_0.tuition_fee_type,
        u1_0.university_id 
    from
        university_info_for_apply u1_0 
    join
        university u2_0 
            on u1_0.university_id=u2_0.id 
    where
        (
            u2_0.country_code in(select
                i1_0.country_code 
            from
                interested_country i1_0 
            join
                country c2_0 
                    on c2_0.code=i1_0.country_code 
            where
                i1_0.site_user_id=?) 
            or u2_0.region_code in(select
                i2_0.region_code 
            from
                interested_region i2_0 
            join
                region r2_0 
                    on r2_0.code=i2_0.region_code 
            where
                i2_0.site_user_id=?)
        ) 
        and u1_0.term=?
``` 

여러 커밋으로 되돌아가서 테스트를 진행해도 N+1 문제는 발생하지 않았습니다 .. 따라서 원래 Fetch Join을 통해 해결할 계획이었으나, 기존 코드 그대로 유지하였습니다.

- 엔티티만 `UniversityInfoForApply` 를 `UnivApplyInfo` 로 변경하였습니다. 코드 내에 존재하는 모든 `UniversityInfoForApply` 를 `UnivApplyInfo` 로 변경하기에는 많은 수정이 있을 것 같고, 머지 시 충돌이 발생할 것 같아 필요 시 별도의 작업으로 분리하는 것이 좋을 거 같습니다.
- 엔티티명은 `UnivApplyInfo` 이지만 테이블명은 기존 이름인 `university_info_for_apply` 를 그대로 유지하도록 하였습니다. 이 부분도 건드리면 일이 엄청 커질 거 같더라구요 .. 따라서 `@Table`, `@JoinColumn`을 통해 테이블 및 컬럼명은 `university_info_for_apply` 형태를 유지하도록 작성하였습니다.

## 리뷰 요구사항 (선택)

- 코드 컨벤션을 잘 준수하고 있나요?
- 테스트 코드가 올바르게 작성되었나요?
- 더 좋은 아이디어가 있다면 말씀해주세요!
