### PR TITLE
feat: access token이 role을 cliam 으로 갖도록

### DIFF
--- a/src/main/java/com/example/solidconnection/auth/controller/AuthController.java
+++ b/src/main/java/com/example/solidconnection/auth/controller/AuthController.java
@@ -113,9 +113,10 @@ public class AuthController {
 
     @PostMapping("/reissue")
     public ResponseEntity<ReissueResponse> reissueToken(
+            @AuthorizedUser long siteUserId,
             @Valid @RequestBody ReissueRequest reissueRequest
     ) {
-        ReissueResponse reissueResponse = authService.reissue(reissueRequest);
+        ReissueResponse reissueResponse = authService.reissue(siteUserId, reissueRequest);
         return ResponseEntity.ok(reissueResponse);
     }
 

--- a/src/main/java/com/example/solidconnection/auth/service/AccessToken.java
+++ b/src/main/java/com/example/solidconnection/auth/service/AccessToken.java
@@ -1,11 +1,14 @@
 package com.example.solidconnection.auth.service;
 
+import com.example.solidconnection.siteuser.domain.Role;
+
 public record AccessToken(
         Subject subject,
+        Role role,
         String token
 ) {
 
-    public AccessToken(String subject, String token) {
-        this(new Subject(subject), token);
+    public AccessToken(String subject, Role role, String token) {
+        this(new Subject(subject), role, token);
     }
 }

--- a/src/main/java/com/example/solidconnection/auth/service/AuthTokenProvider.java
+++ b/src/main/java/com/example/solidconnection/auth/service/AuthTokenProvider.java
@@ -1,7 +1,9 @@
 package com.example.solidconnection.auth.service;
 
 import com.example.solidconnection.auth.domain.TokenType;
+import com.example.solidconnection.siteuser.domain.Role;
 import com.example.solidconnection.siteuser.domain.SiteUser;
+import java.util.Map;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -11,12 +13,16 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class AuthTokenProvider {
 
+    private static final String ROLE_CLAIM_KEY = "role";
+
     private final RedisTemplate<String, String> redisTemplate;
     private final TokenProvider tokenProvider;
 
-    public AccessToken generateAccessToken(Subject subject) {
-        String token = tokenProvider.generateToken(subject.value(), TokenType.ACCESS);
-        return new AccessToken(subject, token);
+    public AccessToken generateAccessToken(Subject subject, Role role) {
+        String token = tokenProvider.generateToken(
+                subject.value(), Map.of(ROLE_CLAIM_KEY, role.name()), TokenType.ACCESS
+        );
+        return new AccessToken(subject, role, token);
     }
 
     public RefreshToken generateAndSaveRefreshToken(Subject subject) {
@@ -50,9 +56,5 @@ public class AuthTokenProvider {
 
     public Subject toSubject(SiteUser siteUser) {
         return new Subject(siteUser.getId().toString());
-    }
-
-    public AccessToken toAccessToken(String token) {
-        return new AccessToken(parseSubject(token), token);
     }
 }

--- a/src/main/java/com/example/solidconnection/auth/service/SignInService.java
+++ b/src/main/java/com/example/solidconnection/auth/service/SignInService.java
@@ -16,7 +16,7 @@ public class SignInService {
     public SignInResponse signIn(SiteUser siteUser) {
         resetQuitedAt(siteUser);
         Subject subject = authTokenProvider.toSubject(siteUser);
-        AccessToken accessToken = authTokenProvider.generateAccessToken(subject);
+        AccessToken accessToken = authTokenProvider.generateAccessToken(subject, siteUser.getRole());
         RefreshToken refreshToken = authTokenProvider.generateAndSaveRefreshToken(subject);
         return SignInResponse.of(accessToken, refreshToken);
     }

--- a/src/main/java/com/example/solidconnection/auth/service/TokenProvider.java
+++ b/src/main/java/com/example/solidconnection/auth/service/TokenProvider.java
@@ -2,10 +2,13 @@ package com.example.solidconnection.auth.service;
 
 import com.example.solidconnection.auth.domain.TokenType;
 import io.jsonwebtoken.Claims;
+import java.util.Map;
 
 public interface TokenProvider {
 
     String generateToken(String string, TokenType tokenType);
+
+    String generateToken(String string, Map<String, String> claims, TokenType tokenType);
 
     String saveToken(String token, TokenType tokenType);
 

--- a/src/test/java/com/example/solidconnection/auth/service/AuthTokenProviderTest.java
+++ b/src/test/java/com/example/solidconnection/auth/service/AuthTokenProviderTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.example.solidconnection.auth.domain.TokenType;
+import com.example.solidconnection.siteuser.domain.Role;
 import com.example.solidconnection.support.TestContainerSpringBootTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -32,11 +33,16 @@ class AuthTokenProviderTest {
     @Test
     void 액세스_토큰을_생성한다() {
         // when
-        AccessToken accessToken = authTokenProvider.generateAccessToken(subject);
+        Role expectedRole = Role.MENTEE;
+        AccessToken accessToken = authTokenProvider.generateAccessToken(subject, expectedRole);
 
         // then
         String actualSubject = authTokenProvider.parseSubject(accessToken.token()).value();
-        assertThat(actualSubject).isEqualTo(subject.value());
+        assertAll(
+                () -> assertThat(actualSubject).isEqualTo(subject.value()),
+                () -> assertThat(accessToken.role()).isEqualTo(expectedRole),
+                () -> assertThat(accessToken.token()).isNotNull()
+        );
     }
 
     @Nested
@@ -61,7 +67,7 @@ class AuthTokenProviderTest {
         void 유효한_리프레시_토큰인지_확인한다() {
             // given
             RefreshToken refreshToken = authTokenProvider.generateAndSaveRefreshToken(subject);
-            AccessToken fakeRefreshToken = authTokenProvider.generateAccessToken(subject);
+            AccessToken fakeRefreshToken = authTokenProvider.generateAccessToken(subject, Role.MENTEE);
 
             // when, then
             assertAll(
@@ -74,7 +80,7 @@ class AuthTokenProviderTest {
         void 액세스_토큰에_해당하는_리프레시_토큰을_삭제한다() {
             // given
             authTokenProvider.generateAndSaveRefreshToken(subject);
-            AccessToken accessToken = authTokenProvider.generateAccessToken(subject);
+            AccessToken accessToken = authTokenProvider.generateAccessToken(subject, Role.MENTEE);
 
             // when
             authTokenProvider.deleteRefreshTokenByAccessToken(accessToken);
@@ -88,7 +94,7 @@ class AuthTokenProviderTest {
     @Test
     void 토큰으로부터_Subject_를_추출한다() {
         // given
-        String accessToken = authTokenProvider.generateAccessToken(subject).token();
+        String accessToken = authTokenProvider.generateAccessToken(subject, Role.MENTEE).token();
 
         // when
         Subject actualSubject = authTokenProvider.parseSubject(accessToken);

--- a/src/test/java/com/example/solidconnection/auth/service/JwtTokenProviderTest.java
+++ b/src/test/java/com/example/solidconnection/auth/service/JwtTokenProviderTest.java
@@ -35,22 +35,46 @@ class JwtTokenProviderTest {
     @Autowired
     private RedisTemplate<String, String> redisTemplate;
 
-    @Test
-    void 토큰을_생성한다() {
-        // given
-        String actualSubject = "subject123";
-        TokenType actualTokenType = TokenType.ACCESS;
+    @Nested
+    class 토큰을_생성한다 {
 
-        // when
-        String token = tokenProvider.generateToken(actualSubject, actualTokenType);
+        @Test
+        void subject_만_있는_토큰을_생성한다() {
+            // given
+            String actualSubject = "subject123";
+            TokenType actualTokenType = TokenType.ACCESS;
 
-        // then - subject와 만료 시간이 일치하는지 검증
-        Claims claims = tokenProvider.parseClaims(token);
-        long expectedExpireTime = claims.getExpiration().getTime() - claims.getIssuedAt().getTime();
-        assertAll(
-                () -> assertThat(claims.getSubject()).isEqualTo(actualSubject),
-                () -> assertThat(expectedExpireTime).isEqualTo(actualTokenType.getExpireTime())
-        );
+            // when
+            String token = tokenProvider.generateToken(actualSubject, actualTokenType);
+
+            // then - subject와 만료 시간이 일치하는지 검증
+            Claims claims = tokenProvider.parseClaims(token);
+            long expectedExpireTime = claims.getExpiration().getTime() - claims.getIssuedAt().getTime();
+            assertAll(
+                    () -> assertThat(claims.getSubject()).isEqualTo(actualSubject),
+                    () -> assertThat(expectedExpireTime).isEqualTo(actualTokenType.getExpireTime())
+            );
+        }
+
+        @Test
+        void subject_와_claims_가_있는_토큰을_생성한다() {
+            // given
+            String actualSubject = "subject123";
+            Map<String, String> customClaims = Map.of("key1", "value1", "key2", "value2");
+            TokenType actualTokenType = TokenType.ACCESS;
+
+            // when
+            String token = tokenProvider.generateToken(actualSubject, customClaims, actualTokenType);
+
+            // then - subject와 커스텀 클레임이 일치하는지 검증
+            Claims claims = tokenProvider.parseClaims(token);
+            long expectedExpireTime = claims.getExpiration().getTime() - claims.getIssuedAt().getTime();
+            assertAll(
+                    () -> assertThat(claims.getSubject()).isEqualTo(actualSubject),
+                    () -> assertThat(claims).containsAllEntriesOf(customClaims),
+                    () -> assertThat(expectedExpireTime).isEqualTo(actualTokenType.getExpireTime())
+            );
+        }
     }
 
     @Test

--- a/src/test/java/com/example/solidconnection/auth/service/TokenBlackListServiceTest.java
+++ b/src/test/java/com/example/solidconnection/auth/service/TokenBlackListServiceTest.java
@@ -4,12 +4,16 @@ import static com.example.solidconnection.auth.domain.TokenType.BLACKLIST;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.example.solidconnection.auth.token.TokenBlackListService;
+import com.example.solidconnection.siteuser.domain.Role;
 import com.example.solidconnection.support.TestContainerSpringBootTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.redis.core.RedisTemplate;
 
+@DisplayName("토큰 블랙리스트 서비스 테스트")
 @TestContainerSpringBootTest
 class TokenBlackListServiceTest {
 
@@ -19,11 +23,16 @@ class TokenBlackListServiceTest {
     @Autowired
     private RedisTemplate<String, String> redisTemplate;
 
+    private AccessToken accessToken;
+
+    @BeforeEach
+    void setUp() {
+        accessToken = new AccessToken("subject", Role.MENTEE, "token");
+    }
+
+
     @Test
     void 액세스_토큰을_블랙리스트에_추가한다() {
-        // given
-        AccessToken accessToken = new AccessToken("subject", "token");
-
         // when
         tokenBlackListService.addToBlacklist(accessToken);
 
@@ -39,7 +48,6 @@ class TokenBlackListServiceTest {
         @Test
         void 블랙리스트에_토큰이_있는_경우() {
             // given
-            AccessToken accessToken = new AccessToken("subject", "token");
             tokenBlackListService.addToBlacklist(accessToken);
 
             // when, then
@@ -48,9 +56,6 @@ class TokenBlackListServiceTest {
 
         @Test
         void 블랙리스트에_토큰이_없는_경우() {
-            // given
-            AccessToken accessToken = new AccessToken("subject", "token");
-
             // when, then
             assertThat(tokenBlackListService.isTokenBlacklisted(accessToken.token())).isFalse();
         }


### PR DESCRIPTION
## 관련 이슈

- resolves: #406 

## 작업 내용

프론트 개발자님이 멘토/멘티 탭 구현할 때 더 편하다 하셔서 추가합니다 🏃‍♀️

- AccessToken 생성자 파라미터 변경
- TokenProvider에 claim 으로 토큰 만드는 함수 생성
- 토큰 재발급 시에도 role을 포함하여 응답하도록 수정

## 특이 사항

디스코드에 말씀드린 "auth 패키지 대변경🧹" 관점에서 추가설명하자면,

이번에 AccessToken 생성 방법 변경으로 '토큰 재발급 함수'에 아래의 변경이 있었습니다.

```java
/* 전 */
AccessToken accessToken = authTokenProvider.toAccessToken(token);

/* 후 */
Subject subject = authTokenProvider.parseSubject(token);
long siteUserId = Long.parseLong(subject.value());
SiteUser siteUser = siteUserRepository.findById(siteUserId)
       .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
AccessToken accessToken = authTokenProvider.generateAccessToken(subject, siteUser.getRole());
```

**이 변경의 문제**
- AccessToken 생성 로직이 여러 곳에 흩어져 있어, 방식을 바꿀 때 각 위치를 모두 수정해야 했다.
- 기존의 authTokenProvider.toAccessToken(token)도 더 이상 사용할 수 없게 되어 아예 삭제했다.

**방안**
- AccessToken 생성 책임을 한 곳에만 두기
- 일관된 변환 함수 생성 : “문자열 → Token 객체”로 바꿔주는 단일 메서드를 구현하면, 생성 방식이 바뀌어도 영향 x

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
