### PR TITLE
feat: 관심 지역 및 국가 수정 API 추가

### DIFF
--- a/src/main/java/com/example/solidconnection/location/country/repository/InterestedCountryRepository.java
+++ b/src/main/java/com/example/solidconnection/location/country/repository/InterestedCountryRepository.java
@@ -1,7 +1,6 @@
 package com.example.solidconnection.location.country.repository;
 
 import com.example.solidconnection.location.country.domain.InterestedCountry;
-import com.example.solidconnection.siteuser.domain.SiteUser;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -11,5 +10,5 @@ public interface InterestedCountryRepository extends JpaRepository<InterestedCou
     List<InterestedCountry> findAllBySiteUserId(long siteUserId);
 
     @Modifying
-    void deleteBySiteUser(SiteUser siteUser);
+    void deleteBySiteUserId(long siteUserId);
 }

--- a/src/main/java/com/example/solidconnection/location/country/repository/InterestedCountryRepository.java
+++ b/src/main/java/com/example/solidconnection/location/country/repository/InterestedCountryRepository.java
@@ -1,10 +1,15 @@
 package com.example.solidconnection.location.country.repository;
 
 import com.example.solidconnection.location.country.domain.InterestedCountry;
+import com.example.solidconnection.siteuser.domain.SiteUser;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 
 public interface InterestedCountryRepository extends JpaRepository<InterestedCountry, Long> {
 
     List<InterestedCountry> findAllBySiteUserId(long siteUserId);
+
+    @Modifying
+    void deleteBySiteUser(SiteUser siteUser);
 }

--- a/src/main/java/com/example/solidconnection/location/country/repository/InterestedCountryRepository.java
+++ b/src/main/java/com/example/solidconnection/location/country/repository/InterestedCountryRepository.java
@@ -9,6 +9,6 @@ public interface InterestedCountryRepository extends JpaRepository<InterestedCou
 
     List<InterestedCountry> findAllBySiteUserId(long siteUserId);
 
-    @Modifying
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     void deleteBySiteUserId(long siteUserId);
 }

--- a/src/main/java/com/example/solidconnection/location/country/service/InterestedCountryService.java
+++ b/src/main/java/com/example/solidconnection/location/country/service/InterestedCountryService.java
@@ -24,4 +24,15 @@ public class InterestedCountryService {
                 .toList();
         interestedCountryRepository.saveAll(interestedCountries);
     }
+
+    @Transactional
+    public void updateInterestedCountry(SiteUser siteUser, List<String> koreanNames) {
+        interestedCountryRepository.deleteBySiteUser(siteUser);
+
+        List<InterestedCountry> interestedCountries = countryRepository.findAllByKoreanNameIn(koreanNames)
+                .stream()
+                .map(country -> new InterestedCountry(siteUser, country))
+                .toList();
+        interestedCountryRepository.saveAll(interestedCountries);
+    }
 }

