### PR TITLE
refactor: refreshToken 쿠키에서 환경별로 Domain 설정하도록

### DIFF
--- a/src/main/java/com/example/solidconnection/auth/controller/RefreshTokenCookieManager.java
+++ b/src/main/java/com/example/solidconnection/auth/controller/RefreshTokenCookieManager.java
@@ -1,17 +1,21 @@
 package com.example.solidconnection.auth.controller;
 
+import com.example.solidconnection.auth.controller.config.RefreshTokenCookieProperties;
 import com.example.solidconnection.auth.domain.TokenType;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class RefreshTokenCookieManager {
 
     private static final String COOKIE_NAME = "refreshToken";
     private static final String PATH = "/";
-    private static final String SAME_SITE = "Strict";
+
+    private final RefreshTokenCookieProperties properties;
 
     public void setCookie(HttpServletResponse response, String refreshToken) {
         long maxAge = convertExpireTimeToCookieMaxAge(TokenType.REFRESH.getExpireTime());
@@ -35,7 +39,8 @@ public class RefreshTokenCookieManager {
                 .secure(true)
                 .path(PATH)
                 .maxAge(maxAge)
-                .sameSite(SAME_SITE)
+                .domain(properties.cookieDomain())
+                .sameSite(properties.sameSite())
                 .build();
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
     }

--- a/src/main/java/com/example/solidconnection/auth/controller/RefreshTokenCookieManager.java
+++ b/src/main/java/com/example/solidconnection/auth/controller/RefreshTokenCookieManager.java
@@ -19,7 +19,7 @@ public class RefreshTokenCookieManager {
     }
 
     private long convertExpireTimeToCookieMaxAge(long milliSeconds) {
-        // jwt의 expireTime: millisecond, cookie의 maxAge: second
+        // jwt의 expireTime 단위인 millisecond를 cookie의 maxAge 단위인 second로 변환
         return milliSeconds / 1000;
     }
 

--- a/src/main/java/com/example/solidconnection/auth/controller/config/RefreshTokenCookieProperties.java
+++ b/src/main/java/com/example/solidconnection/auth/controller/config/RefreshTokenCookieProperties.java
@@ -1,0 +1,21 @@
+package com.example.solidconnection.auth.controller.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.web.server.Cookie.SameSite;
+
+@ConfigurationProperties(prefix = "token.refresh")
+public record RefreshTokenCookieProperties(
+        String cookieDomain
+) {
+
+    public String sameSite() {
+        if (isDomainSet()) {
+            return SameSite.STRICT.attributeValue(); // 도메인을 지정한 경우 SameSite=Strict
+        }
+        return SameSite.NONE.attributeValue(); // 도메인을 지정하지 않은 경우 SameSite=None
+    }
+
+    private boolean isDomainSet() {
+        return cookieDomain != null && !cookieDomain.isBlank();
+    }
+}

--- a/src/test/java/com/example/solidconnection/auth/controller/RefreshTokenCookieManagerTest.java
+++ b/src/test/java/com/example/solidconnection/auth/controller/RefreshTokenCookieManagerTest.java
@@ -2,21 +2,35 @@ package com.example.solidconnection.auth.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.BDDMockito.given;
 
+import com.example.solidconnection.auth.controller.config.RefreshTokenCookieProperties;
 import com.example.solidconnection.auth.domain.TokenType;
+import com.example.solidconnection.support.TestContainerSpringBootTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.mock.web.MockHttpServletResponse;
 
 @DisplayName("리프레시 토큰 쿠키 매니저 테스트")
+@TestContainerSpringBootTest
 class RefreshTokenCookieManagerTest {
 
+    @Autowired
     private RefreshTokenCookieManager cookieManager;
+
+    @MockBean
+    private RefreshTokenCookieProperties refreshTokenCookieProperties;
+
+    private final String sameSite = "Strict";
+    private final String domain = "example.com";
 
     @BeforeEach
     void setUp() {
-        cookieManager = new RefreshTokenCookieManager();
+        given(refreshTokenCookieProperties.cookieDomain()).willReturn(domain);
+        given(refreshTokenCookieProperties.sameSite()).willReturn(sameSite);
     }
 
     @Test
@@ -37,7 +51,8 @@ class RefreshTokenCookieManagerTest {
                 () -> assertThat(header).contains("Secure"),
                 () -> assertThat(header).contains("Path=/"),
                 () -> assertThat(header).contains("Max-Age=" + TokenType.REFRESH.getExpireTime() / 1000),
-                () -> assertThat(header).contains("SameSite=Strict")
+                () -> assertThat(header).contains("Domain=" + domain),
+                () -> assertThat(header).contains("SameSite=" + sameSite)
         );
     }
 
@@ -58,7 +73,9 @@ class RefreshTokenCookieManagerTest {
                 () -> assertThat(header).contains("Secure"),
                 () -> assertThat(header).contains("Path=/"),
                 () -> assertThat(header).contains("Max-Age=0"),
-                () -> assertThat(header).contains("SameSite=Strict")
+                () -> assertThat(header).contains("SameSite=Strict"),
+                () -> assertThat(header).contains("Domain=" + domain),
+                () -> assertThat(header).contains("SameSite=" + sameSite)
         );
     }
 }

