### PR TITLE
feat: 비밀번호 정책 추가

### DIFF
--- a/src/main/java/com/example/solidconnection/auth/dto/EmailSignInRequest.java
+++ b/src/main/java/com/example/solidconnection/auth/dto/EmailSignInRequest.java
@@ -1,5 +1,6 @@
 package com.example.solidconnection.auth.dto;
 
+import com.example.solidconnection.auth.dto.validation.Password;
 import jakarta.validation.constraints.NotBlank;
 
 public record EmailSignInRequest(
@@ -7,6 +8,7 @@ public record EmailSignInRequest(
         @NotBlank(message = "이메일을 입력해주세요.")
         String email,
 
+        @Password
         @NotBlank(message = "비밀번호를 입력해주세요.")
         String password
 ) {

--- a/src/main/java/com/example/solidconnection/auth/dto/EmailSignUpTokenRequest.java
+++ b/src/main/java/com/example/solidconnection/auth/dto/EmailSignUpTokenRequest.java
@@ -1,5 +1,6 @@
 package com.example.solidconnection.auth.dto;
 
+import com.example.solidconnection.auth.dto.validation.Password;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
@@ -8,6 +9,7 @@ public record EmailSignUpTokenRequest(
         @Email(message = "이메일을 입력해주세요.")
         String email,
 
+        @Password
         @NotBlank(message = "비밀번호를 입력해주세요.")
         String password
 ) {

--- a/src/main/java/com/example/solidconnection/auth/dto/validation/Password.java
+++ b/src/main/java/com/example/solidconnection/auth/dto/validation/Password.java
@@ -1,0 +1,20 @@
+package com.example.solidconnection.auth.dto.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.FIELD, ElementType.RECORD_COMPONENT})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = PasswordValidator.class)
+public @interface Password {
+
+    String message() default "비밀번호는 영문, 숫자, 특수문자를 포함한 8자리 이상이어야 합니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/example/solidconnection/auth/dto/validation/PasswordValidator.java
+++ b/src/main/java/com/example/solidconnection/auth/dto/validation/PasswordValidator.java
@@ -1,0 +1,17 @@
+package com.example.solidconnection.auth.dto.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+
+public class PasswordValidator implements ConstraintValidator<Password, String> {
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null || value.isBlank()) {
+            return true;
+        }
+
+        return value.matches("^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-={}\\[\\]|:;\"'<>,.?/`~])\\S{8,}$");
+    }
+}

--- a/src/test/java/com/example/solidconnection/auth/dto/validation/PasswordValidatorTest.java
+++ b/src/test/java/com/example/solidconnection/auth/dto/validation/PasswordValidatorTest.java
@@ -1,0 +1,42 @@
+package com.example.solidconnection.auth.dto.validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("비밀번호 유효성 검사 테스트")
+class PasswordValidatorTest {
+
+    private final PasswordValidator validator = new PasswordValidator();
+
+    @Test
+    void 정상_패턴이면_true를_반환한다() {
+        assertThat(validator.isValid("abcd123!", null)).isTrue();
+    }
+
+    @Test
+    void 숫자가_없으면_false를_반환한다() {
+        assertThat(validator.isValid("abcdefg!", null)).isFalse();
+    }
+
+    @Test
+    void 영문자가_없으면_false를_반환한다() {
+        assertThat(validator.isValid("1234567!", null)).isFalse();
+    }
+
+    @Test
+    void 특수문자가_없으면_false를_반환한다() {
+        assertThat(validator.isValid("abcd1234", null)).isFalse();
+    }
+
+    @Test
+    void 공백을_포함하면_false를_반환한다() {
+        assertThat(validator.isValid("abcd123! ", null)).isFalse();
+    }
+
+    @Test
+    void 길이가_8자_미만이면_false를_반환한다() {
+        assertThat(validator.isValid("ab1!ab", null)).isFalse();
+    }
+}


### PR DESCRIPTION
## 관련 이슈

- resolves: #434

## 작업 내용
<img width="192" height="118" alt="스크린샷 2025-08-10 오전 1 07 26" src="https://github.com/user-attachments/assets/14cae66b-a1d1-4cc8-a956-1719db656e97" />

해당 비밀번호 정책을 추가하였습니다!
- 비밀번호는 영문, 숫자, 특수문자를 포함한 8자리 이상
<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

## 특이 사항

제가 알기로 어노테이션 순서가 상관없는 걸로 아는데 

```
        @Password
        @NotBlank(message = "비밀번호를 입력해주세요.")
        String password
```
        
이상하게 이렇게 해야지만 정상 동작하고


```
        @NotBlank(message = "비밀번호를 입력해주세요.")
        @Password
        String password
```
이렇게 하니까 동작을 안하더라구요. 혹시 이유 아시는 분 계신가요?

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
