### PR TITLE
refactor: 멘토의 멘토링 목록 조회 시 isConfirmed 대신 verifyStatus를 응답하도록

### DIFF
--- a/src/main/java/com/example/solidconnection/mentor/dto/MentoringForMentorResponse.java
+++ b/src/main/java/com/example/solidconnection/mentor/dto/MentoringForMentorResponse.java
@@ -1,5 +1,6 @@
 package com.example.solidconnection.mentor.dto;
 
+import com.example.solidconnection.common.VerifyStatus;
 import com.example.solidconnection.mentor.domain.Mentoring;
 import com.example.solidconnection.siteuser.domain.SiteUser;
 import java.time.ZonedDateTime;
@@ -9,7 +10,7 @@ public record MentoringForMentorResponse(
         String profileImageUrl,
         String nickname,
         boolean isChecked,
-        boolean isConfirmed,
+        VerifyStatus verifyStatus,
         ZonedDateTime createdAt
 ) {
 
@@ -19,7 +20,7 @@ public record MentoringForMentorResponse(
                 partner.getProfileImageUrl(),
                 partner.getNickname(),
                 mentoring.getCheckedAtByMentor() != null,
-                mentoring.getConfirmedAt() != null,
+                mentoring.getVerifyStatus(),
                 mentoring.getCreatedAt()
         );
     }


### PR DESCRIPTION
## 관련 이슈

- resolves: #462 

## 작업 내용

https://github.com/solid-connection/api-docs/pull/45

프론트 만옥님의 요청에 따라
멘토가 멘토링 목록을 조회할 때, `isConfirmed` 대신 `verifyStatus`를 응답하게 합니다.

Dto만 수정된 간단한 수정입니다🤗