--- a/src/test/java/com/example/solidconnection/auth/controller/config/RefreshTokenCookiePropertiesTest.java
+++ b/src/test/java/com/example/solidconnection/auth/controller/config/RefreshTokenCookiePropertiesTest.java
@@ -1,0 +1,35 @@
+package com.example.solidconnection.auth.controller.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.web.server.Cookie.SameSite;
+
+@DisplayName("리프레시 토큰 쿠키 설정 테스트")
+class RefreshTokenCookiePropertiesTest {
+
+    @Test
+    void Domain을_지정했으면_SameSite가_Strict() {
+        // given
+        RefreshTokenCookieProperties properties = new RefreshTokenCookieProperties("example.com");
+
+        // when
+        String sameSite = properties.sameSite();
+
+        // then
+        assertThat(sameSite).isEqualTo(SameSite.STRICT.attributeValue());
+    }
+
+    @Test
+    void Domain을_지정하지_않았으면_SameSite가_None() {
+        // given
+        RefreshTokenCookieProperties properties = new RefreshTokenCookieProperties(null);
+
+        // when
+        String sameSite = properties.sameSite();
+
+        // then
+        assertThat(sameSite).isEqualTo(SameSite.NONE.attributeValue());
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -85,3 +85,6 @@ cors:
     - "http://localhost:8080"
 news:
   default-thumbnail-url: "default-thumbnail-url"
+token:
+  refresh:
+    cookie-domain: "test.domain.com"


### PR DESCRIPTION
## 관련 이슈

- resolves: #449

## 작업 내용

🔽 프론트 만옥님이 말씀하신 문제 상황입니다

<img width="600" alt="Image" src="https://github.com/user-attachments/assets/341c5ecc-8968-4eee-ab92-a8b1b9eca088" />



▶️ 쿠키의 도메인이 일치하지 않아 발생한 문제입니다.
- 백엔드 도메인 : `api.stage.solid-connection.com`
- 프론트 도메인 : `www.stage.solid-connection.com`

▶️ 문제의 원인: 쿠키 정보를 세팅할 때, domain을 별도로 지정하지 않으면 
쿠키를 발급하는 서버의 도메인 (api.stage.xxx) 로 자동 설정된다고 합니다 😓

▶️ 추가 요구사항: 프론트엔드 만옥님의 요청으로, dev 서버의 api는 localhost 에서 테스트할 수 있게 해야합니다.

---

환경별로 나누어 문제를 해결합니다.

- prod 환경
  - 엄격한 보안 필요
  - Domain을 구체적으로 지정
  - `Domain=.solid-connection.com; Path=/; HttpOnly; Secure; SameSite=Strict;`
- dev 환경
  - localhost 에서도 쿠키 저장이 가능하도록, 크로스 사이트 허용 필요
  - Domain을 생략 && SameSite=None 설정
  - `Domain=api.stage.solid-connection.com;(생략 시, 자동으로 서버의 도메인 할당됨) Path=/; HttpOnly; Secure; SameSite=Node;`

추가 요구사항으로 https로 localhost에서 테스트할 수 있도록 cors 허용 리스트에 `https://localhost:3000` 을 추가합니다

## 특이 사항

시크릿 레포에도 PR 올렸습니다 🏃‍♀️
https://github.com/solid-connection/solid-connect-secret/pull/18/files