--- a/src/main/java/com/example/solidconnection/location/country/service/InterestedCountryService.java
+++ b/src/main/java/com/example/solidconnection/location/country/service/InterestedCountryService.java
@@ -27,7 +27,7 @@ public class InterestedCountryService {
 
     @Transactional
     public void updateInterestedCountry(SiteUser siteUser, List<String> koreanNames) {
-        interestedCountryRepository.deleteBySiteUser(siteUser);
+        interestedCountryRepository.deleteBySiteUserId(siteUser.getId());
 
         List<InterestedCountry> interestedCountries = countryRepository.findAllByKoreanNameIn(koreanNames)
                 .stream()

--- a/src/main/java/com/example/solidconnection/location/region/repository/InterestedRegionRepository.java
+++ b/src/main/java/com/example/solidconnection/location/region/repository/InterestedRegionRepository.java
@@ -1,7 +1,6 @@
 package com.example.solidconnection.location.region.repository;
 
 import com.example.solidconnection.location.region.domain.InterestedRegion;
-import com.example.solidconnection.siteuser.domain.SiteUser;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -11,5 +10,5 @@ public interface InterestedRegionRepository extends JpaRepository<InterestedRegi
     List<InterestedRegion> findAllBySiteUserId(long siteUserId);
 
     @Modifying
-    void deleteBySiteUser(SiteUser siteUser);
+    void deleteBySiteUserId(long siteUserId);
 }

--- a/src/main/java/com/example/solidconnection/location/region/repository/InterestedRegionRepository.java
+++ b/src/main/java/com/example/solidconnection/location/region/repository/InterestedRegionRepository.java
@@ -1,10 +1,15 @@
 package com.example.solidconnection.location.region.repository;
 
 import com.example.solidconnection.location.region.domain.InterestedRegion;
+import com.example.solidconnection.siteuser.domain.SiteUser;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 
 public interface InterestedRegionRepository extends JpaRepository<InterestedRegion, Long> {
 
     List<InterestedRegion> findAllBySiteUserId(long siteUserId);
+
+    @Modifying
+    void deleteBySiteUser(SiteUser siteUser);
 }

--- a/src/main/java/com/example/solidconnection/location/region/repository/InterestedRegionRepository.java
+++ b/src/main/java/com/example/solidconnection/location/region/repository/InterestedRegionRepository.java
@@ -9,6 +9,6 @@ public interface InterestedRegionRepository extends JpaRepository<InterestedRegi
 
     List<InterestedRegion> findAllBySiteUserId(long siteUserId);
 
-    @Modifying
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     void deleteBySiteUserId(long siteUserId);
 }

