### PR TITLE
fix: 채널 수정 시 유니크 제약 위반하지 않도록

### DIFF
--- a/src/main/java/com/example/solidconnection/mentor/domain/Channel.java
+++ b/src/main/java/com/example/solidconnection/mentor/domain/Channel.java
@@ -54,4 +54,10 @@ public class Channel {
     public void updateMentor(Mentor mentor) {
         this.mentor = mentor;
     }
+
+    public void update(Channel channel) {
+        this.sequence = channel.sequence;
+        this.type = channel.type;
+        this.url = channel.url;
+    }
 }

--- a/src/main/java/com/example/solidconnection/mentor/domain/Mentor.java
+++ b/src/main/java/com/example/solidconnection/mentor/domain/Mentor.java
@@ -65,13 +65,20 @@ public class Mentor {
     }
 
     public void updateChannels(List<Channel> channels) {
-        this.channels.clear();
-        if (channels == null || channels.isEmpty()) {
-            return;
-        }
-        for (Channel channel : channels) {
-            channel.updateMentor(this);
-            this.channels.add(channel);
+        int newChannelSize = Math.max(channels.size(), this.channels.size());
+        int originalChannelSize = this.channels.size();
+        for (int i = 0; i < newChannelSize; i++) {
+            if (i < channels.size() && i < this.channels.size()) { // 기존 채널 수정
+                Channel existing = this.channels.get(i);
+                Channel newChannel = channels.get(i);
+                existing.update(newChannel);
+            } else if (i < channels.size()) { // 채널 갯수 늘어남 - 새로운 채널 추가
+                Channel newChannel = channels.get(i);
+                newChannel.updateMentor(this);
+                this.channels.add(newChannel);
+            } else if (i < originalChannelSize) { // 채널 갯수 줄어듦 - 기존 채널 삭제
+                this.channels.remove(this.channels.size() - 1);
+            }
         }
     }
 }

--- a/src/test/java/com/example/solidconnection/mentor/service/MentorMyPageServiceTest.java
+++ b/src/test/java/com/example/solidconnection/mentor/service/MentorMyPageServiceTest.java
@@ -3,6 +3,7 @@ package com.example.solidconnection.mentor.service;
 import static com.example.solidconnection.mentor.domain.ChannelType.BLOG;
 import static com.example.solidconnection.mentor.domain.ChannelType.INSTAGRAM;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.example.solidconnection.mentor.domain.Channel;
@@ -109,8 +110,28 @@ class MentorMyPageServiceTest {
         }
 
         @Test
-        void 채널_정보를_수정한다() {
+        void 기존보다_적게_채널_정보를_수정한다() {
             // given
+            channelFixture.채널(1, mentor);
+            channelFixture.채널(2, mentor);
+            channelFixture.채널(3, mentor);
+            channelFixture.채널(4, mentor);
+            List<ChannelRequest> newChannels = List.of(new ChannelRequest(BLOG, "https://blog.com"));
+            MentorMyPageUpdateRequest request = new MentorMyPageUpdateRequest("introduction", "passTip", newChannels);
+
+            // when
+            mentorMyPageService.updateMentorMyPage(mentorUser.getId(), request);
+
+            // then
+            List<Channel> updatedChannels = channelRepositoryForTest.findAllByMentorId(mentor.getId());
+            assertThat(updatedChannels).extracting(Channel::getSequence, Channel::getType, Channel::getUrl)
+                    .containsExactlyInAnyOrder(tuple(1, BLOG, "https://blog.com"));
+        }
+
+        @Test
+        void 기존보다_많게_채널_정보를_수정한다() {
+            // given
+            channelFixture.채널(1, mentor);
             List<ChannelRequest> newChannels = List.of(
                     new ChannelRequest(BLOG, "https://blog.com"),
                     new ChannelRequest(INSTAGRAM, "https://instagram.com")
@@ -122,12 +143,11 @@ class MentorMyPageServiceTest {
 
             // then
             List<Channel> updatedChannels = channelRepositoryForTest.findAllByMentorId(mentor.getId());
-            assertAll(
-                    () -> assertThat(updatedChannels).extracting(Channel::getType)
-                            .containsExactly(BLOG, INSTAGRAM),
-                    () -> assertThat(updatedChannels).extracting(Channel::getUrl)
-                            .containsExactly("https://blog.com", "https://instagram.com")
-            );
+            assertThat(updatedChannels).extracting(Channel::getSequence, Channel::getType, Channel::getUrl)
+                    .containsExactlyInAnyOrder(
+                            tuple(1, BLOG, "https://blog.com"),
+                            tuple(2, INSTAGRAM, "https://instagram.com")
+                    );
         }
     }
 }


### PR DESCRIPTION
## 관련 이슈

- resolves: #424 

## 트러블 슈팅 과정

멘토의 마이 페이지 수정 시, 채널을 변경할 때 'unique 제약조건 위반'이 발생했습니다.
<img width="1780" height="756" alt="image" src="https://github.com/user-attachments/assets/e697c40c-bdc4-43c1-ae98-8074d25ae378" />

Channels 엔티티를 보면 아시겠지만, mentor_id와 sequence 조합으로 unique 제약조건을 설정해둔 상태였습니다.
코드 자체만 봤을 때는 “🤔removeAll 후 add 를 하고 있으니, 문제가 없지 않나?” 싶었습니다.
```java
// 이전 코드
public void updateChannels(List<Channel> channels) {
    this.channels.clear();
    if (channels == null || channels.isEmpty()) {
        return;
    }
    for (Channel channel : channels) {
        channel.updateMentor(this);
        this.channels.add(channel);
    }
}
```

[Hibernate 공식 문서](https://docs.jboss.org/hibernate/orm/4.2/javadocs/org/hibernate/event/internal/AbstractFlushingEventListener.html)에도 컬렉션에 있어서는 delete 문이 먼저 실행된다고 되어있어, 원인을 파악하기 어려웠습니다..
<img width="1454" height="220" alt="image" src="https://github.com/user-attachments/assets/38080023-6b2f-4293-a054-caf7faf2da55" />

진짜 문제는 기존의 코드에서는 new Channel()로 완전히 새로운 객체를 만들어 넣었다는 것이었습니다.
이때문에 4번인 insertion of collection elements 가 아니라 1번의 insert로 인식되어서 delete 보다 먼저 실행되었습니다.

이 문제를 해결하기 위해
- 기존의 채널을 업데이트
- 기존보다 새로운 채널의 수가 많다면, 채널 추가
- 기존보다 새로운 채널의 수가 적다면, 채널 삭제

를 하도록 코드를 수정했습니다.

또한 테스트 코드를 보충했습니다.
