### PR TITLE
refactor: 토큰을 Authorization 헤더가 아니라 쿼리스트링에서 가져오도록

### DIFF
--- a/src/main/java/com/example/solidconnection/chat/config/WebSocketHandshakeInterceptor.java
+++ b/src/main/java/com/example/solidconnection/chat/config/WebSocketHandshakeInterceptor.java
@@ -19,10 +19,9 @@ public class WebSocketHandshakeInterceptor implements HandshakeInterceptor {
 
         if (principal != null) {
             attributes.put("user", principal);
-            return true;
         }
 
-        return false;
+        return true;
     }
 
     @Override

--- a/src/main/java/com/example/solidconnection/security/filter/TokenAuthenticationFilter.java
+++ b/src/main/java/com/example/solidconnection/security/filter/TokenAuthenticationFilter.java
@@ -28,7 +28,7 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
     public void doFilterInternal(@NonNull HttpServletRequest request,
                                  @NonNull HttpServletResponse response,
                                  @NonNull FilterChain filterChain) throws ServletException, IOException {
-        Optional<String> token = authorizationHeaderParser.parseToken(request);
+        Optional<String> token = resolveToken(request);
         if (token.isEmpty()) {
             filterChain.doFilter(request, response);
             return;
@@ -39,5 +39,12 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
         SecurityContextHolder.getContext().setAuthentication(auth);
 
         filterChain.doFilter(request, response);
+    }
+
+    private Optional<String> resolveToken(HttpServletRequest request) {
+        if (request.getRequestURI().startsWith("/connect")) {
+            return Optional.ofNullable(request.getParameter("token"));
+        }
+        return authorizationHeaderParser.parseToken(request);
     }
 }

--- a/src/test/java/com/example/solidconnection/websocket/WebSocketStompIntegrationTest.java
+++ b/src/test/java/com/example/solidconnection/websocket/WebSocketStompIntegrationTest.java
@@ -2,8 +2,7 @@ package com.example.solidconnection.websocket;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.ThrowableAssert.catchThrowable;
-import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.example.solidconnection.auth.service.AccessToken;
 import com.example.solidconnection.auth.service.AuthTokenProvider;
@@ -11,9 +10,8 @@ import com.example.solidconnection.siteuser.domain.SiteUser;
 import com.example.solidconnection.siteuser.fixture.SiteUserFixture;
 import com.example.solidconnection.support.TestContainerSpringBootTest;
 import java.util.List;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -22,11 +20,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.messaging.converter.MappingJackson2MessageConverter;
-import org.springframework.messaging.simp.stomp.StompHeaders;
 import org.springframework.messaging.simp.stomp.StompSession;
 import org.springframework.messaging.simp.stomp.StompSessionHandlerAdapter;
 import org.springframework.web.client.HttpClientErrorException;
-import org.springframework.web.socket.WebSocketHttpHeaders;
 import org.springframework.web.socket.client.standard.StandardWebSocketClient;
 import org.springframework.web.socket.messaging.WebSocketStompClient;
 import org.springframework.web.socket.sockjs.client.SockJsClient;
@@ -67,48 +63,28 @@ class WebSocketStompIntegrationTest {
     @Nested
     class WebSocket_핸드셰이크_및_STOMP_세션_수립_테스트 {
 
-        private final BlockingQueue<Throwable> transportErrorQueue = new ArrayBlockingQueue<>(1);
-
-        private final StompSessionHandlerAdapter sessionHandler = new StompSessionHandlerAdapter() {
-            @Override
-            public void handleTransportError(StompSession session, Throwable exception) {
-                transportErrorQueue.add(exception);
-            }
-        };
-
         @Test
         void 인증된_사용자는_핸드셰이크를_성공한다() throws Exception {
             // given
             SiteUser user = siteUserFixture.사용자();
             AccessToken accessToken = authTokenProvider.generateAccessToken(user);
-
-            WebSocketHttpHeaders handshakeHeaders = new WebSocketHttpHeaders();
-            handshakeHeaders.add("Authorization", "Bearer " + accessToken.token());
+            String tokenUrl = url + "?token=" + accessToken.token();
 
             // when
-            stompSession = stompClient.connectAsync(url, handshakeHeaders, new StompHeaders(), sessionHandler).get(5, SECONDS);
+            stompSession = stompClient.connectAsync(tokenUrl, new StompSessionHandlerAdapter() {}).get(5, SECONDS);
 
             // then
-            assertAll(
-                    () -> assertThat(stompSession).isNotNull(),
-                    () -> assertThat(transportErrorQueue).isEmpty()
-            );
+            assertThat(stompSession.isConnected()).isTrue();
         }
 
         @Test
         void 인증되지_않은_사용자는_핸드셰이크를_실패한다() {
-            // when
-            Throwable thrown = catchThrowable(() -> {
-                stompSession = stompClient.connectAsync(url, new WebSocketHttpHeaders(), new StompHeaders(), sessionHandler).get(5, SECONDS);
-            });
-
-            // then
-            assertAll(
-                    () -> assertThat(thrown)
-                            .isInstanceOf(ExecutionException.class)
-                            .hasCauseInstanceOf(HttpClientErrorException.Unauthorized.class),
-                    () -> assertThat(transportErrorQueue).hasSize(1)
-            );
+            // when & then
+            assertThatThrownBy(() -> {
+                stompClient.connectAsync(url, new StompSessionHandlerAdapter() {
+                }).get(5, TimeUnit.SECONDS);
+            }).isInstanceOf(ExecutionException.class)
+                    .hasCauseInstanceOf(HttpClientErrorException.Unauthorized.class);
         }
     }
 }


### PR DESCRIPTION
## 관련 이슈

- resolves: #466 

## 작업 내용

<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

SockJS로 WebSocket 핸드셰이킹을 진행하는 경우 해당 HTTP 요청의 Authorization 헤더에 토큰을 포함시키는 기능을 지원하지 않습니다. 따라서 기존 방법을 사용하면 인증된 사용자 정보를 가져올 수 없게 됩니다.

토큰을 쿼리스트링을 통해 받도록 변경합니다.

[[관련 논의]](https://discord.com/channels/1367119049074671626/1406455318187343993/1406910344818855956)

## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
