### PR TITLE
feat: 멘토링 관련 도메인 추가

### DIFF
--- a/src/main/java/com/example/solidconnection/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/solidconnection/common/exception/ErrorCode.java
@@ -109,7 +109,7 @@ public enum ErrorCode {
     ALREADY_MENTOR(HttpStatus.BAD_REQUEST.value(), "이미 멘토로 등록된 사용자입니다."),
     MENTOR_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 사용자는 멘토로 등록되어 있지 않습니다."),
     MENTORING_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 멘토링 신청을 찾을 수 없습니다."),
-    UNAUTHORIZED_MENTORING_CONFIRM(HttpStatus.FORBIDDEN.value(), "멘토링 승인 권한이 없습니다."),
+    UNAUTHORIZED_MENTORING(HttpStatus.FORBIDDEN.value(), "멘토링 권한이 없습니다."),
     MENTORING_ALREADY_CONFIRMED(HttpStatus.BAD_REQUEST.value(), "이미 승인 또는 거절된 멘토링입니다."),
 
     // general

--- a/src/main/java/com/example/solidconnection/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/solidconnection/common/exception/ErrorCode.java
@@ -107,6 +107,10 @@ public enum ErrorCode {
     // mentor
     SELF_MENTORING_NOT_ALLOWED(HttpStatus.BAD_REQUEST.value(), "자기 자신을 멘토로 설정할 수 없습니다."),
     ALREADY_MENTOR(HttpStatus.BAD_REQUEST.value(), "이미 멘토로 등록된 사용자입니다."),
+    MENTOR_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 사용자는 멘토로 등록되어 있지 않습니다."),
+    MENTORING_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 멘토링 신청을 찾을 수 없습니다."),
+    UNAUTHORIZED_MENTORING_CONFIRM(HttpStatus.FORBIDDEN.value(), "멘토링 승인 권한이 없습니다."),
+    MENTORING_ALREADY_CONFIRMED(HttpStatus.BAD_REQUEST.value(), "이미 승인 또는 거절된 멘토링입니다."),
 
     // general
     JSON_PARSING_FAILED(HttpStatus.BAD_REQUEST.value(), "JSON 파싱을 할 수 없습니다."),

--- a/src/main/java/com/example/solidconnection/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/solidconnection/common/exception/ErrorCode.java
@@ -104,6 +104,10 @@ public enum ErrorCode {
     // database
     DATA_INTEGRITY_VIOLATION(HttpStatus.CONFLICT.value(), "데이터베이스 무결성 제약조건 위반이 발생했습니다."),
 
+    // mentor
+    SELF_MENTORING_NOT_ALLOWED(HttpStatus.BAD_REQUEST.value(), "자기 자신을 멘토로 설정할 수 없습니다."),
+    ALREADY_MENTOR(HttpStatus.BAD_REQUEST.value(), "이미 멘토로 등록된 사용자입니다."),
+
     // general
     JSON_PARSING_FAILED(HttpStatus.BAD_REQUEST.value(), "JSON 파싱을 할 수 없습니다."),
     JWT_EXCEPTION(HttpStatus.BAD_REQUEST.value(), "JWT 토큰을 처리할 수 없습니다."),

--- a/src/main/java/com/example/solidconnection/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/solidconnection/common/exception/ErrorCode.java
@@ -105,7 +105,6 @@ public enum ErrorCode {
     DATA_INTEGRITY_VIOLATION(HttpStatus.CONFLICT.value(), "데이터베이스 무결성 제약조건 위반이 발생했습니다."),
 
     // mentor
-    SELF_MENTORING_NOT_ALLOWED(HttpStatus.BAD_REQUEST.value(), "자기 자신을 멘토로 설정할 수 없습니다."),
     ALREADY_MENTOR(HttpStatus.BAD_REQUEST.value(), "이미 멘토로 등록된 사용자입니다."),
     MENTOR_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 사용자는 멘토로 등록되어 있지 않습니다."),
     MENTORING_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 멘토링 신청을 찾을 수 없습니다."),

--- a/src/main/java/com/example/solidconnection/mentor/controller/MentoringController.java
+++ b/src/main/java/com/example/solidconnection/mentor/controller/MentoringController.java
@@ -3,16 +3,25 @@ package com.example.solidconnection.mentor.controller;
 import com.example.solidconnection.common.resolver.AuthorizedUser;
 import com.example.solidconnection.mentor.dto.MentoringApplyRequest;
 import com.example.solidconnection.mentor.dto.MentoringApplyResponse;
+import com.example.solidconnection.mentor.dto.MentoringConfirmRequest;
+import com.example.solidconnection.mentor.dto.MentoringConfirmResponse;
+import com.example.solidconnection.mentor.dto.MentoringResponse;
 import com.example.solidconnection.mentor.service.MentoringCommandService;
+import com.example.solidconnection.mentor.service.MentoringQueryService;
 import com.example.solidconnection.siteuser.domain.SiteUser;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,6 +29,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class MentoringController {
 
     private final MentoringCommandService mentoringCommandService;
+    private final MentoringQueryService mentoringQueryService;
 
     @PostMapping("/apply")
     public ResponseEntity<MentoringApplyResponse> applyMentoring(
@@ -30,5 +40,24 @@ public class MentoringController {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(response);
+    }
+
+    // TODO: RequireRoleAccess 어노테이션 추가 필요
+    @GetMapping("/apply")
+    public ResponseEntity<List<MentoringResponse>> getMentorings(
+            @AuthorizedUser SiteUser siteUser
+    ) {
+        List<MentoringResponse> responses = mentoringQueryService.getMentorings(siteUser.getId());
+        return ResponseEntity.ok(responses);
+    }
+
+    @PatchMapping("/{mentoring-id}/apply")
+    public ResponseEntity<MentoringConfirmResponse> confirmMentoring(
+            @AuthorizedUser SiteUser siteUser,
+            @PathVariable("mentoring-id") Long mentoringId,
+            @Valid @RequestBody MentoringConfirmRequest mentoringConfirmRequest
+    ) {
+        MentoringConfirmResponse response = mentoringCommandService.confirmMentoring(siteUser.getId(), mentoringId, mentoringConfirmRequest);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/example/solidconnection/mentor/controller/MentoringController.java
+++ b/src/main/java/com/example/solidconnection/mentor/controller/MentoringController.java
@@ -6,6 +6,7 @@ import com.example.solidconnection.mentor.dto.MentoringApplyResponse;
 import com.example.solidconnection.mentor.dto.MentoringCheckResponse;
 import com.example.solidconnection.mentor.dto.MentoringConfirmRequest;
 import com.example.solidconnection.mentor.dto.MentoringConfirmResponse;
+import com.example.solidconnection.mentor.dto.MentoringCountResponse;
 import com.example.solidconnection.mentor.dto.MentoringResponse;
 import com.example.solidconnection.mentor.service.MentoringCommandService;
 import com.example.solidconnection.mentor.service.MentoringQueryService;
@@ -69,5 +70,13 @@ public class MentoringController {
     ) {
         MentoringCheckResponse response = mentoringCommandService.checkMentoring(siteUser.getId(), mentoringId);
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/check")
+    public ResponseEntity<MentoringCountResponse> getNewMentoringsCount(
+            @AuthorizedUser SiteUser siteUser
+    ) {
+        MentoringCountResponse responses = mentoringQueryService.getNewMentoringsCount(siteUser.getId());
+        return ResponseEntity.ok(responses);
     }
 }

--- a/src/main/java/com/example/solidconnection/mentor/controller/MentoringController.java
+++ b/src/main/java/com/example/solidconnection/mentor/controller/MentoringController.java
@@ -7,6 +7,7 @@ import com.example.solidconnection.mentor.dto.MentoringCheckResponse;
 import com.example.solidconnection.mentor.dto.MentoringConfirmRequest;
 import com.example.solidconnection.mentor.dto.MentoringConfirmResponse;
 import com.example.solidconnection.mentor.dto.MentoringCountResponse;
+import com.example.solidconnection.mentor.dto.MentoringListResponse;
 import com.example.solidconnection.mentor.dto.MentoringResponse;
 import com.example.solidconnection.mentor.service.MentoringCommandService;
 import com.example.solidconnection.mentor.service.MentoringQueryService;
@@ -45,10 +46,10 @@ public class MentoringController {
 
     @RequireRoleAccess(roles = {Role.ADMIN, Role.MENTOR})
     @GetMapping("/apply")
-    public ResponseEntity<List<MentoringResponse>> getMentorings(
+    public ResponseEntity<MentoringListResponse> getMentorings(
             @AuthorizedUser SiteUser siteUser
     ) {
-        List<MentoringResponse> responses = mentoringQueryService.getMentorings(siteUser.getId());
+        MentoringListResponse responses = mentoringQueryService.getMentorings(siteUser.getId());
         return ResponseEntity.ok(responses);
     }
 

--- a/src/main/java/com/example/solidconnection/mentor/controller/MentoringController.java
+++ b/src/main/java/com/example/solidconnection/mentor/controller/MentoringController.java
@@ -1,0 +1,34 @@
+package com.example.solidconnection.mentor.controller;
+
+import com.example.solidconnection.common.resolver.AuthorizedUser;
+import com.example.solidconnection.mentor.dto.MentoringApplyRequest;
+import com.example.solidconnection.mentor.dto.MentoringApplyResponse;
+import com.example.solidconnection.mentor.service.MentoringCommandService;
+import com.example.solidconnection.siteuser.domain.SiteUser;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/mentorings")
+public class MentoringController {
+
+    private final MentoringCommandService mentoringCommandService;
+
+    @PostMapping("/apply")
+    public ResponseEntity<MentoringApplyResponse> applyMentoring(
+            @AuthorizedUser SiteUser siteUser,
+            @Valid @RequestBody MentoringApplyRequest mentoringApplyRequest
+    ) {
+        MentoringApplyResponse response = mentoringCommandService.applyMentoring(siteUser.getId(), mentoringApplyRequest);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(response);
+    }
+}

--- a/src/main/java/com/example/solidconnection/mentor/controller/MentoringController.java
+++ b/src/main/java/com/example/solidconnection/mentor/controller/MentoringController.java
@@ -10,6 +10,8 @@ import com.example.solidconnection.mentor.dto.MentoringCountResponse;
 import com.example.solidconnection.mentor.dto.MentoringResponse;
 import com.example.solidconnection.mentor.service.MentoringCommandService;
 import com.example.solidconnection.mentor.service.MentoringQueryService;
+import com.example.solidconnection.security.annotation.RequireRoleAccess;
+import com.example.solidconnection.siteuser.domain.Role;
 import com.example.solidconnection.siteuser.domain.SiteUser;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -41,7 +43,7 @@ public class MentoringController {
         return ResponseEntity.ok(response);
     }
 
-    // TODO: RequireRoleAccess 어노테이션 추가 필요
+    @RequireRoleAccess(roles = {Role.ADMIN, Role.MENTOR})
     @GetMapping("/apply")
     public ResponseEntity<List<MentoringResponse>> getMentorings(
             @AuthorizedUser SiteUser siteUser
@@ -50,6 +52,7 @@ public class MentoringController {
         return ResponseEntity.ok(responses);
     }
 
+    @RequireRoleAccess(roles = {Role.ADMIN, Role.MENTOR})
     @PatchMapping("/{mentoring-id}/apply")
     public ResponseEntity<MentoringConfirmResponse> confirmMentoring(
             @AuthorizedUser SiteUser siteUser,
@@ -60,6 +63,7 @@ public class MentoringController {
         return ResponseEntity.ok(response);
     }
 
+    @RequireRoleAccess(roles = {Role.ADMIN, Role.MENTOR})
     @PatchMapping("/{mentoring-id}/check")
     public ResponseEntity<MentoringCheckResponse> checkMentoring(
             @AuthorizedUser SiteUser siteUser,
@@ -69,6 +73,7 @@ public class MentoringController {
         return ResponseEntity.ok(response);
     }
 
+    @RequireRoleAccess(roles = {Role.ADMIN, Role.MENTOR})
     @GetMapping("/check")
     public ResponseEntity<MentoringCountResponse> getNewMentoringsCount(
             @AuthorizedUser SiteUser siteUser

--- a/src/main/java/com/example/solidconnection/mentor/controller/MentoringController.java
+++ b/src/main/java/com/example/solidconnection/mentor/controller/MentoringController.java
@@ -3,6 +3,7 @@ package com.example.solidconnection.mentor.controller;
 import com.example.solidconnection.common.resolver.AuthorizedUser;
 import com.example.solidconnection.mentor.dto.MentoringApplyRequest;
 import com.example.solidconnection.mentor.dto.MentoringApplyResponse;
+import com.example.solidconnection.mentor.dto.MentoringCheckResponse;
 import com.example.solidconnection.mentor.dto.MentoringConfirmRequest;
 import com.example.solidconnection.mentor.dto.MentoringConfirmResponse;
 import com.example.solidconnection.mentor.dto.MentoringResponse;
@@ -58,6 +59,15 @@ public class MentoringController {
             @Valid @RequestBody MentoringConfirmRequest mentoringConfirmRequest
     ) {
         MentoringConfirmResponse response = mentoringCommandService.confirmMentoring(siteUser.getId(), mentoringId, mentoringConfirmRequest);
+        return ResponseEntity.ok(response);
+    }
+
+    @PatchMapping("/{mentoring-id}/check")
+    public ResponseEntity<MentoringCheckResponse> checkMentoring(
+            @AuthorizedUser SiteUser siteUser,
+            @PathVariable("mentoring-id") Long mentoringId
+    ) {
+        MentoringCheckResponse response = mentoringCommandService.checkMentoring(siteUser.getId(), mentoringId);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/example/solidconnection/mentor/controller/MentoringController.java
+++ b/src/main/java/com/example/solidconnection/mentor/controller/MentoringController.java
@@ -74,7 +74,7 @@ public class MentoringController {
 
     @RequireRoleAccess(roles = {Role.ADMIN, Role.MENTOR})
     @GetMapping("/check")
-    public ResponseEntity<MentoringCountResponse> getNewMentoringsCount(
+    public ResponseEntity<MentoringCountResponse> getUncheckedMentoringsCount(
             @AuthorizedUser SiteUser siteUser
     ) {
         MentoringCountResponse response = mentoringQueryService.getNewMentoringsCount(siteUser.getId());

--- a/src/main/java/com/example/solidconnection/mentor/controller/MentoringController.java
+++ b/src/main/java/com/example/solidconnection/mentor/controller/MentoringController.java
@@ -8,7 +8,6 @@ import com.example.solidconnection.mentor.dto.MentoringConfirmRequest;
 import com.example.solidconnection.mentor.dto.MentoringConfirmResponse;
 import com.example.solidconnection.mentor.dto.MentoringCountResponse;
 import com.example.solidconnection.mentor.dto.MentoringListResponse;
-import com.example.solidconnection.mentor.dto.MentoringResponse;
 import com.example.solidconnection.mentor.service.MentoringCommandService;
 import com.example.solidconnection.mentor.service.MentoringQueryService;
 import com.example.solidconnection.security.annotation.RequireRoleAccess;
@@ -25,8 +24,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
-
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/mentorings")
@@ -35,6 +32,7 @@ public class MentoringController {
     private final MentoringCommandService mentoringCommandService;
     private final MentoringQueryService mentoringQueryService;
 
+    @RequireRoleAccess(roles = Role.MENTEE)
     @PostMapping("/apply")
     public ResponseEntity<MentoringApplyResponse> applyMentoring(
             @AuthorizedUser SiteUser siteUser,

--- a/src/main/java/com/example/solidconnection/mentor/controller/MentoringController.java
+++ b/src/main/java/com/example/solidconnection/mentor/controller/MentoringController.java
@@ -13,7 +13,6 @@ import com.example.solidconnection.mentor.service.MentoringQueryService;
 import com.example.solidconnection.siteuser.domain.SiteUser;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -39,9 +38,7 @@ public class MentoringController {
             @Valid @RequestBody MentoringApplyRequest mentoringApplyRequest
     ) {
         MentoringApplyResponse response = mentoringCommandService.applyMentoring(siteUser.getId(), mentoringApplyRequest);
-        return ResponseEntity
-                .status(HttpStatus.OK)
-                .body(response);
+        return ResponseEntity.ok(response);
     }
 
     // TODO: RequireRoleAccess 어노테이션 추가 필요
@@ -76,7 +73,7 @@ public class MentoringController {
     public ResponseEntity<MentoringCountResponse> getNewMentoringsCount(
             @AuthorizedUser SiteUser siteUser
     ) {
-        MentoringCountResponse responses = mentoringQueryService.getNewMentoringsCount(siteUser.getId());
-        return ResponseEntity.ok(responses);
+        MentoringCountResponse response = mentoringQueryService.getNewMentoringsCount(siteUser.getId());
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/example/solidconnection/mentor/domain/Mentor.java
+++ b/src/main/java/com/example/solidconnection/mentor/domain/Mentor.java
@@ -45,4 +45,8 @@ public class Mentor {
 
     @OneToMany(mappedBy = "mentor", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Channel> channels = new ArrayList<>();
+
+    public void increaseMenteeCount() {
+        this.menteeCount++;
+    }
 }

--- a/src/main/java/com/example/solidconnection/mentor/domain/Mentoring.java
+++ b/src/main/java/com/example/solidconnection/mentor/domain/Mentoring.java
@@ -12,6 +12,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.PrePersist;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.DynamicInsert;
@@ -24,6 +25,7 @@ import static java.time.temporal.ChronoUnit.MICROS;
 
 @Entity
 @Getter
+@Builder
 @EntityListeners(AuditingEntityListener.class)
 @DynamicInsert
 @AllArgsConstructor
@@ -59,5 +61,19 @@ public class Mentoring {
     @PrePersist
     public void onPrePersist() {
         this.createdAt = ZonedDateTime.now(UTC).truncatedTo(MICROS); // 나노초 6자리 까지만 저장
+    }
+
+    public void confirm(VerifyStatus status, String rejectedReason) {
+        this.verifyStatus = status;
+        this.rejectedReason = rejectedReason;
+        this.confirmedAt = ZonedDateTime.now(UTC).truncatedTo(MICROS);
+
+        if (this.checkedAt == null) {
+            this.checkedAt = this.confirmedAt;
+        }
+    }
+
+    public void check() {
+        this.checkedAt = ZonedDateTime.now(UTC).truncatedTo(MICROS);
     }
 }

--- a/src/main/java/com/example/solidconnection/mentor/domain/Mentoring.java
+++ b/src/main/java/com/example/solidconnection/mentor/domain/Mentoring.java
@@ -12,7 +12,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.PrePersist;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.DynamicInsert;
@@ -25,7 +24,6 @@ import static java.time.temporal.ChronoUnit.MICROS;
 
 @Entity
 @Getter
-@Builder
 @EntityListeners(AuditingEntityListener.class)
 @DynamicInsert
 @AllArgsConstructor
@@ -57,6 +55,12 @@ public class Mentoring {
 
     @Column
     private long menteeId;
+
+    public Mentoring(long mentorId, long menteeId, VerifyStatus verifyStatus) {
+        this.mentorId = mentorId;
+        this.menteeId = menteeId;
+        this.verifyStatus = verifyStatus;
+    }
 
     @PrePersist
     public void onPrePersist() {

--- a/src/main/java/com/example/solidconnection/mentor/dto/MentoringApplyRequest.java
+++ b/src/main/java/com/example/solidconnection/mentor/dto/MentoringApplyRequest.java
@@ -5,7 +5,6 @@ import jakarta.validation.constraints.NotNull;
 public record MentoringApplyRequest(
 
         @NotNull(message = "멘토 id를 입력해주세요.")
-
         Long mentorId
 ) {
 }

--- a/src/main/java/com/example/solidconnection/mentor/dto/MentoringApplyRequest.java
+++ b/src/main/java/com/example/solidconnection/mentor/dto/MentoringApplyRequest.java
@@ -3,7 +3,6 @@ package com.example.solidconnection.mentor.dto;
 import jakarta.validation.constraints.NotNull;
 
 public record MentoringApplyRequest(
-
         @NotNull(message = "멘토 id를 입력해주세요.")
         Long mentorId
 ) {

--- a/src/main/java/com/example/solidconnection/mentor/dto/MentoringApplyRequest.java
+++ b/src/main/java/com/example/solidconnection/mentor/dto/MentoringApplyRequest.java
@@ -1,0 +1,11 @@
+package com.example.solidconnection.mentor.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record MentoringApplyRequest(
+
+        @NotNull(message = "멘토 id를 입력해주세요.")
+
+        Long mentorId
+) {
+}

--- a/src/main/java/com/example/solidconnection/mentor/dto/MentoringApplyResponse.java
+++ b/src/main/java/com/example/solidconnection/mentor/dto/MentoringApplyResponse.java
@@ -3,7 +3,7 @@ package com.example.solidconnection.mentor.dto;
 import com.example.solidconnection.mentor.domain.Mentoring;
 
 public record MentoringApplyResponse(
-        Long mentoringId
+        long mentoringId
 ) {
 
     public static MentoringApplyResponse from(Mentoring mentoring) {

--- a/src/main/java/com/example/solidconnection/mentor/dto/MentoringApplyResponse.java
+++ b/src/main/java/com/example/solidconnection/mentor/dto/MentoringApplyResponse.java
@@ -1,0 +1,12 @@
+package com.example.solidconnection.mentor.dto;
+
+import com.example.solidconnection.mentor.domain.Mentoring;
+
+public record MentoringApplyResponse(
+        Long mentoringId
+) {
+
+    public static MentoringApplyResponse from(Mentoring mentoring) {
+        return new MentoringApplyResponse(mentoring.getId());
+    }
+}

--- a/src/main/java/com/example/solidconnection/mentor/dto/MentoringCheckResponse.java
+++ b/src/main/java/com/example/solidconnection/mentor/dto/MentoringCheckResponse.java
@@ -1,0 +1,10 @@
+package com.example.solidconnection.mentor.dto;
+
+public record MentoringCheckResponse(
+        Long mentoringId
+) {
+
+    public static MentoringCheckResponse from(Long mentoringId) {
+        return new MentoringCheckResponse(mentoringId);
+    }
+}

--- a/src/main/java/com/example/solidconnection/mentor/dto/MentoringCheckResponse.java
+++ b/src/main/java/com/example/solidconnection/mentor/dto/MentoringCheckResponse.java
@@ -1,10 +1,10 @@
 package com.example.solidconnection.mentor.dto;
 
 public record MentoringCheckResponse(
-        Long mentoringId
+        long mentoringId
 ) {
 
-    public static MentoringCheckResponse from(Long mentoringId) {
+    public static MentoringCheckResponse from(long mentoringId) {
         return new MentoringCheckResponse(mentoringId);
     }
 }

--- a/src/main/java/com/example/solidconnection/mentor/dto/MentoringConfirmRequest.java
+++ b/src/main/java/com/example/solidconnection/mentor/dto/MentoringConfirmRequest.java
@@ -4,7 +4,6 @@ import com.example.solidconnection.common.VerifyStatus;
 import jakarta.validation.constraints.NotNull;
 
 public record MentoringConfirmRequest(
-
         @NotNull(message = "승인 상태를 설정해주세요.")
         VerifyStatus status,
 

--- a/src/main/java/com/example/solidconnection/mentor/dto/MentoringConfirmRequest.java
+++ b/src/main/java/com/example/solidconnection/mentor/dto/MentoringConfirmRequest.java
@@ -1,0 +1,12 @@
+package com.example.solidconnection.mentor.dto;
+
+import com.example.solidconnection.application.domain.VerifyStatus;
+import jakarta.validation.constraints.NotNull;
+
+public record MentoringConfirmRequest(
+
+        @NotNull(message = "승인 상태를 설정해주세요.")
+        VerifyStatus status,
+        String rejectedReason
+) {
+}

--- a/src/main/java/com/example/solidconnection/mentor/dto/MentoringConfirmRequest.java
+++ b/src/main/java/com/example/solidconnection/mentor/dto/MentoringConfirmRequest.java
@@ -7,6 +7,7 @@ public record MentoringConfirmRequest(
 
         @NotNull(message = "승인 상태를 설정해주세요.")
         VerifyStatus status,
+
         String rejectedReason
 ) {
 }

--- a/src/main/java/com/example/solidconnection/mentor/dto/MentoringConfirmRequest.java
+++ b/src/main/java/com/example/solidconnection/mentor/dto/MentoringConfirmRequest.java
@@ -1,6 +1,6 @@
 package com.example.solidconnection.mentor.dto;
 
-import com.example.solidconnection.application.domain.VerifyStatus;
+import com.example.solidconnection.common.VerifyStatus;
 import jakarta.validation.constraints.NotNull;
 
 public record MentoringConfirmRequest(

--- a/src/main/java/com/example/solidconnection/mentor/dto/MentoringConfirmResponse.java
+++ b/src/main/java/com/example/solidconnection/mentor/dto/MentoringConfirmResponse.java
@@ -3,7 +3,7 @@ package com.example.solidconnection.mentor.dto;
 import com.example.solidconnection.mentor.domain.Mentoring;
 
 public record MentoringConfirmResponse(
-        Long mentoringId
+        long mentoringId
 ) {
     public static MentoringConfirmResponse from(Mentoring mentoring) {
         return new MentoringConfirmResponse(mentoring.getId());

--- a/src/main/java/com/example/solidconnection/mentor/dto/MentoringConfirmResponse.java
+++ b/src/main/java/com/example/solidconnection/mentor/dto/MentoringConfirmResponse.java
@@ -1,0 +1,11 @@
+package com.example.solidconnection.mentor.dto;
+
+import com.example.solidconnection.mentor.domain.Mentoring;
+
+public record MentoringConfirmResponse(
+        Long mentoringId
+) {
+    public static MentoringConfirmResponse from(Mentoring mentoring) {
+        return new MentoringConfirmResponse(mentoring.getId());
+    }
+}

--- a/src/main/java/com/example/solidconnection/mentor/dto/MentoringCountResponse.java
+++ b/src/main/java/com/example/solidconnection/mentor/dto/MentoringCountResponse.java
@@ -1,0 +1,10 @@
+package com.example.solidconnection.mentor.dto;
+
+public record MentoringCountResponse(
+        int mentoringCount
+) {
+
+    public static MentoringCountResponse from(int mentoringCount) {
+        return new MentoringCountResponse(mentoringCount);
+    }
+}

--- a/src/main/java/com/example/solidconnection/mentor/dto/MentoringCountResponse.java
+++ b/src/main/java/com/example/solidconnection/mentor/dto/MentoringCountResponse.java
@@ -1,10 +1,10 @@
 package com.example.solidconnection.mentor.dto;
 
 public record MentoringCountResponse(
-        int mentoringCount
+        int uncheckedCount
 ) {
 
-    public static MentoringCountResponse from(int mentoringCount) {
-        return new MentoringCountResponse(mentoringCount);
+    public static MentoringCountResponse from(int uncheckedCount) {
+        return new MentoringCountResponse(uncheckedCount);
     }
 }

--- a/src/main/java/com/example/solidconnection/mentor/dto/MentoringListResponse.java
+++ b/src/main/java/com/example/solidconnection/mentor/dto/MentoringListResponse.java
@@ -1,0 +1,11 @@
+package com.example.solidconnection.mentor.dto;
+
+import java.util.List;
+
+public record MentoringListResponse(
+        List<MentoringResponse> mentoringResponseList
+) {
+    public static MentoringListResponse from(List<MentoringResponse> mentoringResponseList) {
+        return new MentoringListResponse(mentoringResponseList);
+    }
+}

--- a/src/main/java/com/example/solidconnection/mentor/dto/MentoringListResponse.java
+++ b/src/main/java/com/example/solidconnection/mentor/dto/MentoringListResponse.java
@@ -3,9 +3,9 @@ package com.example.solidconnection.mentor.dto;
 import java.util.List;
 
 public record MentoringListResponse(
-        List<MentoringResponse> mentoringResponseList
+        List<MentoringResponse> requests
 ) {
-    public static MentoringListResponse from(List<MentoringResponse> mentoringResponseList) {
-        return new MentoringListResponse(mentoringResponseList);
+    public static MentoringListResponse from(List<MentoringResponse> requests) {
+        return new MentoringListResponse(requests);
     }
 }

--- a/src/main/java/com/example/solidconnection/mentor/dto/MentoringResponse.java
+++ b/src/main/java/com/example/solidconnection/mentor/dto/MentoringResponse.java
@@ -6,9 +6,9 @@ import com.example.solidconnection.mentor.domain.Mentoring;
 import java.time.ZonedDateTime;
 
 public record MentoringResponse(
-        Long id,
-        Long mentorId,
-        Long menteeId,
+        long id,
+        long mentorId,
+        long menteeId,
         ZonedDateTime createdAt,
         ZonedDateTime confirmedAt,
         VerifyStatus verifyStatus,

--- a/src/main/java/com/example/solidconnection/mentor/dto/MentoringResponse.java
+++ b/src/main/java/com/example/solidconnection/mentor/dto/MentoringResponse.java
@@ -1,6 +1,6 @@
 package com.example.solidconnection.mentor.dto;
 
-import com.example.solidconnection.application.domain.VerifyStatus;
+import com.example.solidconnection.common.VerifyStatus;
 import com.example.solidconnection.mentor.domain.Mentoring;
 
 import java.time.ZonedDateTime;

--- a/src/main/java/com/example/solidconnection/mentor/dto/MentoringResponse.java
+++ b/src/main/java/com/example/solidconnection/mentor/dto/MentoringResponse.java
@@ -1,0 +1,28 @@
+package com.example.solidconnection.mentor.dto;
+
+import com.example.solidconnection.application.domain.VerifyStatus;
+import com.example.solidconnection.mentor.domain.Mentoring;
+
+import java.time.ZonedDateTime;
+
+public record MentoringResponse(
+        Long id,
+        Long mentorId,
+        Long menteeId,
+        ZonedDateTime createdAt,
+        ZonedDateTime confirmedAt,
+        VerifyStatus verifyStatus,
+        String rejectedReason
+) {
+    public static MentoringResponse from(Mentoring mentoring) {
+        return new MentoringResponse(
+                mentoring.getId(),
+                mentoring.getMentorId(),
+                mentoring.getMenteeId(),
+                mentoring.getCreatedAt(),
+                mentoring.getConfirmedAt(),
+                mentoring.getVerifyStatus(),
+                mentoring.getRejectedReason()
+        );
+    }
+}

--- a/src/main/java/com/example/solidconnection/mentor/dto/MentoringResponse.java
+++ b/src/main/java/com/example/solidconnection/mentor/dto/MentoringResponse.java
@@ -1,28 +1,24 @@
 package com.example.solidconnection.mentor.dto;
 
-import com.example.solidconnection.common.VerifyStatus;
 import com.example.solidconnection.mentor.domain.Mentoring;
+import com.example.solidconnection.siteuser.domain.SiteUser;
 
 import java.time.ZonedDateTime;
 
 public record MentoringResponse(
-        long id,
-        long mentorId,
-        long menteeId,
-        ZonedDateTime createdAt,
-        ZonedDateTime confirmedAt,
-        VerifyStatus verifyStatus,
-        String rejectedReason
+        long mentoringId,
+        String profileImageUrl,
+        String nickname,
+        boolean isChecked,
+        ZonedDateTime createAt
 ) {
-    public static MentoringResponse from(Mentoring mentoring) {
+    public static MentoringResponse from(Mentoring mentoring, SiteUser mentee) {
         return new MentoringResponse(
                 mentoring.getId(),
-                mentoring.getMentorId(),
-                mentoring.getMenteeId(),
-                mentoring.getCreatedAt(),
-                mentoring.getConfirmedAt(),
-                mentoring.getVerifyStatus(),
-                mentoring.getRejectedReason()
+                mentee.getProfileImageUrl(),
+                mentee.getNickname(),
+                mentoring.getCheckedAt() != null,
+                mentoring.getCreatedAt()
         );
     }
 }

--- a/src/main/java/com/example/solidconnection/mentor/dto/MentoringResponse.java
+++ b/src/main/java/com/example/solidconnection/mentor/dto/MentoringResponse.java
@@ -10,7 +10,7 @@ public record MentoringResponse(
         String profileImageUrl,
         String nickname,
         boolean isChecked,
-        ZonedDateTime createAt
+        ZonedDateTime createdAt
 ) {
     public static MentoringResponse from(Mentoring mentoring, SiteUser mentee) {
         return new MentoringResponse(

--- a/src/main/java/com/example/solidconnection/mentor/repository/MentorRepository.java
+++ b/src/main/java/com/example/solidconnection/mentor/repository/MentorRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 
 public interface MentorRepository extends JpaRepository<Mentor, Long> {
     Optional<Mentor> findBySiteUserId(Long siteUserId);
+    boolean existsBySiteUserId(Long siteUserId);
 }

--- a/src/main/java/com/example/solidconnection/mentor/repository/MentorRepository.java
+++ b/src/main/java/com/example/solidconnection/mentor/repository/MentorRepository.java
@@ -8,5 +8,6 @@ import java.util.Optional;
 public interface MentorRepository extends JpaRepository<Mentor, Long> {
 
     Optional<Mentor> findBySiteUserId(long siteUserId);
+
     boolean existsBySiteUserId(long siteUserId);
 }

--- a/src/main/java/com/example/solidconnection/mentor/repository/MentorRepository.java
+++ b/src/main/java/com/example/solidconnection/mentor/repository/MentorRepository.java
@@ -1,0 +1,10 @@
+package com.example.solidconnection.mentor.repository;
+
+import com.example.solidconnection.mentor.domain.Mentor;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MentorRepository extends JpaRepository<Mentor, Long> {
+    Optional<Mentor> findBySiteUserId(Long siteUserId);
+}

--- a/src/main/java/com/example/solidconnection/mentor/repository/MentorRepository.java
+++ b/src/main/java/com/example/solidconnection/mentor/repository/MentorRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface MentorRepository extends JpaRepository<Mentor, Long> {
-    Optional<Mentor> findBySiteUserId(Long siteUserId);
-    boolean existsBySiteUserId(Long siteUserId);
+
+    Optional<Mentor> findBySiteUserId(long siteUserId);
+    boolean existsBySiteUserId(long siteUserId);
 }

--- a/src/main/java/com/example/solidconnection/mentor/repository/MentoringRepository.java
+++ b/src/main/java/com/example/solidconnection/mentor/repository/MentoringRepository.java
@@ -1,0 +1,7 @@
+package com.example.solidconnection.mentor.repository;
+
+import com.example.solidconnection.mentor.domain.Mentoring;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MentoringRepository extends JpaRepository<Mentoring, Long> {
+}

--- a/src/main/java/com/example/solidconnection/mentor/repository/MentoringRepository.java
+++ b/src/main/java/com/example/solidconnection/mentor/repository/MentoringRepository.java
@@ -3,5 +3,9 @@ package com.example.solidconnection.mentor.repository;
 import com.example.solidconnection.mentor.domain.Mentoring;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface MentoringRepository extends JpaRepository<Mentoring, Long> {
+
+    List<Mentoring> findAllByMentorId(Long mentorId);
 }

--- a/src/main/java/com/example/solidconnection/mentor/repository/MentoringRepository.java
+++ b/src/main/java/com/example/solidconnection/mentor/repository/MentoringRepository.java
@@ -7,6 +7,6 @@ import java.util.List;
 
 public interface MentoringRepository extends JpaRepository<Mentoring, Long> {
 
-    List<Mentoring> findAllByMentorId(Long mentorId);
-    int countByMentorIdAndCheckedAtIsNull(Long mentorId);
+    List<Mentoring> findAllByMentorId(long mentorId);
+    int countByMentorIdAndCheckedAtIsNull(long mentorId);
 }

--- a/src/main/java/com/example/solidconnection/mentor/repository/MentoringRepository.java
+++ b/src/main/java/com/example/solidconnection/mentor/repository/MentoringRepository.java
@@ -8,5 +8,6 @@ import java.util.List;
 public interface MentoringRepository extends JpaRepository<Mentoring, Long> {
 
     List<Mentoring> findAllByMentorId(long mentorId);
+
     int countByMentorIdAndCheckedAtIsNull(long mentorId);
 }

--- a/src/main/java/com/example/solidconnection/mentor/repository/MentoringRepository.java
+++ b/src/main/java/com/example/solidconnection/mentor/repository/MentoringRepository.java
@@ -8,4 +8,5 @@ import java.util.List;
 public interface MentoringRepository extends JpaRepository<Mentoring, Long> {
 
     List<Mentoring> findAllByMentorId(Long mentorId);
+    int countByMentorIdAndCheckedAtIsNull(Long mentorId);
 }

--- a/src/main/java/com/example/solidconnection/mentor/service/MentoringCommandService.java
+++ b/src/main/java/com/example/solidconnection/mentor/service/MentoringCommandService.java
@@ -59,15 +59,16 @@ public class MentoringCommandService {
         validateUnauthorizedMentoring(siteUserId, mentor);
         validateAlreadyConfirmed(mentoring);
 
-        if (mentoringConfirmRequest.status() == VerifyStatus.APPROVED) {
-            mentor.increaseMenteeCount();
-        }
-        else if (mentoringConfirmRequest.status() == VerifyStatus.REJECTED
+        if (mentoringConfirmRequest.status() == VerifyStatus.REJECTED
                 && (mentoringConfirmRequest.rejectedReason() == null || mentoringConfirmRequest.rejectedReason().isBlank())) {
             throw new CustomException(REJECTED_REASON_REQUIRED);
         }
 
         mentoring.confirm(mentoringConfirmRequest.status(), mentoringConfirmRequest.rejectedReason());
+
+        if (mentoringConfirmRequest.status() == VerifyStatus.APPROVED) {
+            mentor.increaseMenteeCount();
+        }
 
         return MentoringConfirmResponse.from(mentoring);
     }

--- a/src/main/java/com/example/solidconnection/mentor/service/MentoringCommandService.java
+++ b/src/main/java/com/example/solidconnection/mentor/service/MentoringCommandService.java
@@ -44,7 +44,7 @@ public class MentoringCommandService {
                 .orElseThrow(() -> new CustomException(MENTOR_NOT_FOUND));
 
         validateMentoringOwnership(mentor, mentoring);
-        validateMentoringPermission(mentoring);
+        validateMentoringNotConfirmed(mentoring);
 
         if (mentoringConfirmRequest.status() == VerifyStatus.REJECTED
                 && (mentoringConfirmRequest.rejectedReason() == null || mentoringConfirmRequest.rejectedReason().isBlank())) {
@@ -60,7 +60,7 @@ public class MentoringCommandService {
         return MentoringConfirmResponse.from(mentoring);
     }
 
-    private void validateMentoringPermission(Mentoring mentoring) {
+    private void validateMentoringNotConfirmed(Mentoring mentoring) {
         if (mentoring.getVerifyStatus() != VerifyStatus.PENDING) {
             throw new CustomException(MENTORING_ALREADY_CONFIRMED);
         }

--- a/src/main/java/com/example/solidconnection/mentor/service/MentoringCommandService.java
+++ b/src/main/java/com/example/solidconnection/mentor/service/MentoringCommandService.java
@@ -1,0 +1,51 @@
+package com.example.solidconnection.mentor.service;
+
+import com.example.solidconnection.application.domain.VerifyStatus;
+import com.example.solidconnection.common.exception.CustomException;
+import com.example.solidconnection.mentor.domain.Mentoring;
+import com.example.solidconnection.mentor.dto.MentoringApplyRequest;
+import com.example.solidconnection.mentor.dto.MentoringApplyResponse;
+import com.example.solidconnection.mentor.repository.MentorRepository;
+import com.example.solidconnection.mentor.repository.MentoringRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.example.solidconnection.common.exception.ErrorCode.ALREADY_MENTOR;
+import static com.example.solidconnection.common.exception.ErrorCode.SELF_MENTORING_NOT_ALLOWED;
+
+@Service
+@RequiredArgsConstructor
+public class MentoringCommandService {
+
+    private final MentoringRepository mentoringRepository;
+    private final MentorRepository mentorRepository;
+
+    @Transactional
+    public MentoringApplyResponse applyMentoring(Long siteUserId, MentoringApplyRequest mentoringApplyRequest) {
+        validateSelfMentoring(siteUserId, mentoringApplyRequest);
+        validateAlreadyMentor(siteUserId);
+
+        Mentoring mentoring = Mentoring.builder()
+                .mentorId(mentoringApplyRequest.mentorId())
+                .menteeId(siteUserId)
+                .verifyStatus(VerifyStatus.PENDING)
+                .build();
+
+        return MentoringApplyResponse.from(
+                mentoringRepository.save(mentoring)
+        );
+    }
+
+    private void validateSelfMentoring(Long siteUserId, MentoringApplyRequest request) {
+        if (siteUserId.equals(request.mentorId())) {
+            throw new CustomException(SELF_MENTORING_NOT_ALLOWED);
+        }
+    }
+
+    private void validateAlreadyMentor(Long siteUserId) {
+        if (mentorRepository.existsById(siteUserId)) {
+            throw new CustomException(ALREADY_MENTOR);
+        }
+    }
+}

--- a/src/main/java/com/example/solidconnection/mentor/service/MentoringCommandService.java
+++ b/src/main/java/com/example/solidconnection/mentor/service/MentoringCommandService.java
@@ -30,7 +30,7 @@ public class MentoringCommandService {
     private final MentorRepository mentorRepository;
 
     @Transactional
-    public MentoringApplyResponse applyMentoring(Long siteUserId, MentoringApplyRequest mentoringApplyRequest) {
+    public MentoringApplyResponse applyMentoring(long siteUserId, MentoringApplyRequest mentoringApplyRequest) {
         validateAlreadyMentor(siteUserId);
 
         Mentoring mentoring = Mentoring.builder()
@@ -45,7 +45,7 @@ public class MentoringCommandService {
     }
 
     @Transactional
-    public MentoringConfirmResponse confirmMentoring(Long siteUserId, Long mentoringId, MentoringConfirmRequest mentoringConfirmRequest) {
+    public MentoringConfirmResponse confirmMentoring(long siteUserId, long mentoringId, MentoringConfirmRequest mentoringConfirmRequest) {
         Mentoring mentoring = mentoringRepository.findById(mentoringId)
                 .orElseThrow(() -> new CustomException(MENTORING_NOT_FOUND));
 
@@ -69,7 +69,7 @@ public class MentoringCommandService {
     }
 
     @Transactional
-    public MentoringCheckResponse checkMentoring(Long siteUserId, Long mentoringId) {
+    public MentoringCheckResponse checkMentoring(long siteUserId, long mentoringId) {
         Mentoring mentoring = mentoringRepository.findById(mentoringId)
                 .orElseThrow(() -> new CustomException(MENTORING_NOT_FOUND));
 
@@ -83,15 +83,15 @@ public class MentoringCommandService {
         return MentoringCheckResponse.from(mentoring.getId());
     }
 
-    private void validateAlreadyMentor(Long siteUserId) {
+    private void validateAlreadyMentor(long siteUserId) {
         if (mentorRepository.existsBySiteUserId(siteUserId)) {
             throw new CustomException(ALREADY_MENTOR);
         }
     }
 
     // 멘토는 본인의 멘토링에 대해 confirm 및 check해야 한다.
-    private void validateUnauthorizedMentoring(Long siteUserId, Mentor mentor) {
-        if (!siteUserId.equals(mentor.getSiteUserId())) {
+    private void validateUnauthorizedMentoring(long siteUserId, Mentor mentor) {
+        if (siteUserId != mentor.getSiteUserId()) {
             throw new CustomException(UNAUTHORIZED_MENTORING);
         }
     }

--- a/src/main/java/com/example/solidconnection/mentor/service/MentoringCommandService.java
+++ b/src/main/java/com/example/solidconnection/mentor/service/MentoringCommandService.java
@@ -1,6 +1,6 @@
 package com.example.solidconnection.mentor.service;
 
-import com.example.solidconnection.application.domain.VerifyStatus;
+import com.example.solidconnection.common.VerifyStatus;
 import com.example.solidconnection.common.exception.CustomException;
 import com.example.solidconnection.mentor.domain.Mentor;
 import com.example.solidconnection.mentor.domain.Mentoring;
@@ -60,10 +60,9 @@ public class MentoringCommandService {
         if (mentoringConfirmRequest.status() == VerifyStatus.APPROVED) {
             mentor.increaseMenteeCount();
         }
-        else if (mentoringConfirmRequest.status() == VerifyStatus.REJECTED) {
-            if (mentoringConfirmRequest.rejectedReason() == null || mentoringConfirmRequest.rejectedReason().isBlank()) {
-                throw new CustomException(REJECTED_REASON_REQUIRED);
-            }
+        else if (mentoringConfirmRequest.status() == VerifyStatus.REJECTED
+                && (mentoringConfirmRequest.rejectedReason() == null || mentoringConfirmRequest.rejectedReason().isBlank())) {
+            throw new CustomException(REJECTED_REASON_REQUIRED);
         }
 
         mentoring.confirm(mentoringConfirmRequest.status(), mentoringConfirmRequest.rejectedReason());

--- a/src/main/java/com/example/solidconnection/mentor/service/MentoringCommandService.java
+++ b/src/main/java/com/example/solidconnection/mentor/service/MentoringCommandService.java
@@ -42,6 +42,12 @@ public class MentoringCommandService {
         return MentoringApplyResponse.from(mentoringRepository.save(mentoring));
     }
 
+    private void validateAlreadyMentor(long siteUserId) {
+        if (mentorRepository.existsBySiteUserId(siteUserId)) {
+            throw new CustomException(ALREADY_MENTOR);
+        }
+    }
+
     @Transactional
     public MentoringConfirmResponse confirmMentoring(long siteUserId, long mentoringId, MentoringConfirmRequest mentoringConfirmRequest) {
         Mentoring mentoring = mentoringRepository.findById(mentoringId)
@@ -66,6 +72,12 @@ public class MentoringCommandService {
         return MentoringConfirmResponse.from(mentoring);
     }
 
+    private void validateAlreadyConfirmed(Mentoring mentoring) {
+        if (mentoring.getVerifyStatus() != VerifyStatus.PENDING) {
+            throw new CustomException(MENTORING_ALREADY_CONFIRMED);
+        }
+    }
+
     @Transactional
     public MentoringCheckResponse checkMentoring(long siteUserId, long mentoringId) {
         Mentoring mentoring = mentoringRepository.findById(mentoringId)
@@ -81,22 +93,10 @@ public class MentoringCommandService {
         return MentoringCheckResponse.from(mentoring.getId());
     }
 
-    private void validateAlreadyMentor(long siteUserId) {
-        if (mentorRepository.existsBySiteUserId(siteUserId)) {
-            throw new CustomException(ALREADY_MENTOR);
-        }
-    }
-
     // 멘토는 본인의 멘토링에 대해 confirm 및 check해야 한다.
     private void validateUnauthorizedMentoring(long siteUserId, Mentor mentor) {
         if (siteUserId != mentor.getSiteUserId()) {
             throw new CustomException(UNAUTHORIZED_MENTORING);
-        }
-    }
-
-    private void validateAlreadyConfirmed(Mentoring mentoring) {
-        if (mentoring.getVerifyStatus() != VerifyStatus.PENDING) {
-            throw new CustomException(MENTORING_ALREADY_CONFIRMED);
         }
     }
 }

--- a/src/main/java/com/example/solidconnection/mentor/service/MentoringCommandService.java
+++ b/src/main/java/com/example/solidconnection/mentor/service/MentoringCommandService.java
@@ -20,7 +20,6 @@ import static com.example.solidconnection.common.exception.ErrorCode.MENTORING_A
 import static com.example.solidconnection.common.exception.ErrorCode.MENTORING_NOT_FOUND;
 import static com.example.solidconnection.common.exception.ErrorCode.MENTOR_NOT_FOUND;
 import static com.example.solidconnection.common.exception.ErrorCode.REJECTED_REASON_REQUIRED;
-import static com.example.solidconnection.common.exception.ErrorCode.SELF_MENTORING_NOT_ALLOWED;
 import static com.example.solidconnection.common.exception.ErrorCode.UNAUTHORIZED_MENTORING;
 
 @Service
@@ -32,7 +31,6 @@ public class MentoringCommandService {
 
     @Transactional
     public MentoringApplyResponse applyMentoring(Long siteUserId, MentoringApplyRequest mentoringApplyRequest) {
-        validateSelfMentoring(siteUserId, mentoringApplyRequest);
         validateAlreadyMentor(siteUserId);
 
         Mentoring mentoring = Mentoring.builder()
@@ -83,12 +81,6 @@ public class MentoringCommandService {
         mentoring.check();
 
         return MentoringCheckResponse.from(mentoring.getId());
-    }
-
-    private void validateSelfMentoring(Long siteUserId, MentoringApplyRequest request) {
-        if (siteUserId.equals(request.mentorId())) {
-            throw new CustomException(SELF_MENTORING_NOT_ALLOWED);
-        }
     }
 
     private void validateAlreadyMentor(Long siteUserId) {

--- a/src/main/java/com/example/solidconnection/mentor/service/MentoringCommandService.java
+++ b/src/main/java/com/example/solidconnection/mentor/service/MentoringCommandService.java
@@ -44,10 +44,10 @@ public class MentoringCommandService {
         Mentoring mentoring = mentoringRepository.findById(mentoringId)
                 .orElseThrow(() -> new CustomException(MENTORING_NOT_FOUND));
 
-        Mentor mentor = mentorRepository.findById(mentoring.getMentorId())
+        Mentor mentor = mentorRepository.findBySiteUserId(siteUserId)
                 .orElseThrow(() -> new CustomException(MENTOR_NOT_FOUND));
 
-        validateMentoringOwnership(siteUserId, mentor);
+        validateMentoringOwnership(mentor, mentoring);
         validateMentoringPermission(mentoring);
 
         if (mentoringConfirmRequest.status() == VerifyStatus.REJECTED
@@ -75,10 +75,10 @@ public class MentoringCommandService {
         Mentoring mentoring = mentoringRepository.findById(mentoringId)
                 .orElseThrow(() -> new CustomException(MENTORING_NOT_FOUND));
 
-        Mentor mentor = mentorRepository.findById(mentoring.getMentorId())
+        Mentor mentor = mentorRepository.findBySiteUserId(siteUserId)
                 .orElseThrow(() -> new CustomException(MENTOR_NOT_FOUND));
 
-        validateMentoringOwnership(siteUserId, mentor);
+        validateMentoringOwnership(mentor, mentoring);
 
         mentoring.check();
 
@@ -86,8 +86,8 @@ public class MentoringCommandService {
     }
 
     // 멘토는 본인의 멘토링에 대해 confirm 및 check해야 한다.
-    private void validateMentoringOwnership(long siteUserId, Mentor mentor) {
-        if (siteUserId != mentor.getSiteUserId()) {
+    private void validateMentoringOwnership(Mentor mentor, Mentoring mentoring) {
+        if (mentoring.getMentorId() != mentor.getId()) {
             throw new CustomException(UNAUTHORIZED_MENTORING);
         }
     }

--- a/src/main/java/com/example/solidconnection/mentor/service/MentoringCommandService.java
+++ b/src/main/java/com/example/solidconnection/mentor/service/MentoringCommandService.java
@@ -30,11 +30,11 @@ public class MentoringCommandService {
 
     @Transactional
     public MentoringApplyResponse applyMentoring(long siteUserId, MentoringApplyRequest mentoringApplyRequest) {
-        Mentoring mentoring = Mentoring.builder()
-                .mentorId(mentoringApplyRequest.mentorId())
-                .menteeId(siteUserId)
-                .verifyStatus(VerifyStatus.PENDING)
-                .build();
+        Mentoring mentoring = new Mentoring(
+                mentoringApplyRequest.mentorId(),
+                siteUserId,
+                VerifyStatus.PENDING
+        );
 
         return MentoringApplyResponse.from(mentoringRepository.save(mentoring));
     }

--- a/src/main/java/com/example/solidconnection/mentor/service/MentoringCommandService.java
+++ b/src/main/java/com/example/solidconnection/mentor/service/MentoringCommandService.java
@@ -47,8 +47,8 @@ public class MentoringCommandService {
         Mentor mentor = mentorRepository.findById(mentoring.getMentorId())
                 .orElseThrow(() -> new CustomException(MENTOR_NOT_FOUND));
 
-        validateUnauthorizedMentoring(siteUserId, mentor);
-        validateAlreadyConfirmed(mentoring);
+        validateMentoringOwnership(siteUserId, mentor);
+        validateMentoringPermission(mentoring);
 
         if (mentoringConfirmRequest.status() == VerifyStatus.REJECTED
                 && (mentoringConfirmRequest.rejectedReason() == null || mentoringConfirmRequest.rejectedReason().isBlank())) {
@@ -64,7 +64,7 @@ public class MentoringCommandService {
         return MentoringConfirmResponse.from(mentoring);
     }
 
-    private void validateAlreadyConfirmed(Mentoring mentoring) {
+    private void validateMentoringPermission(Mentoring mentoring) {
         if (mentoring.getVerifyStatus() != VerifyStatus.PENDING) {
             throw new CustomException(MENTORING_ALREADY_CONFIRMED);
         }
@@ -78,7 +78,7 @@ public class MentoringCommandService {
         Mentor mentor = mentorRepository.findById(mentoring.getMentorId())
                 .orElseThrow(() -> new CustomException(MENTOR_NOT_FOUND));
 
-        validateUnauthorizedMentoring(siteUserId, mentor);
+        validateMentoringOwnership(siteUserId, mentor);
 
         mentoring.check();
 
@@ -86,7 +86,7 @@ public class MentoringCommandService {
     }
 
     // 멘토는 본인의 멘토링에 대해 confirm 및 check해야 한다.
-    private void validateUnauthorizedMentoring(long siteUserId, Mentor mentor) {
+    private void validateMentoringOwnership(long siteUserId, Mentor mentor) {
         if (siteUserId != mentor.getSiteUserId()) {
             throw new CustomException(UNAUTHORIZED_MENTORING);
         }

--- a/src/main/java/com/example/solidconnection/mentor/service/MentoringCommandService.java
+++ b/src/main/java/com/example/solidconnection/mentor/service/MentoringCommandService.java
@@ -15,7 +15,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import static com.example.solidconnection.common.exception.ErrorCode.ALREADY_MENTOR;
 import static com.example.solidconnection.common.exception.ErrorCode.MENTORING_ALREADY_CONFIRMED;
 import static com.example.solidconnection.common.exception.ErrorCode.MENTORING_NOT_FOUND;
 import static com.example.solidconnection.common.exception.ErrorCode.MENTOR_NOT_FOUND;
@@ -31,8 +30,6 @@ public class MentoringCommandService {
 
     @Transactional
     public MentoringApplyResponse applyMentoring(long siteUserId, MentoringApplyRequest mentoringApplyRequest) {
-        validateAlreadyMentor(siteUserId);
-
         Mentoring mentoring = Mentoring.builder()
                 .mentorId(mentoringApplyRequest.mentorId())
                 .menteeId(siteUserId)
@@ -40,12 +37,6 @@ public class MentoringCommandService {
                 .build();
 
         return MentoringApplyResponse.from(mentoringRepository.save(mentoring));
-    }
-
-    private void validateAlreadyMentor(long siteUserId) {
-        if (mentorRepository.existsBySiteUserId(siteUserId)) {
-            throw new CustomException(ALREADY_MENTOR);
-        }
     }
 
     @Transactional

--- a/src/main/java/com/example/solidconnection/mentor/service/MentoringCommandService.java
+++ b/src/main/java/com/example/solidconnection/mentor/service/MentoringCommandService.java
@@ -39,9 +39,7 @@ public class MentoringCommandService {
                 .verifyStatus(VerifyStatus.PENDING)
                 .build();
 
-        return MentoringApplyResponse.from(
-                mentoringRepository.save(mentoring)
-        );
+        return MentoringApplyResponse.from(mentoringRepository.save(mentoring));
     }
 
     @Transactional

--- a/src/main/java/com/example/solidconnection/mentor/service/MentoringCommandService.java
+++ b/src/main/java/com/example/solidconnection/mentor/service/MentoringCommandService.java
@@ -92,7 +92,7 @@ public class MentoringCommandService {
     }
 
     private void validateAlreadyMentor(Long siteUserId) {
-        if (mentorRepository.existsById(siteUserId)) {
+        if (mentorRepository.existsBySiteUserId(siteUserId)) {
             throw new CustomException(ALREADY_MENTOR);
         }
     }

--- a/src/main/java/com/example/solidconnection/mentor/service/MentoringCommandService.java
+++ b/src/main/java/com/example/solidconnection/mentor/service/MentoringCommandService.java
@@ -2,9 +2,12 @@ package com.example.solidconnection.mentor.service;
 
 import com.example.solidconnection.application.domain.VerifyStatus;
 import com.example.solidconnection.common.exception.CustomException;
+import com.example.solidconnection.mentor.domain.Mentor;
 import com.example.solidconnection.mentor.domain.Mentoring;
 import com.example.solidconnection.mentor.dto.MentoringApplyRequest;
 import com.example.solidconnection.mentor.dto.MentoringApplyResponse;
+import com.example.solidconnection.mentor.dto.MentoringConfirmRequest;
+import com.example.solidconnection.mentor.dto.MentoringConfirmResponse;
 import com.example.solidconnection.mentor.repository.MentorRepository;
 import com.example.solidconnection.mentor.repository.MentoringRepository;
 import lombok.RequiredArgsConstructor;
@@ -12,7 +15,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import static com.example.solidconnection.common.exception.ErrorCode.ALREADY_MENTOR;
+import static com.example.solidconnection.common.exception.ErrorCode.MENTORING_ALREADY_CONFIRMED;
+import static com.example.solidconnection.common.exception.ErrorCode.MENTORING_NOT_FOUND;
+import static com.example.solidconnection.common.exception.ErrorCode.MENTOR_NOT_FOUND;
+import static com.example.solidconnection.common.exception.ErrorCode.REJECTED_REASON_REQUIRED;
 import static com.example.solidconnection.common.exception.ErrorCode.SELF_MENTORING_NOT_ALLOWED;
+import static com.example.solidconnection.common.exception.ErrorCode.UNAUTHORIZED_MENTORING_CONFIRM;
 
 @Service
 @RequiredArgsConstructor
@@ -37,6 +45,31 @@ public class MentoringCommandService {
         );
     }
 
+    @Transactional
+    public MentoringConfirmResponse confirmMentoring(Long siteUserId, Long mentoringId, MentoringConfirmRequest mentoringConfirmRequest) {
+        Mentoring mentoring = mentoringRepository.findById(mentoringId)
+                .orElseThrow(() -> new CustomException(MENTORING_NOT_FOUND));
+
+        Mentor mentor = mentorRepository.findById(mentoring.getMentorId())
+                .orElseThrow(() -> new CustomException(MENTOR_NOT_FOUND));
+
+        validateUnauthorizedMentoring(siteUserId, mentor);
+        validateAlreadyConfirmed(mentoring);
+
+        if (mentoringConfirmRequest.status() == VerifyStatus.APPROVED) {
+            mentor.increaseMenteeCount();
+        }
+        else if (mentoringConfirmRequest.status() == VerifyStatus.REJECTED) {
+            if (mentoringConfirmRequest.rejectedReason() == null || mentoringConfirmRequest.rejectedReason().isBlank()) {
+                throw new CustomException(REJECTED_REASON_REQUIRED);
+            }
+        }
+
+        mentoring.confirm(mentoringConfirmRequest.status(), mentoringConfirmRequest.rejectedReason());
+
+        return MentoringConfirmResponse.from(mentoring);
+    }
+
     private void validateSelfMentoring(Long siteUserId, MentoringApplyRequest request) {
         if (siteUserId.equals(request.mentorId())) {
             throw new CustomException(SELF_MENTORING_NOT_ALLOWED);
@@ -46,6 +79,19 @@ public class MentoringCommandService {
     private void validateAlreadyMentor(Long siteUserId) {
         if (mentorRepository.existsById(siteUserId)) {
             throw new CustomException(ALREADY_MENTOR);
+        }
+    }
+
+    // 멘토는 본인의 멘토링에 대해 confirm해야 한다.
+    private void validateUnauthorizedMentoring(Long siteUserId, Mentor mentor) {
+        if (!siteUserId.equals(mentor.getSiteUserId())) {
+            throw new CustomException(UNAUTHORIZED_MENTORING_CONFIRM);
+        }
+    }
+
+    private void validateAlreadyConfirmed(Mentoring mentoring) {
+        if (mentoring.getVerifyStatus() != VerifyStatus.PENDING) {
+            throw new CustomException(MENTORING_ALREADY_CONFIRMED);
         }
     }
 }

--- a/src/main/java/com/example/solidconnection/mentor/service/MentoringCommandService.java
+++ b/src/main/java/com/example/solidconnection/mentor/service/MentoringCommandService.java
@@ -30,11 +30,7 @@ public class MentoringCommandService {
 
     @Transactional
     public MentoringApplyResponse applyMentoring(long siteUserId, MentoringApplyRequest mentoringApplyRequest) {
-        Mentoring mentoring = new Mentoring(
-                mentoringApplyRequest.mentorId(),
-                siteUserId,
-                VerifyStatus.PENDING
-        );
+        Mentoring mentoring = new Mentoring(mentoringApplyRequest.mentorId(), siteUserId, VerifyStatus.PENDING);
 
         return MentoringApplyResponse.from(mentoringRepository.save(mentoring));
     }

--- a/src/main/java/com/example/solidconnection/mentor/service/MentoringQueryService.java
+++ b/src/main/java/com/example/solidconnection/mentor/service/MentoringQueryService.java
@@ -24,7 +24,7 @@ public class MentoringQueryService {
     private final MentorRepository mentorRepository;
 
     @Transactional(readOnly = true)
-    public MentoringListResponse getMentorings(Long siteUserId) {
+    public MentoringListResponse getMentorings(long siteUserId) {
         Mentor mentor = mentorRepository.findBySiteUserId(siteUserId)
                 .orElseThrow(() -> new CustomException(MENTOR_NOT_FOUND));
 
@@ -37,7 +37,7 @@ public class MentoringQueryService {
     }
 
     @Transactional(readOnly = true)
-    public MentoringCountResponse getNewMentoringsCount(Long siteUserId) {
+    public MentoringCountResponse getNewMentoringsCount(long siteUserId) {
         Mentor mentor = mentorRepository.findBySiteUserId(siteUserId)
                 .orElseThrow(() -> new CustomException(MENTOR_NOT_FOUND));
 

--- a/src/main/java/com/example/solidconnection/mentor/service/MentoringQueryService.java
+++ b/src/main/java/com/example/solidconnection/mentor/service/MentoringQueryService.java
@@ -1,0 +1,36 @@
+package com.example.solidconnection.mentor.service;
+
+import com.example.solidconnection.common.exception.CustomException;
+import com.example.solidconnection.mentor.domain.Mentor;
+import com.example.solidconnection.mentor.domain.Mentoring;
+import com.example.solidconnection.mentor.dto.MentoringResponse;
+import com.example.solidconnection.mentor.repository.MentorRepository;
+import com.example.solidconnection.mentor.repository.MentoringRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.example.solidconnection.common.exception.ErrorCode.MENTOR_NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+public class MentoringQueryService {
+
+    private final MentoringRepository mentoringRepository;
+    private final MentorRepository mentorRepository;
+
+    @Transactional(readOnly = true)
+    public List<MentoringResponse> getMentorings(Long siteUserId) {
+        Mentor mentor = mentorRepository.findBySiteUserId(siteUserId)
+                .orElseThrow(() -> new CustomException(MENTOR_NOT_FOUND));
+
+        List<Mentoring> mentorings = mentoringRepository.findAllByMentorId(mentor.getId());
+
+        return mentorings.stream()
+                .map(MentoringResponse::from)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/example/solidconnection/mentor/service/MentoringQueryService.java
+++ b/src/main/java/com/example/solidconnection/mentor/service/MentoringQueryService.java
@@ -4,6 +4,7 @@ import com.example.solidconnection.common.exception.CustomException;
 import com.example.solidconnection.mentor.domain.Mentor;
 import com.example.solidconnection.mentor.domain.Mentoring;
 import com.example.solidconnection.mentor.dto.MentoringCountResponse;
+import com.example.solidconnection.mentor.dto.MentoringListResponse;
 import com.example.solidconnection.mentor.dto.MentoringResponse;
 import com.example.solidconnection.mentor.repository.MentorRepository;
 import com.example.solidconnection.mentor.repository.MentoringRepository;
@@ -12,7 +13,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static com.example.solidconnection.common.exception.ErrorCode.MENTOR_NOT_FOUND;
 
@@ -24,15 +24,16 @@ public class MentoringQueryService {
     private final MentorRepository mentorRepository;
 
     @Transactional(readOnly = true)
-    public List<MentoringResponse> getMentorings(Long siteUserId) {
+    public MentoringListResponse getMentorings(Long siteUserId) {
         Mentor mentor = mentorRepository.findBySiteUserId(siteUserId)
                 .orElseThrow(() -> new CustomException(MENTOR_NOT_FOUND));
 
         List<Mentoring> mentorings = mentoringRepository.findAllByMentorId(mentor.getId());
-
-        return mentorings.stream()
+        List<MentoringResponse> mentoringResponses = mentorings.stream()
                 .map(MentoringResponse::from)
-                .collect(Collectors.toList());
+                .toList();
+
+        return MentoringListResponse.from(mentoringResponses);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/example/solidconnection/mentor/service/MentoringQueryService.java
+++ b/src/main/java/com/example/solidconnection/mentor/service/MentoringQueryService.java
@@ -3,6 +3,7 @@ package com.example.solidconnection.mentor.service;
 import com.example.solidconnection.common.exception.CustomException;
 import com.example.solidconnection.mentor.domain.Mentor;
 import com.example.solidconnection.mentor.domain.Mentoring;
+import com.example.solidconnection.mentor.dto.MentoringCountResponse;
 import com.example.solidconnection.mentor.dto.MentoringResponse;
 import com.example.solidconnection.mentor.repository.MentorRepository;
 import com.example.solidconnection.mentor.repository.MentoringRepository;
@@ -32,5 +33,15 @@ public class MentoringQueryService {
         return mentorings.stream()
                 .map(MentoringResponse::from)
                 .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public MentoringCountResponse getNewMentoringsCount(Long siteUserId) {
+        Mentor mentor = mentorRepository.findBySiteUserId(siteUserId)
+                .orElseThrow(() -> new CustomException(MENTOR_NOT_FOUND));
+
+        int count = mentoringRepository.countByMentorIdAndCheckedAtIsNull(mentor.getId());
+
+        return MentoringCountResponse.from(count);
     }
 }

--- a/src/test/java/com/example/solidconnection/mentor/fixture/MentorFixture.java
+++ b/src/test/java/com/example/solidconnection/mentor/fixture/MentorFixture.java
@@ -1,0 +1,21 @@
+package com.example.solidconnection.mentor.fixture;
+
+import com.example.solidconnection.mentor.domain.Mentor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.test.context.TestComponent;
+
+@TestComponent
+@RequiredArgsConstructor
+public class MentorFixture {
+
+    private final MentorFixtureBuilder mentorFixtureBuilder;
+
+    public Mentor 멘토(Long siteUserId, Long universityId) {
+        return mentorFixtureBuilder.mentor()
+                .siteUserId(siteUserId)
+                .universityId(universityId)
+                .introduction("멘토 소개")
+                .passTip("멘토 팁")
+                .create();
+    }
+}

--- a/src/test/java/com/example/solidconnection/mentor/fixture/MentorFixture.java
+++ b/src/test/java/com/example/solidconnection/mentor/fixture/MentorFixture.java
@@ -10,7 +10,7 @@ public class MentorFixture {
 
     private final MentorFixtureBuilder mentorFixtureBuilder;
 
-    public Mentor 멘토(Long siteUserId, Long universityId) {
+    public Mentor 멘토(long siteUserId, long universityId) {
         return mentorFixtureBuilder.mentor()
                 .siteUserId(siteUserId)
                 .universityId(universityId)

--- a/src/test/java/com/example/solidconnection/mentor/fixture/MentorFixtureBuilder.java
+++ b/src/test/java/com/example/solidconnection/mentor/fixture/MentorFixtureBuilder.java
@@ -1,0 +1,68 @@
+package com.example.solidconnection.mentor.fixture;
+
+import com.example.solidconnection.mentor.domain.Mentor;
+import com.example.solidconnection.mentor.repository.MentorRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.test.context.TestComponent;
+
+@TestComponent
+@RequiredArgsConstructor
+public class MentorFixtureBuilder {
+
+    private final MentorRepository mentorRepository;
+
+    private int menteeCount = 0;
+    private boolean hasBadge = false;
+    private String introduction;
+    private String passTip;
+    private Long siteUserId;
+    private Long universityId;
+
+    public MentorFixtureBuilder mentor() {
+        return new MentorFixtureBuilder(mentorRepository);
+    }
+
+    public MentorFixtureBuilder menteeCount(int menteeCount) {
+        this.menteeCount = menteeCount;
+        return this;
+    }
+
+    public MentorFixtureBuilder hasBadge(boolean hasBadge) {
+        this.hasBadge = hasBadge;
+        return this;
+    }
+
+    public MentorFixtureBuilder introduction(String introduction) {
+        this.introduction = introduction;
+        return this;
+    }
+
+    public MentorFixtureBuilder passTip(String passTip) {
+        this.passTip = passTip;
+        return this;
+    }
+
+    public MentorFixtureBuilder siteUserId(Long siteUserId) {
+        this.siteUserId = siteUserId;
+        return this;
+    }
+
+    public MentorFixtureBuilder universityId(Long universityId) {
+        this.universityId = universityId;
+        return this;
+    }
+
+    public Mentor create() {
+        Mentor mentor = new Mentor(
+                null,
+                menteeCount,
+                hasBadge,
+                introduction,
+                passTip,
+                siteUserId,
+                universityId,
+                null
+        );
+        return mentorRepository.save(mentor);
+    }
+}

--- a/src/test/java/com/example/solidconnection/mentor/fixture/MentorFixtureBuilder.java
+++ b/src/test/java/com/example/solidconnection/mentor/fixture/MentorFixtureBuilder.java
@@ -15,8 +15,8 @@ public class MentorFixtureBuilder {
     private boolean hasBadge = false;
     private String introduction;
     private String passTip;
-    private Long siteUserId;
-    private Long universityId;
+    private long siteUserId;
+    private long universityId;
 
     public MentorFixtureBuilder mentor() {
         return new MentorFixtureBuilder(mentorRepository);

--- a/src/test/java/com/example/solidconnection/mentor/fixture/MentoringFixture.java
+++ b/src/test/java/com/example/solidconnection/mentor/fixture/MentoringFixture.java
@@ -54,24 +54,6 @@ public class MentoringFixture {
                 .create();
     }
 
-    public Mentoring 멘토링(
-            long mentorId,
-            long menteeId,
-            VerifyStatus status,
-            String rejectedReason,
-            ZonedDateTime confirmedAt,
-            ZonedDateTime checkedAt) {
-
-        return mentoringFixtureBuilder.mentoring()
-                .mentorId(mentorId)
-                .menteeId(menteeId)
-                .verifyStatus(status)
-                .rejectedReason(rejectedReason)
-                .confirmedAt(confirmedAt)
-                .checkedAt(checkedAt)
-                .create();
-    }
-
     private ZonedDateTime getCurrentTime() {
         return ZonedDateTime.now(UTC).truncatedTo(MICROS);
     }

--- a/src/test/java/com/example/solidconnection/mentor/fixture/MentoringFixture.java
+++ b/src/test/java/com/example/solidconnection/mentor/fixture/MentoringFixture.java
@@ -1,0 +1,78 @@
+package com.example.solidconnection.mentor.fixture;
+
+import com.example.solidconnection.common.VerifyStatus;
+import com.example.solidconnection.mentor.domain.Mentoring;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.test.context.TestComponent;
+
+import java.time.ZonedDateTime;
+
+import static java.time.ZoneOffset.UTC;
+import static java.time.temporal.ChronoUnit.MICROS;
+
+@TestComponent
+@RequiredArgsConstructor
+public class MentoringFixture {
+
+    private final MentoringFixtureBuilder mentoringFixtureBuilder;
+
+    public Mentoring 대기중_멘토링(long mentorId, long menteeId) {
+        return mentoringFixtureBuilder.mentoring()
+                .mentorId(mentorId)
+                .menteeId(menteeId)
+                .create();
+    }
+
+    public Mentoring 승인된_멘토링(long mentorId, long menteeId) {
+        ZonedDateTime now = getCurrentTime();
+        return mentoringFixtureBuilder.mentoring()
+                .mentorId(mentorId)
+                .menteeId(menteeId)
+                .verifyStatus(VerifyStatus.APPROVED)
+                .confirmedAt(now)
+                .checkedAt(now)
+                .create();
+    }
+
+    public Mentoring 거절된_멘토링(long mentorId, long menteeId, String rejectedReason) {
+        ZonedDateTime now = getCurrentTime();
+        return mentoringFixtureBuilder.mentoring()
+                .mentorId(mentorId)
+                .menteeId(menteeId)
+                .verifyStatus(VerifyStatus.REJECTED)
+                .rejectedReason(rejectedReason)
+                .confirmedAt(now)
+                .checkedAt(now)
+                .create();
+    }
+
+    public Mentoring 확인되지_않은_멘토링(long mentorId, long menteeId) {
+        return mentoringFixtureBuilder.mentoring()
+                .mentorId(mentorId)
+                .menteeId(menteeId)
+                .checkedAt(null)
+                .create();
+    }
+
+    public Mentoring 멘토링(
+            long mentorId,
+            long menteeId,
+            VerifyStatus status,
+            String rejectedReason,
+            ZonedDateTime confirmedAt,
+            ZonedDateTime checkedAt) {
+
+        return mentoringFixtureBuilder.mentoring()
+                .mentorId(mentorId)
+                .menteeId(menteeId)
+                .verifyStatus(status)
+                .rejectedReason(rejectedReason)
+                .confirmedAt(confirmedAt)
+                .checkedAt(checkedAt)
+                .create();
+    }
+
+    private ZonedDateTime getCurrentTime() {
+        return ZonedDateTime.now(UTC).truncatedTo(MICROS);
+    }
+}

--- a/src/test/java/com/example/solidconnection/mentor/fixture/MentoringFixtureBuilder.java
+++ b/src/test/java/com/example/solidconnection/mentor/fixture/MentoringFixtureBuilder.java
@@ -1,0 +1,77 @@
+package com.example.solidconnection.mentor.fixture;
+
+import com.example.solidconnection.common.VerifyStatus;
+import com.example.solidconnection.mentor.domain.Mentoring;
+import com.example.solidconnection.mentor.repository.MentoringRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.test.context.TestComponent;
+
+import java.time.ZonedDateTime;
+
+@TestComponent
+@RequiredArgsConstructor
+public class MentoringFixtureBuilder {
+
+    private final MentoringRepository mentoringRepository;
+
+    private ZonedDateTime createdAt;
+    private ZonedDateTime confirmedAt;
+    private ZonedDateTime checkedAt;
+    private VerifyStatus verifyStatus = VerifyStatus.PENDING;
+    private String rejectedReason;
+    private long mentorId;
+    private long menteeId;
+
+    public MentoringFixtureBuilder mentoring() {
+        return new MentoringFixtureBuilder(mentoringRepository);
+    }
+
+    public MentoringFixtureBuilder createdAt(ZonedDateTime createdAt) {
+        this.createdAt = createdAt;
+        return this;
+    }
+
+    public MentoringFixtureBuilder confirmedAt(ZonedDateTime confirmedAt) {
+        this.confirmedAt = confirmedAt;
+        return this;
+    }
+
+    public MentoringFixtureBuilder checkedAt(ZonedDateTime checkedAt) {
+        this.checkedAt = checkedAt;
+        return this;
+    }
+
+    public MentoringFixtureBuilder verifyStatus(VerifyStatus verifyStatus) {
+        this.verifyStatus = verifyStatus;
+        return this;
+    }
+
+    public MentoringFixtureBuilder rejectedReason(String rejectedReason) {
+        this.rejectedReason = rejectedReason;
+        return this;
+    }
+
+    public MentoringFixtureBuilder mentorId(long mentorId) {
+        this.mentorId = mentorId;
+        return this;
+    }
+
+    public MentoringFixtureBuilder menteeId(long menteeId) {
+        this.menteeId = menteeId;
+        return this;
+    }
+
+    public Mentoring create() {
+        Mentoring mentoring = new Mentoring(
+                null,
+                createdAt,
+                confirmedAt,
+                checkedAt,
+                verifyStatus,
+                rejectedReason,
+                mentorId,
+                menteeId
+        );
+        return mentoringRepository.save(mentoring);
+    }
+}

--- a/src/test/java/com/example/solidconnection/mentor/service/MentoringCommandServiceTest.java
+++ b/src/test/java/com/example/solidconnection/mentor/service/MentoringCommandServiceTest.java
@@ -27,10 +27,10 @@ import static com.example.solidconnection.common.exception.ErrorCode.MENTORING_A
 import static com.example.solidconnection.common.exception.ErrorCode.MENTORING_NOT_FOUND;
 import static com.example.solidconnection.common.exception.ErrorCode.REJECTED_REASON_REQUIRED;
 import static com.example.solidconnection.common.exception.ErrorCode.UNAUTHORIZED_MENTORING;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
+
 @TestContainerSpringBootTest
 @DisplayName("멘토링 CUD 서비스 테스트")
 class MentoringCommandServiceTest {

--- a/src/test/java/com/example/solidconnection/mentor/service/MentoringCommandServiceTest.java
+++ b/src/test/java/com/example/solidconnection/mentor/service/MentoringCommandServiceTest.java
@@ -1,0 +1,246 @@
+package com.example.solidconnection.mentor.service;
+
+import com.example.solidconnection.common.VerifyStatus;
+import com.example.solidconnection.common.exception.CustomException;
+import com.example.solidconnection.mentor.domain.Mentor;
+import com.example.solidconnection.mentor.domain.Mentoring;
+import com.example.solidconnection.mentor.dto.MentoringApplyRequest;
+import com.example.solidconnection.mentor.dto.MentoringApplyResponse;
+import com.example.solidconnection.mentor.dto.MentoringCheckResponse;
+import com.example.solidconnection.mentor.dto.MentoringConfirmRequest;
+import com.example.solidconnection.mentor.dto.MentoringConfirmResponse;
+import com.example.solidconnection.mentor.fixture.MentorFixture;
+import com.example.solidconnection.mentor.fixture.MentoringFixture;
+import com.example.solidconnection.mentor.repository.MentorRepository;
+import com.example.solidconnection.mentor.repository.MentoringRepository;
+import com.example.solidconnection.siteuser.domain.SiteUser;
+import com.example.solidconnection.siteuser.fixture.SiteUserFixture;
+import com.example.solidconnection.support.TestContainerSpringBootTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static com.example.solidconnection.common.exception.ErrorCode.ALREADY_MENTOR;
+import static com.example.solidconnection.common.exception.ErrorCode.MENTORING_ALREADY_CONFIRMED;
+import static com.example.solidconnection.common.exception.ErrorCode.MENTORING_NOT_FOUND;
+import static com.example.solidconnection.common.exception.ErrorCode.REJECTED_REASON_REQUIRED;
+import static com.example.solidconnection.common.exception.ErrorCode.UNAUTHORIZED_MENTORING;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+@TestContainerSpringBootTest
+@DisplayName("멘토링 CUD 서비스 테스트")
+class MentoringCommandServiceTest {
+
+    @Autowired
+    private MentoringCommandService mentoringCommandService;
+
+    @Autowired
+    private MentorRepository mentorRepository;
+
+    @Autowired
+    private MentoringRepository mentoringRepository;
+
+    @Autowired
+    private SiteUserFixture siteUserFixture;
+
+    @Autowired
+    private MentorFixture mentorFixture;
+
+    @Autowired
+    private MentoringFixture mentoringFixture;
+
+    private SiteUser mentorUser1;
+    private SiteUser mentorUser2;
+
+    private SiteUser menteeUser;
+    private Mentor mentor1;
+    private Mentor mentor2;
+
+    @BeforeEach
+    void setUp() {
+        mentorUser1 = siteUserFixture.멘토(1, "mentor1");
+        menteeUser = siteUserFixture.사용자(2, "mentee1");
+        mentorUser2 = siteUserFixture.멘토(3, "mentor2");
+
+        mentor1 = mentorFixture.멘토(mentorUser1.getId(), 1L);
+        mentor2 = mentorFixture.멘토(mentorUser2.getId(), 2L);
+    }
+
+    @Nested
+    class 멘토링_신청_테스트 {
+
+        @Test
+        void 멘토링을_성공적으로_신청한다() {
+            // given
+            MentoringApplyRequest request = new MentoringApplyRequest(mentor1.getId());
+
+            // when
+            MentoringApplyResponse response = mentoringCommandService.applyMentoring(menteeUser.getId(), request);
+
+            // then
+            Mentoring mentoring = mentoringRepository.findById(response.mentoringId()).orElseThrow();
+
+            assertAll(
+                    () -> assertThat(mentoring.getMentorId()).isEqualTo(mentor1.getId()),
+                    () -> assertThat(mentoring.getMenteeId()).isEqualTo(menteeUser.getId()),
+                    () -> assertThat(mentoring.getVerifyStatus()).isEqualTo(VerifyStatus.PENDING)
+            );
+        }
+
+        @Test
+        void 이미_멘토인_사용자가_신청시_예외를_반환한다() {
+            // given
+            MentoringApplyRequest request = new MentoringApplyRequest(mentor2.getId());
+
+            // when & then
+            assertThatThrownBy(() ->
+                    mentoringCommandService.applyMentoring(mentorUser1.getId(), request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(ALREADY_MENTOR.getMessage());
+        }
+    }
+
+    @Nested
+    class 멘토링_승인_거절_테스트 {
+
+        @Test
+        void 멘토링을_성공적으로_승인한다() {
+            // given
+            Mentoring mentoring = mentoringFixture.대기중_멘토링(mentor1.getId(), menteeUser.getId());
+            MentoringConfirmRequest request = new MentoringConfirmRequest(VerifyStatus.APPROVED, null);
+            int beforeMenteeCount = mentor1.getMenteeCount();
+
+            // when
+            MentoringConfirmResponse response = mentoringCommandService.confirmMentoring(mentorUser1.getId(), mentoring.getId(), request);
+
+            // then
+            Mentoring confirmedMentoring = mentoringRepository.findById(response.mentoringId()).orElseThrow();
+            Mentor mentor = mentorRepository.findById(mentor1.getId()).orElseThrow();
+
+            assertAll(
+                    () -> assertThat(confirmedMentoring.getVerifyStatus()).isEqualTo(VerifyStatus.APPROVED),
+                    () -> assertThat(confirmedMentoring.getConfirmedAt()).isNotNull(),
+                    () -> assertThat(confirmedMentoring.getCheckedAt()).isNotNull(),
+                    () -> assertThat(mentor.getMenteeCount()).isEqualTo(beforeMenteeCount + 1)
+            );
+        }
+
+        @Test
+        void 멘토링을_성공적으로_거절한다() {
+            // given
+            Mentoring mentoring = mentoringFixture.대기중_멘토링(mentor1.getId(), menteeUser.getId());
+            String rejectedReason = "멘토링 거절 사유";
+            MentoringConfirmRequest request = new MentoringConfirmRequest(VerifyStatus.REJECTED, rejectedReason);
+            int beforeMenteeCount = mentor1.getMenteeCount();
+
+            // when
+            MentoringConfirmResponse response = mentoringCommandService.confirmMentoring(mentorUser1.getId(), mentoring.getId(), request);
+
+            // then
+            Mentoring confirmedMentoring = mentoringRepository.findById(response.mentoringId()).orElseThrow();
+            Mentor mentor = mentorRepository.findById(mentor1.getId()).orElseThrow();
+
+            assertAll(
+                    () -> assertThat(confirmedMentoring.getVerifyStatus()).isEqualTo(VerifyStatus.REJECTED),
+                    () -> assertThat(confirmedMentoring.getRejectedReason()).isEqualTo(rejectedReason),
+                    () -> assertThat(confirmedMentoring.getConfirmedAt()).isNotNull(),
+                    () -> assertThat(confirmedMentoring.getCheckedAt()).isNotNull(),
+                    () -> assertThat(mentor.getMenteeCount()).isEqualTo(beforeMenteeCount)
+            );
+        }
+
+        @Test
+        void 거절_시_사유가_없으면_예외를_반환한다() {
+            // given
+            Mentoring mentoring = mentoringFixture.대기중_멘토링(mentor1.getId(), menteeUser.getId());
+            MentoringConfirmRequest request = new MentoringConfirmRequest(VerifyStatus.REJECTED, null);
+
+            // when & then
+            assertThatThrownBy(() ->
+                    mentoringCommandService.confirmMentoring(mentorUser1.getId(), mentoring.getId(), request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(REJECTED_REASON_REQUIRED.getMessage());
+        }
+
+        @Test
+        void 다른_멘토의_멘토링을_승인할_수_없다() {
+            // given
+            Mentoring mentoring = mentoringFixture.대기중_멘토링(mentor1.getId(), menteeUser.getId());
+            MentoringConfirmRequest request = new MentoringConfirmRequest(VerifyStatus.APPROVED, null);
+
+            // when & then
+            assertThatThrownBy(() ->
+                    mentoringCommandService.confirmMentoring(mentorUser2.getId(), mentoring.getId(), request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(UNAUTHORIZED_MENTORING.getMessage());
+        }
+
+        @Test
+        void 이미_처리된_멘토링은_다시_승인할_수_없다() {
+            // given
+            Mentoring mentoring = mentoringFixture.승인된_멘토링(mentor1.getId(), menteeUser.getId());
+            MentoringConfirmRequest request = new MentoringConfirmRequest(VerifyStatus.APPROVED, null);
+
+            // when & then
+            assertThatThrownBy(() ->
+                    mentoringCommandService.confirmMentoring(mentorUser1.getId(), mentoring.getId(), request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(MENTORING_ALREADY_CONFIRMED.getMessage());
+        }
+
+        @Test
+        void 존재하지_않는_멘토링_아이디로_요청시_예외를_반환한다() {
+            // given
+            MentoringConfirmRequest request = new MentoringConfirmRequest(VerifyStatus.APPROVED, null);
+            Long invalidMentoringId = 9999L;
+
+            // when & then
+            assertThatThrownBy(() -> mentoringCommandService.confirmMentoring(mentorUser1.getId(), invalidMentoringId, request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(MENTORING_NOT_FOUND.getMessage());
+        }
+    }
+
+    @Nested
+    class 멘토링_확인_테스트 {
+
+        @Test
+        void 멘토링을_성공적으로_확인_처리한다() {
+            // given
+            Mentoring mentoring = mentoringFixture.확인되지_않은_멘토링(mentor1.getId(), menteeUser.getId());
+
+            // when
+            MentoringCheckResponse response = mentoringCommandService.checkMentoring(mentorUser1.getId(), mentoring.getId());
+
+            // then
+            Mentoring checked = mentoringRepository.findById(response.mentoringId()).orElseThrow();
+
+            assertThat(checked.getCheckedAt()).isNotNull();
+        }
+
+        @Test
+        void 다른_멘토의_멘토링은_확인할_수_없다() {
+            // given
+            Mentoring mentoring = mentoringFixture.확인되지_않은_멘토링(mentor1.getId(), menteeUser.getId());
+
+            // when & then
+            assertThatThrownBy(() -> mentoringCommandService.checkMentoring(mentorUser2.getId(), mentoring.getId()))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(UNAUTHORIZED_MENTORING.getMessage());
+        }
+
+        @Test
+        void 존재하지_않는_멘토링_아이디로_요청시_예외를_반환한다() {
+            // given
+            Long invalidMentoringId = 9999L;
+
+            // when & then
+            assertThatThrownBy(() -> mentoringCommandService.checkMentoring(mentorUser1.getId(), invalidMentoringId))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(MENTORING_NOT_FOUND.getMessage());
+        }
+    }
+}

--- a/src/test/java/com/example/solidconnection/mentor/service/MentoringCommandServiceTest.java
+++ b/src/test/java/com/example/solidconnection/mentor/service/MentoringCommandServiceTest.java
@@ -183,7 +183,7 @@ class MentoringCommandServiceTest {
         void 존재하지_않는_멘토링_아이디로_요청시_예외_응답을_반환한다() {
             // given
             MentoringConfirmRequest request = new MentoringConfirmRequest(VerifyStatus.APPROVED, null);
-            Long invalidMentoringId = 9999L;
+            long invalidMentoringId = 9999L;
 
             // when & then
             assertThatThrownBy(() -> mentoringCommandService.confirmMentoring(mentorUser1.getId(), invalidMentoringId, request))
@@ -223,7 +223,7 @@ class MentoringCommandServiceTest {
         @Test
         void 존재하지_않는_멘토링_아이디로_요청시_예외_응답을_반환한다() {
             // given
-            Long invalidMentoringId = 9999L;
+            long invalidMentoringId = 9999L;
 
             // when & then
             assertThatThrownBy(() -> mentoringCommandService.checkMentoring(mentorUser1.getId(), invalidMentoringId))

--- a/src/test/java/com/example/solidconnection/mentor/service/MentoringCommandServiceTest.java
+++ b/src/test/java/com/example/solidconnection/mentor/service/MentoringCommandServiceTest.java
@@ -160,8 +160,7 @@ class MentoringCommandServiceTest {
             MentoringConfirmRequest request = new MentoringConfirmRequest(VerifyStatus.APPROVED, null);
 
             // when & then
-            assertThatThrownBy(() ->
-                    mentoringCommandService.confirmMentoring(mentorUser2.getId(), mentoring.getId(), request))
+            assertThatThrownBy(() -> mentoringCommandService.confirmMentoring(mentorUser2.getId(), mentoring.getId(), request))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(UNAUTHORIZED_MENTORING.getMessage());
         }
@@ -173,8 +172,7 @@ class MentoringCommandServiceTest {
             MentoringConfirmRequest request = new MentoringConfirmRequest(VerifyStatus.APPROVED, null);
 
             // when & then
-            assertThatThrownBy(() ->
-                    mentoringCommandService.confirmMentoring(mentorUser1.getId(), mentoring.getId(), request))
+            assertThatThrownBy(() -> mentoringCommandService.confirmMentoring(mentorUser1.getId(), mentoring.getId(), request))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(MENTORING_ALREADY_CONFIRMED.getMessage());
         }

--- a/src/test/java/com/example/solidconnection/mentor/service/MentoringCommandServiceTest.java
+++ b/src/test/java/com/example/solidconnection/mentor/service/MentoringCommandServiceTest.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import static com.example.solidconnection.common.exception.ErrorCode.ALREADY_MENTOR;
 import static com.example.solidconnection.common.exception.ErrorCode.MENTORING_ALREADY_CONFIRMED;
 import static com.example.solidconnection.common.exception.ErrorCode.MENTORING_NOT_FOUND;
 import static com.example.solidconnection.common.exception.ErrorCode.REJECTED_REASON_REQUIRED;
@@ -89,18 +88,6 @@ class MentoringCommandServiceTest {
                     () -> assertThat(mentoring.getMenteeId()).isEqualTo(menteeUser.getId()),
                     () -> assertThat(mentoring.getVerifyStatus()).isEqualTo(VerifyStatus.PENDING)
             );
-        }
-
-        @Test
-        void 이미_멘토인_사용자가_신청시_예외_응답을_반환한다() {
-            // given
-            MentoringApplyRequest request = new MentoringApplyRequest(mentor2.getId());
-
-            // when & then
-            assertThatThrownBy(() ->
-                    mentoringCommandService.applyMentoring(mentorUser1.getId(), request))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(ALREADY_MENTOR.getMessage());
         }
     }
 

--- a/src/test/java/com/example/solidconnection/mentor/service/MentoringCommandServiceTest.java
+++ b/src/test/java/com/example/solidconnection/mentor/service/MentoringCommandServiceTest.java
@@ -27,6 +27,7 @@ import static com.example.solidconnection.common.exception.ErrorCode.MENTORING_A
 import static com.example.solidconnection.common.exception.ErrorCode.MENTORING_NOT_FOUND;
 import static com.example.solidconnection.common.exception.ErrorCode.REJECTED_REASON_REQUIRED;
 import static com.example.solidconnection.common.exception.ErrorCode.UNAUTHORIZED_MENTORING;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -91,7 +92,7 @@ class MentoringCommandServiceTest {
         }
 
         @Test
-        void 이미_멘토인_사용자가_신청시_예외를_반환한다() {
+        void 이미_멘토인_사용자가_신청시_예외_응답을_반환한다() {
             // given
             MentoringApplyRequest request = new MentoringApplyRequest(mentor2.getId());
 
@@ -153,7 +154,7 @@ class MentoringCommandServiceTest {
         }
 
         @Test
-        void 거절_시_사유가_없으면_예외를_반환한다() {
+        void 거절_시_사유가_없으면_예외_응답을_반환한다() {
             // given
             Mentoring mentoring = mentoringFixture.대기중_멘토링(mentor1.getId(), menteeUser.getId());
             MentoringConfirmRequest request = new MentoringConfirmRequest(VerifyStatus.REJECTED, null);
@@ -192,7 +193,7 @@ class MentoringCommandServiceTest {
         }
 
         @Test
-        void 존재하지_않는_멘토링_아이디로_요청시_예외를_반환한다() {
+        void 존재하지_않는_멘토링_아이디로_요청시_예외_응답을_반환한다() {
             // given
             MentoringConfirmRequest request = new MentoringConfirmRequest(VerifyStatus.APPROVED, null);
             Long invalidMentoringId = 9999L;
@@ -233,7 +234,7 @@ class MentoringCommandServiceTest {
         }
 
         @Test
-        void 존재하지_않는_멘토링_아이디로_요청시_예외를_반환한다() {
+        void 존재하지_않는_멘토링_아이디로_요청시_예외_응답을_반환한다() {
             // given
             Long invalidMentoringId = 9999L;
 

--- a/src/test/java/com/example/solidconnection/mentor/service/MentoringQueryServiceTest.java
+++ b/src/test/java/com/example/solidconnection/mentor/service/MentoringQueryServiceTest.java
@@ -1,0 +1,134 @@
+package com.example.solidconnection.mentor.service;
+
+import com.example.solidconnection.common.exception.CustomException;
+import com.example.solidconnection.mentor.domain.Mentor;
+import com.example.solidconnection.mentor.domain.Mentoring;
+import com.example.solidconnection.mentor.dto.MentoringCountResponse;
+import com.example.solidconnection.mentor.dto.MentoringResponse;
+import com.example.solidconnection.mentor.fixture.MentorFixture;
+import com.example.solidconnection.mentor.fixture.MentoringFixture;
+import com.example.solidconnection.siteuser.domain.SiteUser;
+import com.example.solidconnection.siteuser.fixture.SiteUserFixture;
+import com.example.solidconnection.support.TestContainerSpringBootTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static com.example.solidconnection.common.exception.ErrorCode.MENTOR_NOT_FOUND;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@TestContainerSpringBootTest
+@DisplayName("멘토링 조회 서비스 테스트")
+class MentoringQueryServiceTest {
+
+    @Autowired
+    private MentoringQueryService mentoringQueryService;
+
+    @Autowired
+    private SiteUserFixture siteUserFixture;
+
+    @Autowired
+    private MentorFixture mentorFixture;
+
+    @Autowired
+    private MentoringFixture mentoringFixture;
+
+    private SiteUser mentorUser;
+    private SiteUser menteeUser;
+    private Mentor mentor;
+
+    @BeforeEach
+    void setUp() {
+        mentorUser = siteUserFixture.멘토(1, "mentor1");
+        menteeUser = siteUserFixture.사용자(2, "mentee1");
+        mentor = mentorFixture.멘토(mentorUser.getId(), 1L);
+    }
+
+    @Nested
+    class 멘토링_목록_조회_테스트 {
+
+        @Test
+        void 멘토의_모든_멘토링을_조회한다() {
+            // given
+            Mentoring mentoring1 = mentoringFixture.대기중_멘토링(mentor.getId(), menteeUser.getId());
+            Mentoring mentoring2 = mentoringFixture.승인된_멘토링(mentor.getId(), menteeUser.getId());
+            Mentoring mentoring3 = mentoringFixture.거절된_멘토링(mentor.getId(), menteeUser.getId(), "거절 사유");
+
+            // when
+            List<MentoringResponse> responses = mentoringQueryService.getMentorings(mentorUser.getId());
+
+            // then
+            assertAll(
+                    () -> assertThat(responses).hasSize(3),
+                    () -> assertThat(responses).extracting(MentoringResponse::id)
+                            .containsExactlyInAnyOrder(
+                                    mentoring1.getId(),
+                                    mentoring2.getId(),
+                                    mentoring3.getId()
+                            )
+            );
+        }
+
+        @Test
+        void 멘티가_멘토링을_조회하면_예외를_반환한다() {
+            // when & then
+            assertThatThrownBy(() -> mentoringQueryService.getMentorings(menteeUser.getId()))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(MENTOR_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        void 멘토링이_없는_경우_빈_리스트를_반환한다() {
+            // when
+            List<MentoringResponse> responses = mentoringQueryService.getMentorings(mentorUser.getId());
+
+            // then
+            assertThat(responses).isEmpty();
+        }
+    }
+
+    @Nested
+    class 새_멘토링_개수_조회_테스트 {
+
+        @Test
+        void 확인되지_않은_멘토링_개수를_반환한다() {
+            // given
+            mentoringFixture.확인되지_않은_멘토링(mentor.getId(), menteeUser.getId());
+            mentoringFixture.확인되지_않은_멘토링(mentor.getId(), menteeUser.getId());
+            mentoringFixture.승인된_멘토링(mentor.getId(), menteeUser.getId());
+
+            // when
+            MentoringCountResponse response = mentoringQueryService.getNewMentoringsCount(mentorUser.getId());
+
+            // then
+            assertThat(response.mentoringCount()).isEqualTo(2);
+        }
+
+        @Test
+        void 확인되지_않은_멘토링이_없으면_0을_반환한다() {
+            // given
+            mentoringFixture.승인된_멘토링(mentor.getId(), menteeUser.getId());
+
+            // when
+            MentoringCountResponse response = mentoringQueryService.getNewMentoringsCount(mentorUser.getId());
+
+            // then
+            assertThat(response.mentoringCount()).isZero();
+        }
+
+        @Test
+        void 멘티가_멘토링_개수를_조회하면_예외를_반환한다() {
+            // when & then
+            assertThatThrownBy(() ->
+                    mentoringQueryService.getNewMentoringsCount(menteeUser.getId()))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(MENTOR_NOT_FOUND.getMessage());
+        }
+    }
+}

--- a/src/test/java/com/example/solidconnection/mentor/service/MentoringQueryServiceTest.java
+++ b/src/test/java/com/example/solidconnection/mentor/service/MentoringQueryServiceTest.java
@@ -61,8 +61,8 @@ class MentoringQueryServiceTest {
 
             // then
             assertAll(
-                    () -> assertThat(responses.mentoringResponseList()).hasSize(3),
-                    () -> assertThat(responses.mentoringResponseList()).extracting(MentoringResponse::id)
+                    () -> assertThat(responses.requests()).hasSize(3),
+                    () -> assertThat(responses.requests()).extracting(MentoringResponse::mentoringId)
                             .containsExactlyInAnyOrder(
                                     mentoring1.getId(),
                                     mentoring2.getId(),
@@ -77,7 +77,7 @@ class MentoringQueryServiceTest {
             MentoringListResponse responses = mentoringQueryService.getMentorings(mentorUser.getId());
 
             // then
-            assertThat(responses.mentoringResponseList()).isEmpty();
+            assertThat(responses.requests()).isEmpty();
         }
     }
 
@@ -95,7 +95,7 @@ class MentoringQueryServiceTest {
             MentoringCountResponse response = mentoringQueryService.getNewMentoringsCount(mentorUser.getId());
 
             // then
-            assertThat(response.mentoringCount()).isEqualTo(2);
+            assertThat(response.uncheckedCount()).isEqualTo(2);
         }
 
         @Test
@@ -107,7 +107,7 @@ class MentoringQueryServiceTest {
             MentoringCountResponse response = mentoringQueryService.getNewMentoringsCount(mentorUser.getId());
 
             // then
-            assertThat(response.mentoringCount()).isZero();
+            assertThat(response.uncheckedCount()).isZero();
         }
     }
 }

--- a/src/test/java/com/example/solidconnection/mentor/service/MentoringQueryServiceTest.java
+++ b/src/test/java/com/example/solidconnection/mentor/service/MentoringQueryServiceTest.java
@@ -1,6 +1,5 @@
 package com.example.solidconnection.mentor.service;
 
-import com.example.solidconnection.common.exception.CustomException;
 import com.example.solidconnection.mentor.domain.Mentor;
 import com.example.solidconnection.mentor.domain.Mentoring;
 import com.example.solidconnection.mentor.dto.MentoringCountResponse;
@@ -17,9 +16,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import static com.example.solidconnection.common.exception.ErrorCode.MENTOR_NOT_FOUND;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 @TestContainerSpringBootTest
@@ -75,14 +72,6 @@ class MentoringQueryServiceTest {
         }
 
         @Test
-        void 멘티가_멘토링을_조회하면_예외를_반환한다() {
-            // when & then
-            assertThatThrownBy(() -> mentoringQueryService.getMentorings(menteeUser.getId()))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(MENTOR_NOT_FOUND.getMessage());
-        }
-
-        @Test
         void 멘토링이_없는_경우_빈_리스트를_반환한다() {
             // when
             MentoringListResponse responses = mentoringQueryService.getMentorings(mentorUser.getId());
@@ -119,15 +108,6 @@ class MentoringQueryServiceTest {
 
             // then
             assertThat(response.mentoringCount()).isZero();
-        }
-
-        @Test
-        void 멘티가_멘토링_개수를_조회하면_예외를_반환한다() {
-            // when & then
-            assertThatThrownBy(() ->
-                    mentoringQueryService.getNewMentoringsCount(menteeUser.getId()))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(MENTOR_NOT_FOUND.getMessage());
         }
     }
 }

--- a/src/test/java/com/example/solidconnection/mentor/service/MentoringQueryServiceTest.java
+++ b/src/test/java/com/example/solidconnection/mentor/service/MentoringQueryServiceTest.java
@@ -4,6 +4,7 @@ import com.example.solidconnection.common.exception.CustomException;
 import com.example.solidconnection.mentor.domain.Mentor;
 import com.example.solidconnection.mentor.domain.Mentoring;
 import com.example.solidconnection.mentor.dto.MentoringCountResponse;
+import com.example.solidconnection.mentor.dto.MentoringListResponse;
 import com.example.solidconnection.mentor.dto.MentoringResponse;
 import com.example.solidconnection.mentor.fixture.MentorFixture;
 import com.example.solidconnection.mentor.fixture.MentoringFixture;
@@ -15,8 +16,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-
-import java.util.List;
 
 import static com.example.solidconnection.common.exception.ErrorCode.MENTOR_NOT_FOUND;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -61,12 +60,12 @@ class MentoringQueryServiceTest {
             Mentoring mentoring3 = mentoringFixture.거절된_멘토링(mentor.getId(), menteeUser.getId(), "거절 사유");
 
             // when
-            List<MentoringResponse> responses = mentoringQueryService.getMentorings(mentorUser.getId());
+            MentoringListResponse responses = mentoringQueryService.getMentorings(mentorUser.getId());
 
             // then
             assertAll(
-                    () -> assertThat(responses).hasSize(3),
-                    () -> assertThat(responses).extracting(MentoringResponse::id)
+                    () -> assertThat(responses.mentoringResponseList()).hasSize(3),
+                    () -> assertThat(responses.mentoringResponseList()).extracting(MentoringResponse::id)
                             .containsExactlyInAnyOrder(
                                     mentoring1.getId(),
                                     mentoring2.getId(),
@@ -86,10 +85,10 @@ class MentoringQueryServiceTest {
         @Test
         void 멘토링이_없는_경우_빈_리스트를_반환한다() {
             // when
-            List<MentoringResponse> responses = mentoringQueryService.getMentorings(mentorUser.getId());
+            MentoringListResponse responses = mentoringQueryService.getMentorings(mentorUser.getId());
 
             // then
-            assertThat(responses).isEmpty();
+            assertThat(responses.mentoringResponseList()).isEmpty();
         }
     }
 


### PR DESCRIPTION
## 관련 이슈

- resolves: #352

## 작업 내용

![image](https://github.com/user-attachments/assets/9f43e6d0-3da0-4ae2-b181-13c530e4fbec)
멘토링 관련 로직을 작성하였습니다. ~~도메인 특성 상 `Mentor` 와 엮이는데, 병합 시 충돌 해결하면 될 듯 합니다. 이전 PR이 병합되면 rebase해서 마저 작업 진행하겠습니다.~~

## 특이 사항

- [x] #353 이 머지되면 `@RequireRoleAccess(roles = {Role.ADMIN, Role.MENTOR})` 코드 추가하겠습니다. 관련 내용 TODO로 표시했습니다.
- (그럴 일은 없겠지만) 멘토링 확인을 거치지 않고 수락/거절을 하게 된다면 `checkedAt` 값을 수락/거절 시점으로  결정하였습니다.

## 리뷰 요구사항 (선택)

- 추후 리팩토링할 때 URI의 snake_case를 kebab-case로 바꾸면 좋을 거 같습니다.
