### PR TITLE
refactor: 멘토의 마이페이지 응답에 '합격 팁' 추가

### DIFF
--- a/src/main/java/com/example/solidconnection/mentor/controller/MentorController.java
+++ b/src/main/java/com/example/solidconnection/mentor/controller/MentorController.java
@@ -1,7 +1,5 @@
 package com.example.solidconnection.mentor.controller;
 
-import static org.springframework.data.domain.Sort.Direction.DESC;
-
 import com.example.solidconnection.common.dto.SliceResponse;
 import com.example.solidconnection.common.resolver.AuthorizedUser;
 import com.example.solidconnection.mentor.dto.MentorDetailResponse;
@@ -41,7 +39,7 @@ public class MentorController {
             @AuthorizedUser long siteUserId,
             @RequestParam("region") String region,
             
-            @PageableDefault(size = 3, sort = "menteeCount", direction = DESC)
+            @PageableDefault(size = 3)
             @SortDefaults({
                     @SortDefault(sort = "menteeCount", direction = Sort.Direction.DESC),
                     @SortDefault(sort = "id", direction = Sort.Direction.ASC)

--- a/src/main/java/com/example/solidconnection/mentor/dto/MentorMyPageResponse.java
+++ b/src/main/java/com/example/solidconnection/mentor/dto/MentorMyPageResponse.java
@@ -15,6 +15,7 @@ public record MentorMyPageResponse(
         int menteeCount,
         boolean hasBadge,
         String introduction,
+        String passTip,
         List<ChannelResponse> channels
 ) {
 
@@ -29,6 +30,7 @@ public record MentorMyPageResponse(
                 mentor.getMenteeCount(),
                 mentor.isHasBadge(),
                 mentor.getIntroduction(),
+                mentor.getPassTip(),
                 mentor.getChannels().stream()
                         .map(ChannelResponse::from)
                         .toList()


### PR DESCRIPTION
## 관련 이슈

- related: 419

## 작업 내용

멘토의 마이페이지 응답 GET api가 범용적으로 사용되도록, '합격 팁'을 포함하여 응답하게 합니다.

**AS-IS**
- 멘토의 마이페이지 미리보기 화면에서는 '합격 팁'이 존재하지 않아 내려주지 않았습니다.

**TO-BE**
- 멘토가 마이페이지를 수정할 때 보여주는 '마이페이지 상세 조회'에는 합격 팁이 존재합니다.
- 이들 api를 하나로 통일하기 위해 '마이페이지' GET 의 응답이 '합격 팁'을 추가합니다.


멘토/멘티 api 변경 회의에서 이야기 나온 🔽 부분을 적용했다 생각하시면 됩니다.
<img width="1916" height="1034" alt="image" src="https://github.com/user-attachments/assets/e7ca0da7-33b9-47a7-8eb0-ac524b6419f6" />


## 특이 사항

"페이지네이션이 중복 설정된 것" 을 삭제하는 것까지
이번 PR에서 포함해봅니다 🐒


