### PR TITLE
feat: 채팅방 생성 기능 추가

### DIFF
--- a/src/main/java/com/example/solidconnection/chat/domain/ChatRoom.java
+++ b/src/main/java/com/example/solidconnection/chat/domain/ChatRoom.java
@@ -2,11 +2,14 @@ package com.example.solidconnection.chat.domain;
 
 import com.example.solidconnection.common.BaseEntity;
 import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -17,6 +20,12 @@ import org.hibernate.annotations.BatchSize;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(uniqueConstraints = {
+        @UniqueConstraint(
+                name = "uk_chat_room_mentoring_id",
+                columnNames = {"mentoring_id"}
+        )
+})
 public class ChatRoom extends BaseEntity {
 
     @Id
@@ -24,6 +33,9 @@ public class ChatRoom extends BaseEntity {
     private Long id;
 
     private boolean isGroup = false;
+
+    @Column(name = "mentoring_id")
+    private Long mentoringId;
 
     @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL)
     @BatchSize(size = 10)
@@ -33,6 +45,11 @@ public class ChatRoom extends BaseEntity {
     private final List<ChatMessage> chatMessages = new ArrayList<>();
 
     public ChatRoom(boolean isGroup) {
+        this.isGroup = isGroup;
+    }
+
+    public ChatRoom(Long mentoringId, boolean isGroup) {
+        this.mentoringId = mentoringId;
         this.isGroup = isGroup;
     }
 }

--- a/src/main/java/com/example/solidconnection/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/example/solidconnection/chat/repository/ChatRoomRepository.java
@@ -2,6 +2,7 @@ package com.example.solidconnection.chat.repository;
 
 import com.example.solidconnection.chat.domain.ChatRoom;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -33,4 +34,6 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
            AND (crs.updatedAt IS NULL OR cm.createdAt > crs.updatedAt)
            """)
     long countUnreadMessages(@Param("chatRoomId") long chatRoomId, @Param("userId") long userId);
+
+    Optional<ChatRoom> findByMentoringId(long mentoringId);
 }

--- a/src/main/java/com/example/solidconnection/chat/service/ChatService.java
+++ b/src/main/java/com/example/solidconnection/chat/service/ChatService.java
@@ -124,4 +124,18 @@ public class ChatService {
 
         chatReadStatusRepository.upsertReadStatus(roomId, participant.getId());
     }
+
+    @Transactional
+    public void createMentoringChatRoom(Long mentoringId, Long mentorId, Long menteeId) {
+        Optional<ChatRoom> existingChatRoom = chatRoomRepository.findByMentoringId(mentoringId);
+        if (existingChatRoom.isPresent()) {
+            return;
+        }
+
+        ChatRoom chatRoom = new ChatRoom(mentoringId, false);
+        chatRoom = chatRoomRepository.save(chatRoom);
+        ChatParticipant mentorParticipant = new ChatParticipant(mentorId, chatRoom);
+        ChatParticipant menteeParticipant = new ChatParticipant(menteeId, chatRoom);
+        chatParticipantRepository.saveAll(List.of(mentorParticipant, menteeParticipant));
+    }
 }

--- a/src/main/java/com/example/solidconnection/mentor/dto/MentoringApprovedEvent.java
+++ b/src/main/java/com/example/solidconnection/mentor/dto/MentoringApprovedEvent.java
@@ -1,0 +1,12 @@
+package com.example.solidconnection.mentor.dto;
+
+public record MentoringApprovedEvent(
+        long mentoringId,
+        long mentorId,
+        long menteeId
+) {
+
+    public static MentoringApprovedEvent of(long mentoringId, long mentorId, long menteeId) {
+        return new MentoringApprovedEvent(mentoringId, mentorId, menteeId);
+    }
+}

--- a/src/main/java/com/example/solidconnection/mentor/service/MentoringCommandService.java
+++ b/src/main/java/com/example/solidconnection/mentor/service/MentoringCommandService.java
@@ -11,11 +11,13 @@ import com.example.solidconnection.mentor.domain.Mentor;
 import com.example.solidconnection.mentor.domain.Mentoring;
 import com.example.solidconnection.mentor.dto.MentoringApplyRequest;
 import com.example.solidconnection.mentor.dto.MentoringApplyResponse;
+import com.example.solidconnection.mentor.dto.MentoringApprovedEvent;
 import com.example.solidconnection.mentor.dto.MentoringConfirmRequest;
 import com.example.solidconnection.mentor.dto.MentoringConfirmResponse;
 import com.example.solidconnection.mentor.repository.MentorRepository;
 import com.example.solidconnection.mentor.repository.MentoringRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,6 +27,7 @@ public class MentoringCommandService {
 
     private final MentoringRepository mentoringRepository;
     private final MentorRepository mentorRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public MentoringApplyResponse applyMentoring(long siteUserId, MentoringApplyRequest mentoringApplyRequest) {
@@ -48,6 +51,7 @@ public class MentoringCommandService {
 
         if (mentoringConfirmRequest.status() == VerifyStatus.APPROVED) {
             mentor.increaseMenteeCount();
+            eventPublisher.publishEvent(MentoringApprovedEvent.of(mentoringId, mentor.getSiteUserId(), mentoring.getMenteeId()));
         }
 
         return MentoringConfirmResponse.from(mentoring);

--- a/src/main/java/com/example/solidconnection/mentor/service/MentoringEventHandler.java
+++ b/src/main/java/com/example/solidconnection/mentor/service/MentoringEventHandler.java
@@ -1,0 +1,24 @@
+package com.example.solidconnection.mentor.service;
+
+import com.example.solidconnection.chat.service.ChatService;
+import com.example.solidconnection.mentor.dto.MentoringApprovedEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class MentoringEventHandler {
+
+    private final ChatService chatService;
+
+    @EventListener
+    @Async
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handleMentoringApproved(MentoringApprovedEvent event) {
+        chatService.createMentoringChatRoom(event.mentoringId(), event.mentorId(), event.menteeId());
+    }
+}

--- a/src/main/resources/db/migration/V28__add_mentoring_id_to_chat_room.sql
+++ b/src/main/resources/db/migration/V28__add_mentoring_id_to_chat_room.sql
@@ -1,0 +1,6 @@
+ALTER TABLE chat_room
+    ADD COLUMN mentoring_id BIGINT;
+
+ALTER TABLE chat_room
+    ADD CONSTRAINT uk_chat_room_mentoring_id
+        UNIQUE (mentoring_id);

--- a/src/test/java/com/example/solidconnection/chat/repository/ChatRoomRepositoryForTest.java
+++ b/src/test/java/com/example/solidconnection/chat/repository/ChatRoomRepositoryForTest.java
@@ -1,0 +1,29 @@
+package com.example.solidconnection.chat.repository;
+
+import com.example.solidconnection.chat.domain.ChatRoom;
+import io.lettuce.core.dynamic.annotation.Param;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface ChatRoomRepositoryForTest extends JpaRepository<ChatRoom, Long> {
+
+    @Query("""
+           SELECT cr FROM ChatRoom cr
+           LEFT JOIN FETCH cr.chatParticipants cp
+           WHERE cr.isGroup = false
+           AND EXISTS (
+               SELECT 1 FROM ChatParticipant cp1 
+               WHERE cp1.chatRoom = cr AND cp1.siteUserId = :mentorId
+           )
+           AND EXISTS (
+               SELECT 1 FROM ChatParticipant cp2 
+               WHERE cp2.chatRoom = cr AND cp2.siteUserId = :menteeId
+           )
+           AND (
+               SELECT COUNT(cp3) FROM ChatParticipant cp3 
+               WHERE cp3.chatRoom = cr
+           ) = 2
+           """)
+    Optional<ChatRoom> findOneOnOneChatRoomByParticipants(@Param("mentorId") long mentorId, @Param("menteeId") long menteeId);
+}

--- a/src/test/java/com/example/solidconnection/mentor/service/MentoringCommandServiceTest.java
+++ b/src/test/java/com/example/solidconnection/mentor/service/MentoringCommandServiceTest.java
@@ -7,6 +7,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.example.solidconnection.chat.domain.ChatParticipant;
+import com.example.solidconnection.chat.domain.ChatRoom;
+import com.example.solidconnection.chat.repository.ChatRoomRepositoryForTest;
 import com.example.solidconnection.common.VerifyStatus;
 import com.example.solidconnection.common.exception.CustomException;
 import com.example.solidconnection.mentor.domain.Mentor;
@@ -22,6 +25,8 @@ import com.example.solidconnection.mentor.repository.MentoringRepository;
 import com.example.solidconnection.siteuser.domain.SiteUser;
 import com.example.solidconnection.siteuser.fixture.SiteUserFixture;
 import com.example.solidconnection.support.TestContainerSpringBootTest;
+import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -40,6 +45,9 @@ class MentoringCommandServiceTest {
 
     @Autowired
     private MentoringRepository mentoringRepository;
+
+    @Autowired
+    private ChatRoomRepositoryForTest chatRoomRepositoryForTest;
 
     @Autowired
     private SiteUserFixture siteUserFixture;
@@ -116,6 +124,31 @@ class MentoringCommandServiceTest {
         }
 
         @Test
+        void 멘토링_승인시_채팅방이_자동으로_생성된다() {
+            // given
+            Mentoring mentoring = mentoringFixture.대기중_멘토링(mentor1.getId(), menteeUser.getId());
+            MentoringConfirmRequest request = new MentoringConfirmRequest(VerifyStatus.APPROVED);
+
+            Optional<ChatRoom> beforeChatRoom = chatRoomRepositoryForTest.findOneOnOneChatRoomByParticipants(mentorUser1.getId(), menteeUser.getId());
+            assertThat(beforeChatRoom).isEmpty();
+
+            // when
+            mentoringCommandService.confirmMentoring(mentorUser1.getId(), mentoring.getId(), request);
+
+            // then
+            ChatRoom afterChatRoom = chatRoomRepositoryForTest
+                    .findOneOnOneChatRoomByParticipants(mentorUser1.getId(), menteeUser.getId())
+                    .orElseThrow();
+            List<Long> participantIds = afterChatRoom.getChatParticipants().stream()
+                    .map(ChatParticipant::getSiteUserId)
+                    .toList();
+            assertAll(
+                    () -> assertThat(afterChatRoom.isGroup()).isFalse(),
+                    () -> assertThat(participantIds).containsExactly(mentorUser1.getId(), menteeUser.getId())
+            );
+        }
+
+        @Test
         void 멘토링을_성공적으로_거절한다() {
             // given
             Mentoring mentoring = mentoringFixture.대기중_멘토링(mentor1.getId(), menteeUser.getId());
@@ -135,6 +168,23 @@ class MentoringCommandServiceTest {
                     () -> assertThat(confirmedMentoring.getCheckedAtByMentor()).isNotNull(),
                     () -> assertThat(mentor.getMenteeCount()).isEqualTo(beforeMenteeCount)
             );
+        }
+
+        @Test
+        void 멘토링_거절시_채팅방이_자동으로_생성되지_않는다() {
+            // given
+            Mentoring mentoring = mentoringFixture.대기중_멘토링(mentor1.getId(), menteeUser.getId());
+            MentoringConfirmRequest request = new MentoringConfirmRequest(VerifyStatus.REJECTED);
+
+            Optional<ChatRoom> beforeChatRoom = chatRoomRepositoryForTest.findOneOnOneChatRoomByParticipants(mentorUser1.getId(), menteeUser.getId());
+            assertThat(beforeChatRoom).isEmpty();
+
+            // when
+            mentoringCommandService.confirmMentoring(mentorUser1.getId(), mentoring.getId(), request);
+
+            // then
+            Optional<ChatRoom> afterChatRoom = chatRoomRepositoryForTest.findOneOnOneChatRoomByParticipants(mentorUser1.getId(), menteeUser.getId());
+            assertThat(afterChatRoom).isEmpty();
         }
 
         @Test


### PR DESCRIPTION
## 관련 이슈

- resolves: #438

## 작업 내용

성혁님 리뷰 반영해서 채팅방 생성 기능 구현했습니다.

디스코드에서 얘기했던 대로 ChatRoom에 mentoringId랑 유니크키 추가했고,
mentoringId가 null이면 유니크키가 안 깨지니까 나중에 커뮤니티 다대다 채팅 들어와도 문제 없을 거 같아서 long 대신 Long으로 구현하였습니다.
이렇게 하니까 isGroup은 사실 필요 없어진 거 같긴 한데 그냥 무시(?)했습니다 ㅎㅎ

멘토링 성사될 때 이벤트 기반으로 채팅방이 생성되게 했고,
채팅방 개설에서 예외가 나더라도 멘토링 승인에는 영향을 없게 하려고 Propagation.REQUIRES_NEW로 설정했습니다.

혹시 예외 터질 때 retry 등의 기능이 필요할 수도 있긴 한데, 당분간은 문제 없을 거 같기도 하고... 복잡해지는 것 같아 뺐습니다.

지금 생각하기엔 관리자 api로 채팅방 강제로 만들어주는 것을 차라리 구현하는 게 나을 수도 있지 않을까란 생각이 듭니다!


<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

## 리뷰 요구사항 (선택)

flyway 스크립트 제대로 작성했나요?
<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
