### PR TITLE
refactor: accessToken 재발급을 refreshToken 쿠키를 통해 하도록

### DIFF
--- a/src/main/java/com/example/solidconnection/auth/controller/AuthController.java
+++ b/src/main/java/com/example/solidconnection/auth/controller/AuthController.java
@@ -3,7 +3,6 @@ package com.example.solidconnection.auth.controller;
 import com.example.solidconnection.auth.dto.EmailSignInRequest;
 import com.example.solidconnection.auth.dto.EmailSignUpTokenRequest;
 import com.example.solidconnection.auth.dto.EmailSignUpTokenResponse;
-import com.example.solidconnection.auth.dto.ReissueRequest;
 import com.example.solidconnection.auth.dto.ReissueResponse;
 import com.example.solidconnection.auth.dto.SignInResponse;
 import com.example.solidconnection.auth.dto.SignUpRequest;
@@ -19,6 +18,7 @@ import com.example.solidconnection.common.exception.CustomException;
 import com.example.solidconnection.common.exception.ErrorCode;
 import com.example.solidconnection.common.resolver.AuthorizedUser;
 import com.example.solidconnection.siteuser.domain.AuthType;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -118,10 +118,10 @@ public class AuthController {
 
     @PostMapping("/reissue")
     public ResponseEntity<ReissueResponse> reissueToken(
-            @AuthorizedUser long siteUserId,
-            @Valid @RequestBody ReissueRequest reissueRequest
+            HttpServletRequest request
     ) {
-        ReissueResponse reissueResponse = authService.reissue(siteUserId, reissueRequest);
+        String refreshToken = refreshTokenCookieManager.getRefreshToken(request);
+        ReissueResponse reissueResponse = authService.reissue(refreshToken);
         return ResponseEntity.ok(reissueResponse);
     }
 

--- a/src/main/java/com/example/solidconnection/auth/controller/RefreshTokenCookieManager.java
+++ b/src/main/java/com/example/solidconnection/auth/controller/RefreshTokenCookieManager.java
@@ -52,16 +52,24 @@ public class RefreshTokenCookieManager {
     }
 
     public String getRefreshToken(HttpServletRequest request) {
+        // 쿠키가 없거나 비어있는 경우 예외 발생
         Cookie[] cookies = request.getCookies();
         if (cookies == null || cookies.length == 0) {
             throw new CustomException(REFRESH_TOKEN_NOT_EXISTS);
         }
 
-        return Arrays.stream(cookies)
+        // refreshToken 쿠키가 없는 경우 예외 발생
+        Cookie refreshTokenCookie = Arrays.stream(cookies)
                 .filter(cookie -> COOKIE_NAME.equals(cookie.getName()))
                 .findFirst()
-                .orElseThrow(() -> new CustomException(REFRESH_TOKEN_NOT_EXISTS))
-                .getValue();
+                .orElseThrow(() -> new CustomException(REFRESH_TOKEN_NOT_EXISTS));
+
+        // 쿠키 값이 비어있는 경우 예외 발생
+        String refreshToken = refreshTokenCookie.getValue();
+        if (refreshToken == null || refreshToken.isBlank()) {
+            throw new CustomException(REFRESH_TOKEN_NOT_EXISTS);
+        }
+        return refreshToken;
     }
 }
 

--- a/src/main/java/com/example/solidconnection/auth/controller/RefreshTokenCookieManager.java
+++ b/src/main/java/com/example/solidconnection/auth/controller/RefreshTokenCookieManager.java
@@ -1,15 +1,15 @@
 package com.example.solidconnection.auth.controller;
 
-import com.example.solidconnection.auth.controller.config.RefreshTokenCookieProperties;
 import static com.example.solidconnection.common.exception.ErrorCode.REFRESH_TOKEN_NOT_EXISTS;
 
+import com.example.solidconnection.auth.controller.config.RefreshTokenCookieProperties;
 import com.example.solidconnection.auth.domain.TokenType;
 import com.example.solidconnection.common.exception.CustomException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.RequiredArgsConstructor;
 import java.util.Arrays;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;

--- a/src/main/java/com/example/solidconnection/auth/controller/RefreshTokenCookieManager.java
+++ b/src/main/java/com/example/solidconnection/auth/controller/RefreshTokenCookieManager.java
@@ -1,9 +1,15 @@
 package com.example.solidconnection.auth.controller;
 
 import com.example.solidconnection.auth.controller.config.RefreshTokenCookieProperties;
+import static com.example.solidconnection.common.exception.ErrorCode.REFRESH_TOKEN_NOT_EXISTS;
+
 import com.example.solidconnection.auth.domain.TokenType;
