### PR TITLE
chore: build.gradle에 flyway 파일명 검증 관련 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,19 +72,12 @@ tasks.named('test', Test) {
     useJUnitPlatform()
 }
 
-tasks.named('build') {
-    dependsOn 'flywayValidate'
-}
-
-tasks.named('bootJar') {
-    dependsOn 'flywayValidate'
-}
-
 // To include QueryDLS classes in compile classpath
 sourceSets {
     main.java.srcDirs += ['build/generated/sources/annotationProcessor/java/main']
 }
 
+// build 단계에서 flyway 검증
 flyway {
     url = 'jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1'
     user = 'sa'
@@ -92,4 +85,12 @@ flyway {
     locations = ['filesystem:src/main/resources/db/migration']
     validateMigrationNaming = true
     ignoreMigrationPatterns = ['*:pending']
+}
+
+tasks.named('build') {
+    dependsOn 'flywayValidate'
+}
+
+tasks.named('bootJar') {
+    dependsOn 'flywayValidate'
 }


### PR DESCRIPTION
## 관련 이슈

- resolves: #391 

## 작업 내용

기존에는 flyway의 파일명, 체크섬 등과 같은 유효성 검사가 런타임에 수행되었습니다. 마이그레이션 파일명 오타는 리뷰 시 놓치기 쉽지만 치명적인 결과를 초래하기에 이를 CI 단계에서 발견하도록 `build.gradle` 을 수정합니다.

`flyway` 플러그인을 추가해 `flywayValidate` 태스크를 사용하도록 하였고, 빌드 전 `flywayValidate` 를 수행하도록 하였습니다.

CI 단계에서 사용할 가상의 DB가 있어야 하기 때문에 임시로 H2 데이터베이스를 생성합니다.

## 특이 사항

<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/15f8806a-7ca9-4abf-b7df-4db425d166b8" />

파일명 오타를 발견하면 위와 같은 오류 메시지가 출력됩니다.

## 리뷰 요구사항 (선택)
