### PR TITLE
fix: cd 스크립트의 alloy 파일 경로 수정

### DIFF
--- a/.github/workflows/dev-cd.yml
+++ b/.github/workflows/dev-cd.yml
@@ -68,7 +68,7 @@ jobs:
           host: ${{ secrets.DEV_HOST }}
           username: ${{ secrets.DEV_USERNAME }}
           key: ${{ secrets.DEV_PRIVATE_KEY }}
-          source: "./docs/config.alloy"
+          source: "./docs/infra-config/config.alloy"
           target: "/home/${{ secrets.DEV_USERNAME }}/solid-connection-dev/"
 
       - name: Run docker compose

--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -68,7 +68,7 @@ jobs:
         host: ${{ secrets.HOST }}
         username: ${{ secrets.USERNAME }}
         key: ${{ secrets.PRIVATE_KEY }}
-        source: "./docs/config.alloy"
+        source: "./docs/infra-config/config.alloy"
         target: "/home/${{ secrets.USERNAME }}/solid-connect-server/"
 
     - name: Run docker compose


### PR DESCRIPTION

<img width="1862" height="616" alt="image" src="https://github.com/user-attachments/assets/233344ac-f277-44e9-991f-0d3be45360d5" />

dev CD가 안돌아서 왜 그런가 봤더니... alloy 파일 경로를 수정 안했더라고요 🫨🫨