+import com.example.solidconnection.common.exception.CustomException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import java.util.Arrays;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
@@ -44,4 +50,18 @@ public class RefreshTokenCookieManager {
                 .build();
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
     }
+
+    public String getRefreshToken(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null || cookies.length == 0) {
+            throw new CustomException(REFRESH_TOKEN_NOT_EXISTS);
+        }
+
+        return Arrays.stream(cookies)
+                .filter(cookie -> COOKIE_NAME.equals(cookie.getName()))
+                .findFirst()
+                .orElseThrow(() -> new CustomException(REFRESH_TOKEN_NOT_EXISTS))
+                .getValue();
+    }
 }
+

--- a/src/main/java/com/example/solidconnection/auth/dto/ReissueRequest.java
+++ b/src/main/java/com/example/solidconnection/auth/dto/ReissueRequest.java
@@ -1,9 +1,0 @@
-package com.example.solidconnection.auth.dto;
-
-import jakarta.validation.constraints.NotBlank;
-
-public record ReissueRequest(
-        @NotBlank(message = "리프레시 토큰과 함께 요청해주세요.")
-        String refreshToken) {
-
-}

--- a/src/main/java/com/example/solidconnection/auth/service/AuthService.java
+++ b/src/main/java/com/example/solidconnection/auth/service/AuthService.java
@@ -3,7 +3,6 @@ package com.example.solidconnection.auth.service;
 import static com.example.solidconnection.common.exception.ErrorCode.REFRESH_TOKEN_EXPIRED;
 import static com.example.solidconnection.common.exception.ErrorCode.USER_NOT_FOUND;
 
-import com.example.solidconnection.auth.dto.ReissueRequest;
 import com.example.solidconnection.auth.dto.ReissueResponse;
 import com.example.solidconnection.auth.token.TokenBlackListService;
 import com.example.solidconnection.common.exception.CustomException;
