### PR TITLE
feat: 소식지 좋아요 기능 구현

### DIFF
--- a/src/main/java/com/example/solidconnection/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/solidconnection/common/exception/ErrorCode.java
@@ -99,6 +99,7 @@ public enum ErrorCode {
 
     // news
     INVALID_NEWS_ACCESS(HttpStatus.BAD_REQUEST.value(), "자신의 소식지만 제어할 수 있습니다."),
+    ALREADY_LIKED_NEWS(HttpStatus.BAD_REQUEST.value(), "이미 좋아요한 소식지입니다."),
 
 
     // database

--- a/src/main/java/com/example/solidconnection/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/solidconnection/common/exception/ErrorCode.java
@@ -100,7 +100,7 @@ public enum ErrorCode {
     // news
     INVALID_NEWS_ACCESS(HttpStatus.BAD_REQUEST.value(), "자신의 소식지만 제어할 수 있습니다."),
     ALREADY_LIKED_NEWS(HttpStatus.BAD_REQUEST.value(), "이미 좋아요한 소식지입니다."),
-
+    NOT_LIKED_NEWS(HttpStatus.BAD_REQUEST.value(), "좋아요하지 않은 소식지입니다."),
 
     // database
     DATA_INTEGRITY_VIOLATION(HttpStatus.CONFLICT.value(), "데이터베이스 무결성 제약조건 위반이 발생했습니다."),

--- a/src/main/java/com/example/solidconnection/news/controller/NewsController.java
+++ b/src/main/java/com/example/solidconnection/news/controller/NewsController.java
@@ -82,11 +82,11 @@ public class NewsController {
     }
 
     @GetMapping("/{news-id}/like")
-    public ResponseEntity<LikedNewsResponse> getNewsLikeStatus(
+    public ResponseEntity<LikedNewsResponse> isNewsLiked(
             @AuthorizedUser SiteUser siteUser,
             @PathVariable("news-id") Long newsId
     ) {
-        LikedNewsResponse likedNewsResponse = newsLikeService.getNewsLikeStatus(siteUser.getId(), newsId);
+        LikedNewsResponse likedNewsResponse = newsLikeService.isNewsLiked(siteUser.getId(), newsId);
         return ResponseEntity.ok(likedNewsResponse);
     }
 

--- a/src/main/java/com/example/solidconnection/news/controller/NewsController.java
+++ b/src/main/java/com/example/solidconnection/news/controller/NewsController.java
@@ -91,18 +91,20 @@ public class NewsController {
     }
 
     @PostMapping("/{news-id}/like")
-    public void addNewsLike(
+    public ResponseEntity<Void> addNewsLike(
             @AuthorizedUser SiteUser siteUser,
             @PathVariable("news-id") Long newsId
     ) {
         newsLikeService.addNewsLike(siteUser.getId(), newsId);
+        return ResponseEntity.ok().build();
     }
 
     @DeleteMapping("/{news-id}/like")
-    public void cancelNewsLike(
+    public ResponseEntity<Void> cancelNewsLike(
             @AuthorizedUser SiteUser siteUser,
             @PathVariable("news-id") Long newsId
     ) {
         newsLikeService.cancelNewsLike(siteUser.getId(), newsId);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/example/solidconnection/news/controller/NewsController.java
+++ b/src/main/java/com/example/solidconnection/news/controller/NewsController.java
@@ -1,11 +1,13 @@
 package com.example.solidconnection.news.controller;
 
 import com.example.solidconnection.common.resolver.AuthorizedUser;
+import com.example.solidconnection.news.dto.LikedNewsResponse;
 import com.example.solidconnection.news.dto.NewsCommandResponse;
 import com.example.solidconnection.news.dto.NewsCreateRequest;
 import com.example.solidconnection.news.dto.NewsListResponse;
 import com.example.solidconnection.news.dto.NewsUpdateRequest;
 import com.example.solidconnection.news.service.NewsCommandService;
+import com.example.solidconnection.news.service.NewsLikeService;
 import com.example.solidconnection.news.service.NewsQueryService;
 import com.example.solidconnection.security.annotation.RequireRoleAccess;
 import com.example.solidconnection.siteuser.domain.Role;
@@ -31,6 +33,7 @@ public class NewsController {
 
     private final NewsQueryService newsQueryService;
     private final NewsCommandService newsCommandService;
+    private final NewsLikeService newsLikeService;
 
     // todo: 추후 Slice 적용
     @GetMapping
@@ -76,5 +79,14 @@ public class NewsController {
     ) {
         NewsCommandResponse newsCommandResponse = newsCommandService.deleteNewsById(siteUser, newsId);
         return ResponseEntity.ok(newsCommandResponse);
+    }
+
+    @PostMapping("/{news-id}/like")
+    public ResponseEntity<LikedNewsResponse> addNewsLike(
+            @AuthorizedUser SiteUser siteUser,
+            @PathVariable("news-id") Long newsId
+    ) {
+        LikedNewsResponse likedNewsResponse = newsLikeService.addNewsLike(siteUser.getId(), newsId);
+        return ResponseEntity.ok(likedNewsResponse);
     }
 }

--- a/src/main/java/com/example/solidconnection/news/controller/NewsController.java
+++ b/src/main/java/com/example/solidconnection/news/controller/NewsController.java
@@ -81,6 +81,15 @@ public class NewsController {
         return ResponseEntity.ok(newsCommandResponse);
     }
 
+    @GetMapping("/{news-id}/like")
+    public ResponseEntity<LikedNewsResponse> getNewsLikeStatus(
+            @AuthorizedUser SiteUser siteUser,
+            @PathVariable("news-id") Long newsId
+    ) {
+        LikedNewsResponse likedNewsResponse = newsLikeService.getNewsLikeStatus(siteUser.getId(), newsId);
+        return ResponseEntity.ok(likedNewsResponse);
+    }
+
     @PostMapping("/{news-id}/like")
     public ResponseEntity<LikedNewsResponse> addNewsLike(
             @AuthorizedUser SiteUser siteUser,

--- a/src/main/java/com/example/solidconnection/news/controller/NewsController.java
+++ b/src/main/java/com/example/solidconnection/news/controller/NewsController.java
@@ -91,20 +91,18 @@ public class NewsController {
     }
 
     @PostMapping("/{news-id}/like")
-    public ResponseEntity<LikedNewsResponse> addNewsLike(
+    public void addNewsLike(
             @AuthorizedUser SiteUser siteUser,
             @PathVariable("news-id") Long newsId
     ) {
-        LikedNewsResponse likedNewsResponse = newsLikeService.addNewsLike(siteUser.getId(), newsId);
-        return ResponseEntity.ok(likedNewsResponse);
+        newsLikeService.addNewsLike(siteUser.getId(), newsId);
     }
 
     @DeleteMapping("/{news-id}/like")
-    public ResponseEntity<LikedNewsResponse> cancelNewsLike(
+    public void cancelNewsLike(
             @AuthorizedUser SiteUser siteUser,
             @PathVariable("news-id") Long newsId
     ) {
-        LikedNewsResponse likedNewsResponse = newsLikeService.cancelNewsLike(siteUser.getId(), newsId);
-        return ResponseEntity.ok(likedNewsResponse);
+        newsLikeService.cancelNewsLike(siteUser.getId(), newsId);
     }
 }

--- a/src/main/java/com/example/solidconnection/news/controller/NewsController.java
+++ b/src/main/java/com/example/solidconnection/news/controller/NewsController.java
@@ -89,4 +89,13 @@ public class NewsController {
         LikedNewsResponse likedNewsResponse = newsLikeService.addNewsLike(siteUser.getId(), newsId);
         return ResponseEntity.ok(likedNewsResponse);
     }
+
+    @DeleteMapping("/{news-id}/like")
+    public ResponseEntity<LikedNewsResponse> cancelNewsLike(
+            @AuthorizedUser SiteUser siteUser,
+            @PathVariable("news-id") Long newsId
+    ) {
+        LikedNewsResponse likedNewsResponse = newsLikeService.cancelNewsLike(siteUser.getId(), newsId);
+        return ResponseEntity.ok(likedNewsResponse);
+    }
 }

--- a/src/main/java/com/example/solidconnection/news/domain/LikedNews.java
+++ b/src/main/java/com/example/solidconnection/news/domain/LikedNews.java
@@ -33,4 +33,9 @@ public class LikedNews {
 
     @Column(name = "site_user_id")
     private long siteUserId;
+
+    public LikedNews(long newsId, long siteUserId) {
+        this.newsId = newsId;
+        this.siteUserId = siteUserId;
+    }
 }

--- a/src/main/java/com/example/solidconnection/news/dto/LikedNewsResponse.java
+++ b/src/main/java/com/example/solidconnection/news/dto/LikedNewsResponse.java
@@ -1,0 +1,11 @@
+package com.example.solidconnection.news.dto;
+
+public record LikedNewsResponse(
+        long id,
+        boolean isLike
+) {
+
+    public static LikedNewsResponse of(long id, boolean isLike) {
+        return new LikedNewsResponse(id, isLike);
+    }
+}

--- a/src/main/java/com/example/solidconnection/news/dto/LikedNewsResponse.java
+++ b/src/main/java/com/example/solidconnection/news/dto/LikedNewsResponse.java
@@ -1,11 +1,10 @@
 package com.example.solidconnection.news.dto;
 
 public record LikedNewsResponse(
-        long id,
         boolean isLike
 ) {
 
-    public static LikedNewsResponse of(long id, boolean isLike) {
-        return new LikedNewsResponse(id, isLike);
+    public static LikedNewsResponse of(boolean isLike) {
+        return new LikedNewsResponse(isLike);
     }
 }

--- a/src/main/java/com/example/solidconnection/news/repository/LikedNewsRepository.java
+++ b/src/main/java/com/example/solidconnection/news/repository/LikedNewsRepository.java
@@ -1,0 +1,9 @@
+package com.example.solidconnection.news.repository;
+
+import com.example.solidconnection.news.domain.LikedNews;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LikedNewsRepository extends JpaRepository<LikedNews, Long> {
+
+    boolean existsByNewsIdAndSiteUserId(long newsId, long siteUserId);
+}

--- a/src/main/java/com/example/solidconnection/news/repository/LikedNewsRepository.java
+++ b/src/main/java/com/example/solidconnection/news/repository/LikedNewsRepository.java
@@ -3,7 +3,11 @@ package com.example.solidconnection.news.repository;
 import com.example.solidconnection.news.domain.LikedNews;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface LikedNewsRepository extends JpaRepository<LikedNews, Long> {
 
     boolean existsByNewsIdAndSiteUserId(long newsId, long siteUserId);
+
+    Optional<LikedNews> findByNewsIdAndSiteUserId(long newsId, long siteUserId);
 }

--- a/src/main/java/com/example/solidconnection/news/service/NewsLikeService.java
+++ b/src/main/java/com/example/solidconnection/news/service/NewsLikeService.java
@@ -30,7 +30,7 @@ public class NewsLikeService {
     }
 
     @Transactional
-    public LikedNewsResponse addNewsLike(long siteUserId, long newsId) {
+    public void addNewsLike(long siteUserId, long newsId) {
         if (!newsRepository.existsById(newsId)) {
             throw new CustomException(NEWS_NOT_FOUND);
         }
@@ -38,18 +38,16 @@ public class NewsLikeService {
             throw new CustomException(ALREADY_LIKED_NEWS);
         }
         LikedNews likedNews = new LikedNews(newsId, siteUserId);
-        LikedNews savedLikedNews = likedNewsRepository.save(likedNews);
-        return LikedNewsResponse.of(savedLikedNews.getId(), true);
+        likedNewsRepository.save(likedNews);
     }
 
     @Transactional
-    public LikedNewsResponse cancelNewsLike(long siteUserId, long newsId) {
+    public void cancelNewsLike(long siteUserId, long newsId) {
         if (!newsRepository.existsById(newsId)) {
             throw new CustomException(NEWS_NOT_FOUND);
         }
         LikedNews likedNews = likedNewsRepository.findByNewsIdAndSiteUserId(newsId, siteUserId)
                 .orElseThrow(() -> new CustomException(NOT_LIKED_NEWS));
         likedNewsRepository.delete(likedNews);
-        return LikedNewsResponse.of(likedNews.getId(), false);
     }
 }

--- a/src/main/java/com/example/solidconnection/news/service/NewsLikeService.java
+++ b/src/main/java/com/example/solidconnection/news/service/NewsLikeService.java
@@ -1,0 +1,34 @@
+package com.example.solidconnection.news.service;
+
+import com.example.solidconnection.common.exception.CustomException;
+import com.example.solidconnection.news.domain.LikedNews;
+import com.example.solidconnection.news.dto.LikedNewsResponse;
+import com.example.solidconnection.news.repository.LikedNewsRepository;
+import com.example.solidconnection.news.repository.NewsRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.example.solidconnection.common.exception.ErrorCode.ALREADY_LIKED_NEWS;
+import static com.example.solidconnection.common.exception.ErrorCode.NEWS_NOT_FOUND;
+
+@RequiredArgsConstructor
+@Service
+public class NewsLikeService {
+
+    private final NewsRepository newsRepository;
+    private final LikedNewsRepository likedNewsRepository;
+
+    @Transactional
+    public LikedNewsResponse addNewsLike(long siteUserId, Long newsId) {
+        if (!newsRepository.existsById(newsId)) {
+            throw new CustomException(NEWS_NOT_FOUND);
+        }
+        if (likedNewsRepository.existsByNewsIdAndSiteUserId(newsId, siteUserId)) {
+            throw new CustomException(ALREADY_LIKED_NEWS);
+        }
+        LikedNews likedNews = new LikedNews(newsId, siteUserId);
+        LikedNews savedLikedNews = likedNewsRepository.save(likedNews);
+        return LikedNewsResponse.of(savedLikedNews.getId(), true);
+    }
+}

--- a/src/main/java/com/example/solidconnection/news/service/NewsLikeService.java
+++ b/src/main/java/com/example/solidconnection/news/service/NewsLikeService.java
@@ -21,7 +21,7 @@ public class NewsLikeService {
     private final LikedNewsRepository likedNewsRepository;
 
     @Transactional(readOnly = true)
-    public LikedNewsResponse getNewsLikeStatus(long siteUserId, long newsId) {
+    public LikedNewsResponse isNewsLiked(long siteUserId, long newsId) {
         if (!newsRepository.existsById(newsId)) {
             throw new CustomException(NEWS_NOT_FOUND);
         }

--- a/src/main/java/com/example/solidconnection/news/service/NewsLikeService.java
+++ b/src/main/java/com/example/solidconnection/news/service/NewsLikeService.java
@@ -11,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import static com.example.solidconnection.common.exception.ErrorCode.ALREADY_LIKED_NEWS;
 import static com.example.solidconnection.common.exception.ErrorCode.NEWS_NOT_FOUND;
+import static com.example.solidconnection.common.exception.ErrorCode.NOT_LIKED_NEWS;
 
 @RequiredArgsConstructor
 @Service
@@ -30,5 +31,16 @@ public class NewsLikeService {
         LikedNews likedNews = new LikedNews(newsId, siteUserId);
         LikedNews savedLikedNews = likedNewsRepository.save(likedNews);
         return LikedNewsResponse.of(savedLikedNews.getId(), true);
+    }
+
+    @Transactional
+    public LikedNewsResponse cancelNewsLike(long siteUserId, Long newsId) {
+        if (!newsRepository.existsById(newsId)) {
+            throw new CustomException(NEWS_NOT_FOUND);
+        }
+        LikedNews likedNews = likedNewsRepository.findByNewsIdAndSiteUserId(newsId, siteUserId)
+                .orElseThrow(() -> new CustomException(NOT_LIKED_NEWS));
+        likedNewsRepository.delete(likedNews);
+        return LikedNewsResponse.of(likedNews.getId(), false);
     }
 }

--- a/src/main/java/com/example/solidconnection/news/service/NewsLikeService.java
+++ b/src/main/java/com/example/solidconnection/news/service/NewsLikeService.java
@@ -21,7 +21,7 @@ public class NewsLikeService {
     private final LikedNewsRepository likedNewsRepository;
 
     @Transactional(readOnly = true)
-    public LikedNewsResponse getNewsLikeStatus(long siteUserId, Long newsId) {
+    public LikedNewsResponse getNewsLikeStatus(long siteUserId, long newsId) {
         if (!newsRepository.existsById(newsId)) {
             throw new CustomException(NEWS_NOT_FOUND);
         }
@@ -30,7 +30,7 @@ public class NewsLikeService {
     }
 
     @Transactional
-    public LikedNewsResponse addNewsLike(long siteUserId, Long newsId) {
+    public LikedNewsResponse addNewsLike(long siteUserId, long newsId) {
         if (!newsRepository.existsById(newsId)) {
             throw new CustomException(NEWS_NOT_FOUND);
         }
@@ -43,7 +43,7 @@ public class NewsLikeService {
     }
 
     @Transactional
-    public LikedNewsResponse cancelNewsLike(long siteUserId, Long newsId) {
+    public LikedNewsResponse cancelNewsLike(long siteUserId, long newsId) {
         if (!newsRepository.existsById(newsId)) {
             throw new CustomException(NEWS_NOT_FOUND);
         }

--- a/src/main/java/com/example/solidconnection/news/service/NewsLikeService.java
+++ b/src/main/java/com/example/solidconnection/news/service/NewsLikeService.java
@@ -25,8 +25,8 @@ public class NewsLikeService {
         if (!newsRepository.existsById(newsId)) {
             throw new CustomException(NEWS_NOT_FOUND);
         }
-        boolean isLiked = likedNewsRepository.existsByNewsIdAndSiteUserId(newsId, siteUserId);
-        return LikedNewsResponse.of(newsId, isLiked);
+        boolean isLike = likedNewsRepository.existsByNewsIdAndSiteUserId(newsId, siteUserId);
+        return LikedNewsResponse.of(isLike);
     }
 
     @Transactional

--- a/src/main/java/com/example/solidconnection/news/service/NewsLikeService.java
+++ b/src/main/java/com/example/solidconnection/news/service/NewsLikeService.java
@@ -20,6 +20,15 @@ public class NewsLikeService {
     private final NewsRepository newsRepository;
     private final LikedNewsRepository likedNewsRepository;
 
+    @Transactional(readOnly = true)
+    public LikedNewsResponse getNewsLikeStatus(long siteUserId, Long newsId) {
+        if (!newsRepository.existsById(newsId)) {
+            throw new CustomException(NEWS_NOT_FOUND);
+        }
+        boolean isLiked = likedNewsRepository.existsByNewsIdAndSiteUserId(newsId, siteUserId);
+        return LikedNewsResponse.of(newsId, isLiked);
+    }
+
     @Transactional
     public LikedNewsResponse addNewsLike(long siteUserId, Long newsId) {
         if (!newsRepository.existsById(newsId)) {

--- a/src/test/java/com/example/solidconnection/news/service/NewsLikeServiceTest.java
+++ b/src/test/java/com/example/solidconnection/news/service/NewsLikeServiceTest.java
@@ -1,0 +1,73 @@
+package com.example.solidconnection.news.service;
+
+import com.example.solidconnection.common.exception.CustomException;
+import com.example.solidconnection.news.domain.News;
+import com.example.solidconnection.news.dto.LikedNewsResponse;
+import com.example.solidconnection.news.fixture.NewsFixture;
+import com.example.solidconnection.news.repository.LikedNewsRepository;
+import com.example.solidconnection.siteuser.domain.SiteUser;
+import com.example.solidconnection.siteuser.fixture.SiteUserFixture;
+import com.example.solidconnection.support.TestContainerSpringBootTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static com.example.solidconnection.common.exception.ErrorCode.ALREADY_LIKED_NEWS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@TestContainerSpringBootTest
+@DisplayName("소식지 좋아요 서비스 테스트")
+class NewsLikeServiceTest {
+
+    @Autowired
+    private NewsLikeService newsLikeService;
+
+    @Autowired
+    private LikedNewsRepository likedNewsRepository;
+
+    @Autowired
+    private SiteUserFixture siteUserFixture;
+
+    @Autowired
+    private NewsFixture newsFixture;
+
+    private SiteUser user;
+    private News news;
+
+    @BeforeEach
+    void setUp() {
+        user = siteUserFixture.사용자();
+        news = newsFixture.소식지(siteUserFixture.멘토(1, "mentor").getId());
+    }
+
+    @Nested
+    class 소식지_좋아요를_등록한다 {
+
+        @Test
+        void 성공적으로_좋아요를_등록한다() {
+            // when
+            LikedNewsResponse response = newsLikeService.addNewsLike(user.getId(), news.getId());
+
+            // then
+            assertAll(
+                () -> assertThat(response.isLike()).isTrue(),
+                () -> assertThat(likedNewsRepository.existsByNewsIdAndSiteUserId(news.getId(), user.getId())).isTrue()
+            );
+        }
+
+        @Test
+        void 이미_좋아요했으면_예외_응답을_반환한다() {
+            // given
+            newsLikeService.addNewsLike(user.getId(), news.getId());
+
+            // when & then
+            assertThatCode(() -> newsLikeService.addNewsLike(user.getId(), news.getId()))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(ALREADY_LIKED_NEWS.getMessage());
+        }
+    }
+}

--- a/src/test/java/com/example/solidconnection/news/service/NewsLikeServiceTest.java
+++ b/src/test/java/com/example/solidconnection/news/service/NewsLikeServiceTest.java
@@ -48,7 +48,7 @@ class NewsLikeServiceTest {
     class 소식지_좋아요_상태를_조회한다 {
 
         @Test
-        void 좋아요한_소식지인지_확인한다() {
+        void 좋아요한_소식지의_좋아요_상태를_조회한다() {
             // given
             newsLikeService.addNewsLike(user.getId(), news.getId());
 
@@ -60,7 +60,7 @@ class NewsLikeServiceTest {
         }
 
         @Test
-        void 좋아요하지_않은_소식지의_좋아요_상태를_조회한다() {
+        void 좋아요하지_않은_소식지의_좋아요_상태를_조회한다(){
             // when
             LikedNewsResponse response = newsLikeService.getNewsLikeStatus(user.getId(), news.getId());
 

--- a/src/test/java/com/example/solidconnection/news/service/NewsLikeServiceTest.java
+++ b/src/test/java/com/example/solidconnection/news/service/NewsLikeServiceTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import static com.example.solidconnection.common.exception.ErrorCode.ALREADY_LIKED_NEWS;
+import static com.example.solidconnection.common.exception.ErrorCode.NOT_LIKED_NEWS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -68,6 +69,33 @@ class NewsLikeServiceTest {
             assertThatCode(() -> newsLikeService.addNewsLike(user.getId(), news.getId()))
                 .isInstanceOf(CustomException.class)
                 .hasMessage(ALREADY_LIKED_NEWS.getMessage());
+        }
+    }
+
+    @Nested
+    class 소식지_좋아요를_취소한다 {
+
+        @Test
+        void 성공적으로_좋아요를_취소한다() {
+            // given
+            newsLikeService.addNewsLike(user.getId(), news.getId());
+
+            // when
+            LikedNewsResponse response = newsLikeService.cancelNewsLike(user.getId(), news.getId());
+
+            // then
+            assertAll(
+                () -> assertThat(response.isLike()).isFalse(),
+                () -> assertThat(likedNewsRepository.existsByNewsIdAndSiteUserId(news.getId(), user.getId())).isFalse()
+            );
+        }
+
+        @Test
+        void 좋아요하지_않았으면_예외_응답을_반환한다() {
+            // when & then
+            assertThatCode(() -> newsLikeService.cancelNewsLike(user.getId(), news.getId()))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(NOT_LIKED_NEWS.getMessage());
         }
     }
 }

--- a/src/test/java/com/example/solidconnection/news/service/NewsLikeServiceTest.java
+++ b/src/test/java/com/example/solidconnection/news/service/NewsLikeServiceTest.java
@@ -53,7 +53,7 @@ class NewsLikeServiceTest {
             newsLikeService.addNewsLike(user.getId(), news.getId());
 
             // when
-            LikedNewsResponse response = newsLikeService.getNewsLikeStatus(user.getId(), news.getId());
+            LikedNewsResponse response = newsLikeService.isNewsLiked(user.getId(), news.getId());
 
             // then
             assertThat(response.isLike()).isTrue();
@@ -62,7 +62,7 @@ class NewsLikeServiceTest {
         @Test
         void 좋아요하지_않은_소식지의_좋아요_상태를_조회한다() {
             // when
-            LikedNewsResponse response = newsLikeService.getNewsLikeStatus(user.getId(), news.getId());
+            LikedNewsResponse response = newsLikeService.isNewsLiked(user.getId(), news.getId());
 
             // then
             assertThat(response.isLike()).isFalse();

--- a/src/test/java/com/example/solidconnection/news/service/NewsLikeServiceTest.java
+++ b/src/test/java/com/example/solidconnection/news/service/NewsLikeServiceTest.java
@@ -46,6 +46,31 @@ class NewsLikeServiceTest {
     }
 
     @Nested
+    class 소식지_좋아요_상태를_조회한다 {
+
+        @Test
+        void 좋아요한_소식지인지_확인한다() {
+            // given
+            newsLikeService.addNewsLike(user.getId(), news.getId());
+
+            // when
+            LikedNewsResponse response = newsLikeService.getNewsLikeStatus(user.getId(), news.getId());
+
+            // then
+            assertThat(response.isLike()).isTrue();
+        }
+
+        @Test
+        void 좋아요하지_않은_소식지의_좋아요_상태를_조회한다() {
+            // when
+            LikedNewsResponse response = newsLikeService.getNewsLikeStatus(user.getId(), news.getId());
+
+            // then
+            assertThat(response.isLike()).isFalse();
+        }
+    }
+
+    @Nested
     class 소식지_좋아요를_등록한다 {
 
         @Test

--- a/src/test/java/com/example/solidconnection/news/service/NewsLikeServiceTest.java
+++ b/src/test/java/com/example/solidconnection/news/service/NewsLikeServiceTest.java
@@ -60,7 +60,7 @@ class NewsLikeServiceTest {
         }
 
         @Test
-        void 좋아요하지_않은_소식지의_좋아요_상태를_조회한다(){
+        void 좋아요하지_않은_소식지의_좋아요_상태를_조회한다() {
             // when
             LikedNewsResponse response = newsLikeService.getNewsLikeStatus(user.getId(), news.getId());
 

--- a/src/test/java/com/example/solidconnection/news/service/NewsLikeServiceTest.java
+++ b/src/test/java/com/example/solidconnection/news/service/NewsLikeServiceTest.java
@@ -18,7 +18,6 @@ import static com.example.solidconnection.common.exception.ErrorCode.ALREADY_LIK
 import static com.example.solidconnection.common.exception.ErrorCode.NOT_LIKED_NEWS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
-import static org.junit.jupiter.api.Assertions.assertAll;
 
 @TestContainerSpringBootTest
 @DisplayName("소식지 좋아요 서비스 테스트")
@@ -76,13 +75,10 @@ class NewsLikeServiceTest {
         @Test
         void 성공적으로_좋아요를_등록한다() {
             // when
-            LikedNewsResponse response = newsLikeService.addNewsLike(user.getId(), news.getId());
+            newsLikeService.addNewsLike(user.getId(), news.getId());
 
             // then
-            assertAll(
-                () -> assertThat(response.isLike()).isTrue(),
-                () -> assertThat(likedNewsRepository.existsByNewsIdAndSiteUserId(news.getId(), user.getId())).isTrue()
-            );
+            assertThat(likedNewsRepository.existsByNewsIdAndSiteUserId(news.getId(), user.getId())).isTrue();
         }
 
         @Test
@@ -106,13 +102,10 @@ class NewsLikeServiceTest {
             newsLikeService.addNewsLike(user.getId(), news.getId());
 
             // when
-            LikedNewsResponse response = newsLikeService.cancelNewsLike(user.getId(), news.getId());
+            newsLikeService.cancelNewsLike(user.getId(), news.getId());
 
             // then
-            assertAll(
-                () -> assertThat(response.isLike()).isFalse(),
-                () -> assertThat(likedNewsRepository.existsByNewsIdAndSiteUserId(news.getId(), user.getId())).isFalse()
-            );
+            assertThat(likedNewsRepository.existsByNewsIdAndSiteUserId(news.getId(), user.getId())).isFalse();
         }
 
         @Test


### PR DESCRIPTION
## 관련 이슈

- resolves: #376

## 작업 내용

소식지 좋아요 관련 기능을 추가했습니다!
기존 대학 지원 정보 좋아요 관련 기능을 최대한 참고하며 진행했습니다!

상태확인, 좋아요, 좋아요 취소에 대해 무얼 응답하면 좋을지에 대해 아직 확정이 나지 않아 우선은 모두 id와 좋아요중인지를 응답하는 방식으로 통일해두었습니다!
(사실 전 지금 방식도 괜찮은 거 같긴 한데 의견 남겨주시면 좋을 거 같습니다!)

<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

## 특이 사항
소식지가 존재하지 않는 경우에 대해서는 따로 테스트 코드를 작성하지 않았습니다!
<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

## 리뷰 요구사항 (선택)

### 1. 불필요한 find는 좋지 않다고 알고 있기에 기존 대학 지원 정보와 달리 JPA의 exist를 활용했는데 괜찮은가요?

### 2. 좋아요 상태 확인 함수명
getNewsLikeStatus로 일단 해두긴 했는데 뭐가 적절한지 모르겠네요 기존 대학 지원 정보에서는 getIsLiked로 되어있었긴 합니다!
<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