--- a/src/main/java/com/example/solidconnection/location/region/service/InterestedRegionService.java
+++ b/src/main/java/com/example/solidconnection/location/region/service/InterestedRegionService.java
@@ -27,7 +27,7 @@ public class InterestedRegionService {
 
     @Transactional
     public void updateInterestedRegion(SiteUser siteUser, List<String> koreanNames) {
-        interestedRegionRepository.deleteBySiteUser(siteUser);
+        interestedRegionRepository.deleteBySiteUserId(siteUser.getId());
 
         List<InterestedRegion> interestedRegions = regionRepository.findAllByKoreanNameIn(koreanNames)
                 .stream()

--- a/src/main/java/com/example/solidconnection/location/region/service/InterestedRegionService.java
+++ b/src/main/java/com/example/solidconnection/location/region/service/InterestedRegionService.java
@@ -24,4 +24,15 @@ public class InterestedRegionService {
                 .toList();
         interestedRegionRepository.saveAll(interestedRegions);
     }
+
+    @Transactional
+    public void updateInterestedRegion(SiteUser siteUser, List<String> koreanNames) {
+        interestedRegionRepository.deleteBySiteUser(siteUser);
+
+        List<InterestedRegion> interestedRegions = regionRepository.findAllByKoreanNameIn(koreanNames)
+                .stream()
+                .map(region -> new InterestedRegion(siteUser, region))
+                .toList();
+        interestedRegionRepository.saveAll(interestedRegions);
+    }
 }

--- a/src/main/java/com/example/solidconnection/siteuser/controller/MyPageController.java
+++ b/src/main/java/com/example/solidconnection/siteuser/controller/MyPageController.java
@@ -2,6 +2,7 @@ package com.example.solidconnection.siteuser.controller;
 
 
 import com.example.solidconnection.common.resolver.AuthorizedUser;
+import com.example.solidconnection.siteuser.dto.LocationUpdateRequest;
 import com.example.solidconnection.siteuser.dto.MyPageResponse;
 import com.example.solidconnection.siteuser.dto.PasswordUpdateRequest;
 import com.example.solidconnection.siteuser.service.MyPageService;
@@ -47,6 +48,15 @@ class MyPageController {
             @RequestBody @Valid PasswordUpdateRequest request
     ) {
         myPageService.updatePassword(siteUserId, request);
+        return ResponseEntity.ok().build();
+    }
+
+    @PatchMapping("/location")
+    public ResponseEntity<Void> updateLocation(
+            @AuthorizedUser long siteUserId,
+            @RequestBody LocationUpdateRequest request
+            ) {
+        myPageService.updateLocation(siteUserId, request);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/example/solidconnection/siteuser/dto/LocationUpdateRequest.java
+++ b/src/main/java/com/example/solidconnection/siteuser/dto/LocationUpdateRequest.java
@@ -1,0 +1,10 @@
+package com.example.solidconnection.siteuser.dto;
+
+import java.util.List;
+
+public record LocationUpdateRequest(
+        List<String> interestedRegions,
+        List<String> interestedCountries
+) {
+
+}

--- a/src/main/java/com/example/solidconnection/siteuser/service/MyPageService.java
+++ b/src/main/java/com/example/solidconnection/siteuser/service/MyPageService.java
@@ -6,10 +6,13 @@ import static com.example.solidconnection.common.exception.ErrorCode.PASSWORD_MI
 import static com.example.solidconnection.common.exception.ErrorCode.USER_NOT_FOUND;
 
 import com.example.solidconnection.common.exception.CustomException;
+import com.example.solidconnection.location.country.service.InterestedCountryService;
+import com.example.solidconnection.location.region.service.InterestedRegionService;
 import com.example.solidconnection.s3.domain.ImgType;
 import com.example.solidconnection.s3.dto.UploadedFileUrlResponse;
 import com.example.solidconnection.s3.service.S3Service;
 import com.example.solidconnection.siteuser.domain.SiteUser;
+import com.example.solidconnection.siteuser.dto.LocationUpdateRequest;
 import com.example.solidconnection.siteuser.dto.MyPageResponse;
 import com.example.solidconnection.siteuser.dto.PasswordUpdateRequest;
 import com.example.solidconnection.siteuser.repository.SiteUserRepository;
@@ -33,6 +36,8 @@ public class MyPageService {
     private final SiteUserRepository siteUserRepository;
     private final LikedUnivApplyInfoRepository likedUnivApplyInfoRepository;
     private final S3Service s3Service;
+    private final InterestedCountryService interestedCountryService;
+    private final InterestedRegionService interestedRegionService;
 
     /*
      * 마이페이지 정보를 조회한다.
@@ -107,5 +112,14 @@ public class MyPageService {
         if (!passwordEncoder.matches(currentPassword, userPassword)) {
             throw new CustomException(PASSWORD_MISMATCH);
         }
+    }
+
+    @Transactional
+    public void updateLocation(long siteUserId, LocationUpdateRequest request) {
+        SiteUser siteUser = siteUserRepository.findById(siteUserId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        interestedCountryService.updateInterestedCountry(siteUser, request.interestedCountries());
+        interestedRegionService.updateInterestedRegion(siteUser, request.interestedRegions());
     }
 }

--- a/src/test/java/com/example/solidconnection/siteuser/service/MyPageServiceTest.java
+++ b/src/test/java/com/example/solidconnection/siteuser/service/MyPageServiceTest.java
@@ -286,7 +286,7 @@ class MyPageServiceTest {
 
             List<String> newCountries = List.of(캐나다.getKoreanName(), 일본.getKoreanName());
             List<String> newRegions = List.of(아시아.getKoreanName());
-            LocationUpdateRequest request = new LocationUpdateRequest(newCountries, newRegions);
+            LocationUpdateRequest request = new LocationUpdateRequest(newRegions, newCountries);
 
             // when
             myPageService.updateLocation(user.getId(), request);
@@ -310,7 +310,7 @@ class MyPageServiceTest {
             // given
             List<String> newCountries = List.of(미국.getKoreanName());
             List<String> newRegions = List.of(영미권.getKoreanName());
-            LocationUpdateRequest request = new LocationUpdateRequest(newCountries, newRegions);
+            LocationUpdateRequest request = new LocationUpdateRequest(newRegions, newCountries);
 
             // when
             myPageService.updateLocation(user.getId(), request);


### PR DESCRIPTION
## 관련 이슈

- resolves: #447 

## 작업 내용

<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

<img width="634" height="767" alt="image" src="https://github.com/user-attachments/assets/df2896c6-22d0-451c-9856-3fab545e4aec" />

관심 국가 및 지역을 수정하는 API를 구현하였습니다. UI 상에는 '관심 국가 변경' 탭만 있으나, 이 탭에서 지역도 변경할 수 있는 것으로 간주하고 구현하였습니다.

## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