@@ -58,16 +57,17 @@ public class AuthService {
      * - 유효한 리프레시토큰이면, 액세스 토큰을 재발급한다.
      * - 그렇지 않으면 예외를 발생시킨다.
      * */
-    public ReissueResponse reissue(long siteUserId, ReissueRequest reissueRequest) {
+    public ReissueResponse reissue(String requestedRefreshToken) {
         // 리프레시 토큰 확인
-        String requestedRefreshToken = reissueRequest.refreshToken();
         if (!authTokenProvider.isValidRefreshToken(requestedRefreshToken)) {
             throw new CustomException(REFRESH_TOKEN_EXPIRED);
         }
+        Subject subject = authTokenProvider.parseSubject(requestedRefreshToken);
+        long siteUserId = Long.parseLong(subject.value());
+
         // 액세스 토큰 재발급
         SiteUser siteUser = siteUserRepository.findById(siteUserId)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
-        Subject subject = authTokenProvider.parseSubject(requestedRefreshToken);
         AccessToken newAccessToken = authTokenProvider.generateAccessToken(subject, siteUser.getRole());
         return ReissueResponse.from(newAccessToken);
     }

--- a/src/main/java/com/example/solidconnection/auth/service/SignInService.java
+++ b/src/main/java/com/example/solidconnection/auth/service/SignInService.java
@@ -15,9 +15,8 @@ public class SignInService {
     @Transactional
     public SignInResponse signIn(SiteUser siteUser) {
         resetQuitedAt(siteUser);
-        Subject subject = authTokenProvider.toSubject(siteUser);
-        AccessToken accessToken = authTokenProvider.generateAccessToken(subject, siteUser.getRole());
-        RefreshToken refreshToken = authTokenProvider.generateAndSaveRefreshToken(subject);
+        AccessToken accessToken = authTokenProvider.generateAccessToken(siteUser);
+        RefreshToken refreshToken = authTokenProvider.generateAndSaveRefreshToken(siteUser);
         return SignInResponse.of(accessToken, refreshToken);
     }
 

--- a/src/main/java/com/example/solidconnection/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/solidconnection/common/exception/ErrorCode.java
@@ -56,6 +56,7 @@ public enum ErrorCode {
     ACCESS_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED.value(), "액세스 토큰이 만료되었습니다. 재발급 api를 호출해주세요."),
     REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED.value(), "리프레시 토큰이 만료되었습니다. 다시 로그인을 진행해주세요."),
     ACCESS_DENIED(HttpStatus.FORBIDDEN.value(), "접근 권한이 없습니다."),
+    REFRESH_TOKEN_NOT_EXISTS(HttpStatus.BAD_REQUEST.value(), "리프레시 토큰이 존재하지 않습니다."),
     PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST.value(), "비밀번호가 일치하지 않습니다."),
     PASSWORD_NOT_CHANGED(HttpStatus.BAD_REQUEST.value(), "현재 비밀번호와 새 비밀번호가 동일합니다."),
     PASSWORD_NOT_CONFIRMED(HttpStatus.BAD_REQUEST.value(), "새 비밀번호가 일치하지 않습니다."),

--- a/src/test/java/com/example/solidconnection/auth/controller/RefreshTokenCookieManagerTest.java
+++ b/src/test/java/com/example/solidconnection/auth/controller/RefreshTokenCookieManagerTest.java
@@ -18,6 +18,8 @@ import org.springframework.mock.web.MockHttpServletResponse;
 @TestContainerSpringBootTest
 class RefreshTokenCookieManagerTest {
 
+    private static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
+
     @Autowired
     private RefreshTokenCookieManager cookieManager;
 
@@ -46,7 +48,7 @@ class RefreshTokenCookieManagerTest {
         String header = response.getHeader("Set-Cookie");
         assertAll(
                 () -> assertThat(header).isNotNull(),
-                () -> assertThat(header).contains("refreshToken=" + refreshToken),
+                () -> assertThat(header).contains(REFRESH_TOKEN_COOKIE_NAME + "=" + refreshToken),
                 () -> assertThat(header).contains("HttpOnly"),
                 () -> assertThat(header).contains("Secure"),
                 () -> assertThat(header).contains("Path=/"),
@@ -68,12 +70,11 @@ class RefreshTokenCookieManagerTest {
         String header = response.getHeader("Set-Cookie");
         assertAll(
                 () -> assertThat(header).isNotNull(),
-                () -> assertThat(header).contains("refreshToken="),
+                () -> assertThat(header).contains(REFRESH_TOKEN_COOKIE_NAME + "="),
                 () -> assertThat(header).contains("HttpOnly"),
                 () -> assertThat(header).contains("Secure"),
                 () -> assertThat(header).contains("Path=/"),
                 () -> assertThat(header).contains("Max-Age=0"),
-                () -> assertThat(header).contains("SameSite=Strict"),
                 () -> assertThat(header).contains("Domain=" + domain),
                 () -> assertThat(header).contains("SameSite=" + sameSite)
         );

--- a/src/test/java/com/example/solidconnection/auth/controller/RefreshTokenCookieManagerTest.java
+++ b/src/test/java/com/example/solidconnection/auth/controller/RefreshTokenCookieManagerTest.java
@@ -17,6 +17,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
@@ -115,10 +117,23 @@ class RefreshTokenCookieManagerTest {
         }
 
         @Test
-        void 리프레시_토큰에_해당하는_쿠키가_없으면_예외가_발생한다() {
+        void 리프레시_토큰_쿠키가_없으면_예외가_발생한다() {
             // given
             MockHttpServletRequest request = new MockHttpServletRequest();
             request.setCookies(new Cookie("otherCookie", "some-value"));
+
+            // when & then
+            assertThatCode(() -> cookieManager.getRefreshToken(request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(ErrorCode.REFRESH_TOKEN_NOT_EXISTS.getMessage());
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"", " "})
+        void 리프레시_토큰_쿠키가_비어있으면_예외가_발생한다(String token) {
+            // given
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            request.setCookies(new Cookie(REFRESH_TOKEN_COOKIE_NAME, token));
 
             // when & then
             assertThatCode(() -> cookieManager.getRefreshToken(request))

--- a/src/test/java/com/example/solidconnection/auth/controller/RefreshTokenCookieManagerTest.java
+++ b/src/test/java/com/example/solidconnection/auth/controller/RefreshTokenCookieManagerTest.java
@@ -1,17 +1,23 @@
 package com.example.solidconnection.auth.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.BDDMockito.given;
 
 import com.example.solidconnection.auth.controller.config.RefreshTokenCookieProperties;
 import com.example.solidconnection.auth.domain.TokenType;
 import com.example.solidconnection.support.TestContainerSpringBootTest;
+import com.example.solidconnection.common.exception.CustomException;
+import com.example.solidconnection.common.exception.ErrorCode;
+import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
 @DisplayName("리프레시 토큰 쿠키 매니저 테스트")
@@ -78,5 +84,46 @@ class RefreshTokenCookieManagerTest {
                 () -> assertThat(header).contains("Domain=" + domain),
                 () -> assertThat(header).contains("SameSite=" + sameSite)
         );
+    }
+
+    @Nested
+    class 쿠키에서_리프레시_토큰을_추출한다 {
+
+        @Test
+        void 리프레시_토큰이_있으면_정상_반환한다() {
+            // given
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            String refreshToken = "test-refresh-token";
+            request.setCookies(new Cookie(REFRESH_TOKEN_COOKIE_NAME, refreshToken));
+
+            // when
+            String retrievedToken = cookieManager.getRefreshToken(request);
+
+            // then
+            assertThat(retrievedToken).isEqualTo(refreshToken);
+        }
+
+        @Test
+        void 쿠키가_없으면_예외가_발생한다() {
+            // given
+            MockHttpServletRequest request = new MockHttpServletRequest();
+
+            // when & then
+            assertThatCode(() -> cookieManager.getRefreshToken(request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(ErrorCode.REFRESH_TOKEN_NOT_EXISTS.getMessage());
+        }
+
+        @Test
+        void 리프레시_토큰에_해당하는_쿠키가_없으면_예외가_발생한다() {
+            // given
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            request.setCookies(new Cookie("otherCookie", "some-value"));
+
+            // when & then
+            assertThatCode(() -> cookieManager.getRefreshToken(request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(ErrorCode.REFRESH_TOKEN_NOT_EXISTS.getMessage());
+        }
     }
 }

--- a/src/test/java/com/example/solidconnection/auth/controller/RefreshTokenCookieManagerTest.java
+++ b/src/test/java/com/example/solidconnection/auth/controller/RefreshTokenCookieManagerTest.java
@@ -7,18 +7,18 @@ import static org.mockito.BDDMockito.given;
 
 import com.example.solidconnection.auth.controller.config.RefreshTokenCookieProperties;
 import com.example.solidconnection.auth.domain.TokenType;
-import com.example.solidconnection.support.TestContainerSpringBootTest;
 import com.example.solidconnection.common.exception.CustomException;
 import com.example.solidconnection.common.exception.ErrorCode;
+import com.example.solidconnection.support.TestContainerSpringBootTest;
 import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 

--- a/src/test/java/com/example/solidconnection/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/example/solidconnection/auth/service/AuthServiceTest.java
@@ -44,14 +44,12 @@ class AuthServiceTest {
     private SiteUserRepository siteUserRepository;
 
     private SiteUser siteUser;
-    private Subject subject;
     private AccessToken accessToken;
 
     @BeforeEach
     void setUp() {
         siteUser = siteUserFixture.사용자();
-        subject = authTokenProvider.toSubject(siteUser);
-        accessToken = authTokenProvider.generateAccessToken(subject, siteUser.getRole());
+        accessToken = authTokenProvider.generateAccessToken(siteUser);
     }
 
     @Test
@@ -60,7 +58,7 @@ class AuthServiceTest {
         authService.signOut(accessToken.token());
 
         // then
-        String refreshTokenKey = TokenType.REFRESH.addPrefix(subject.value());
+        String refreshTokenKey = TokenType.REFRESH.addPrefix(accessToken.subject().value());
         assertAll(
                 () -> assertThat(redisTemplate.opsForValue().get(refreshTokenKey)).isNull(),
                 () -> assertThat(tokenBlackListService.isTokenBlacklisted(accessToken.token())).isTrue()
@@ -74,7 +72,7 @@ class AuthServiceTest {
 
         // then
         LocalDate tomorrow = LocalDate.now().plusDays(1);
-        String refreshTokenKey = TokenType.REFRESH.addPrefix(subject.value());
+        String refreshTokenKey = TokenType.REFRESH.addPrefix(accessToken.subject().value());
         SiteUser actualSitUser = siteUserRepository.findById(siteUser.getId()).orElseThrow();
         assertAll(
                 () -> assertThat(actualSitUser.getQuitedAt()).isEqualTo(tomorrow),
@@ -89,15 +87,15 @@ class AuthServiceTest {
         @Test
         void 요청의_리프레시_토큰이_저장되어_있으면_액세스_토큰을_재발급한다() {
             // given
-            RefreshToken refreshToken = authTokenProvider.generateAndSaveRefreshToken(new Subject("1"));
+            RefreshToken refreshToken = authTokenProvider.generateAndSaveRefreshToken(siteUser);
 
             // when
             ReissueResponse reissuedAccessToken = authService.reissue(refreshToken.token());
 
-            // then - 요청의 리프레시 토큰과 재발급한 액세스 토큰의 subject 가 동일해야 한다.
-            Subject expectedSubject = authTokenProvider.parseSubject(refreshToken.token());
-            Subject actualSubject = authTokenProvider.parseSubject(reissuedAccessToken.accessToken());
-            assertThat(actualSubject).isEqualTo(expectedSubject);
+            // then - 요청의 리프레시 토큰과 재발급한 액세스 토큰의 주체가 동일해야 한다.
+            SiteUser actualSiteUser = authTokenProvider.parseSiteUser(refreshToken.token());
+            SiteUser expectedSiteUser = authTokenProvider.parseSiteUser(reissuedAccessToken.accessToken());
+            assertThat(actualSiteUser.getId()).isEqualTo(expectedSiteUser.getId());
         }
 
         @Test

--- a/src/test/java/com/example/solidconnection/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/example/solidconnection/auth/service/AuthServiceTest.java
@@ -6,7 +6,6 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.example.solidconnection.auth.domain.TokenType;
-import com.example.solidconnection.auth.dto.ReissueRequest;
 import com.example.solidconnection.auth.dto.ReissueResponse;
 import com.example.solidconnection.auth.token.TokenBlackListService;
 import com.example.solidconnection.common.exception.CustomException;
@@ -90,11 +89,10 @@ class AuthServiceTest {
         @Test
         void 요청의_리프레시_토큰이_저장되어_있으면_액세스_토큰을_재발급한다() {
             // given
-            RefreshToken refreshToken = authTokenProvider.generateAndSaveRefreshToken(new Subject("subject"));
-            ReissueRequest reissueRequest = new ReissueRequest(refreshToken.token());
+            RefreshToken refreshToken = authTokenProvider.generateAndSaveRefreshToken(new Subject("1"));
 
             // when
-            ReissueResponse reissuedAccessToken = authService.reissue(siteUser.getId(), reissueRequest);
+            ReissueResponse reissuedAccessToken = authService.reissue(refreshToken.token());
 
             // then - 요청의 리프레시 토큰과 재발급한 액세스 토큰의 subject 가 동일해야 한다.
             Subject expectedSubject = authTokenProvider.parseSubject(refreshToken.token());
@@ -106,10 +104,9 @@ class AuthServiceTest {
         void 요청의_리프레시_토큰이_저장되어있지_않다면_예외가_발생한다() {
             // given
             String invalidRefreshToken = accessToken.token();
-            ReissueRequest reissueRequest = new ReissueRequest(invalidRefreshToken);
 
             // when, then
-            assertThatCode(() -> authService.reissue(siteUser.getId(), reissueRequest))
+            assertThatCode(() -> authService.reissue(invalidRefreshToken))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(REFRESH_TOKEN_EXPIRED.getMessage());
         }

--- a/src/test/java/com/example/solidconnection/websocket/WebSocketStompIntegrationTest.java
+++ b/src/test/java/com/example/solidconnection/websocket/WebSocketStompIntegrationTest.java
@@ -80,7 +80,7 @@ class WebSocketStompIntegrationTest {
         void 인증된_사용자는_핸드셰이크를_성공한다() throws Exception {
             // given
             SiteUser user = siteUserFixture.사용자();
-            AccessToken accessToken = authTokenProvider.generateAccessToken(authTokenProvider.toSubject(user), user.getRole());
+            AccessToken accessToken = authTokenProvider.generateAccessToken(user);
 
             WebSocketHttpHeaders handshakeHeaders = new WebSocketHttpHeaders();
             handshakeHeaders.add("Authorization", "Bearer " + accessToken.token());


### PR DESCRIPTION
## 관련 이슈

- resolves: #451 

## 작업 내용

- **AS-IS**
  - Body에 refreshToken을 전달해야 했습니다.
  - 하지만 '쿠키에 refreshToken을 저장'하도록 보안 정책이 바뀌었고, 
  프론트엔드에서 브라우저의 쿠키에 접근할 수 없게 됨에 따라 이 방법이 불가능해졌습니다.
- **TO-BE**
  - 쿠키의 refreshToken을 추출하여 accessToken을 재발급하도록 변경합니다.

## 특이 사항

사실 이 PR에 포함되는 범위는 아니지만...
authTokenProvider의 몇몇 함수를 고쳐 중복 코드를 없앴습니다.. 🙄🙄
어차피 auth 패키지 리팩터링하려 했으니 이정도는 괜찮겠지요? 호호..

## 리뷰 요구사항 (선택)

커밋 따라가며 읽으시면 쉽습니다!

https://github.com/solid-connection/api-docs/pull/41 와 함께 머지합니다.