### PR TITLE
refactor: 채팅방 관련 n + 1 문제 개선

### DIFF
--- a/src/main/java/com/example/solidconnection/chat/dto/ChatRoomData.java
+++ b/src/main/java/com/example/solidconnection/chat/dto/ChatRoomData.java
@@ -1,0 +1,24 @@
+package com.example.solidconnection.chat.dto;
+
+import com.example.solidconnection.chat.domain.ChatMessage;
+import com.example.solidconnection.siteuser.domain.SiteUser;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public record ChatRoomData(
+        Map<Long, ChatMessage> latestMessages,
+        Map<Long, Long> unreadCounts,
+        Map<Long, SiteUser> partnerUsers
+) {
+
+    public static ChatRoomData from(List<ChatMessage> latestMessages,
+                                    List<UnreadCountDto> unreadCounts,
+                                    List<SiteUser> partnerUsers) {
+        return new ChatRoomData(
+                latestMessages.stream().collect(Collectors.toMap(msg -> msg.getChatRoom().getId(), msg -> msg)),
+                unreadCounts.stream().collect(Collectors.toMap(UnreadCountDto::chatRoomId, UnreadCountDto::count)),
+                partnerUsers.stream().collect(Collectors.toMap(SiteUser::getId, user -> user))
+        );
+    }
+}

--- a/src/main/java/com/example/solidconnection/chat/dto/UnreadCountDto.java
+++ b/src/main/java/com/example/solidconnection/chat/dto/UnreadCountDto.java
@@ -1,0 +1,8 @@
+package com.example.solidconnection.chat.dto;
+
+public record UnreadCountDto(
+        long chatRoomId,
+        long count
+) {
+
+}

--- a/src/main/java/com/example/solidconnection/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/example/solidconnection/chat/repository/ChatMessageRepository.java
@@ -1,7 +1,8 @@
 package com.example.solidconnection.chat.repository;
 
 import com.example.solidconnection.chat.domain.ChatMessage;
-import java.util.Optional;
+import com.example.solidconnection.chat.dto.UnreadCountDto;
+import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -18,5 +19,33 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
            """)
     Slice<ChatMessage> findByRoomIdWithPaging(@Param("roomId") long roomId, Pageable pageable);
 
-    Optional<ChatMessage> findFirstByChatRoomIdOrderByCreatedAtDesc(long chatRoomId);
+    @Query("""
+           SELECT cm FROM ChatMessage cm
+           WHERE cm.id IN (
+               SELECT MAX(cm2.id)
+               FROM ChatMessage cm2
+               WHERE cm2.chatRoom.id IN :chatRoomIds
+               GROUP BY cm2.chatRoom.id
+           )
+           """)
+    List<ChatMessage> findLatestMessagesByChatRoomIds(@Param("chatRoomIds") List<Long> chatRoomIds);
+
+    @Query("""
+           SELECT new com.example.solidconnection.chat.dto.UnreadCountDto(
+               cm.chatRoom.id,
+               COUNT(cm)
+           )
+           FROM ChatMessage cm
+           LEFT JOIN ChatReadStatus crs ON crs.chatRoomId = cm.chatRoom.id
+               AND crs.chatParticipantId = (
+                   SELECT cp.id FROM ChatParticipant cp
+                   WHERE cp.chatRoom.id = cm.chatRoom.id
+                   AND cp.siteUserId = :userId
+               )
+           WHERE cm.chatRoom.id IN :chatRoomIds
+           AND cm.senderId != :userId
+           AND (crs.updatedAt IS NULL OR cm.createdAt > crs.updatedAt)
+           GROUP BY cm.chatRoom.id
+           """)
+    List<UnreadCountDto> countUnreadMessagesBatch(@Param("chatRoomIds") List<Long> chatRoomIds, @Param("userId") long userId);
 }

--- a/src/main/java/com/example/solidconnection/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/example/solidconnection/chat/repository/ChatRoomRepository.java
@@ -9,30 +9,21 @@ import org.springframework.data.repository.query.Param;
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
     @Query("""
-           SELECT cr FROM ChatRoom cr
-           JOIN cr.chatParticipants cp
-           WHERE cp.siteUserId = :userId AND cr.isGroup = false
+           SELECT DISTINCT cr FROM ChatRoom cr
+           JOIN FETCH cr.chatParticipants
+           WHERE cr.id IN (
+               SELECT DISTINCT cp2.chatRoom.id
+               FROM ChatParticipant cp2
+               WHERE cp2.siteUserId = :userId
+           )
+           AND cr.isGroup = false
            ORDER BY (
                SELECT MAX(cm.createdAt)
                FROM ChatMessage cm
                WHERE cm.chatRoom = cr
            ) DESC NULLS LAST
            """)
-    List<ChatRoom> findOneOnOneChatRoomsByUserId(@Param("userId") long userId);
-
-    @Query("""
-           SELECT COUNT(cm) FROM ChatMessage cm
-           LEFT JOIN ChatReadStatus crs ON crs.chatRoomId = cm.chatRoom.id 
-               AND crs.chatParticipantId = (
-                   SELECT cp.id FROM ChatParticipant cp 
-                   WHERE cp.chatRoom.id = :chatRoomId 
-                   AND cp.siteUserId = :userId
-               )
-           WHERE cm.chatRoom.id = :chatRoomId
-           AND cm.senderId != :userId
-           AND (crs.updatedAt IS NULL OR cm.createdAt > crs.updatedAt)
-           """)
-    long countUnreadMessages(@Param("chatRoomId") long chatRoomId, @Param("userId") long userId);
+    List<ChatRoom> findOneOnOneChatRoomsByUserIdWithParticipants(@Param("userId") long userId);
 
     boolean existsByMentoringId(long mentoringId);
 }

--- a/src/main/java/com/example/solidconnection/chat/service/ChatService.java
+++ b/src/main/java/com/example/solidconnection/chat/service/ChatService.java
@@ -15,6 +15,7 @@ import com.example.solidconnection.chat.dto.ChatMessageSendResponse;
 import com.example.solidconnection.chat.dto.ChatParticipantResponse;
 import com.example.solidconnection.chat.dto.ChatRoomListResponse;
 import com.example.solidconnection.chat.dto.ChatRoomResponse;
+import com.example.solidconnection.chat.dto.UnreadCountDto;
 import com.example.solidconnection.chat.repository.ChatMessageRepository;
 import com.example.solidconnection.chat.repository.ChatParticipantRepository;
 import com.example.solidconnection.chat.repository.ChatReadStatusRepository;
@@ -25,7 +26,8 @@ import com.example.solidconnection.siteuser.domain.SiteUser;
 import com.example.solidconnection.siteuser.repository.SiteUserRepository;
 import java.time.ZonedDateTime;
 import java.util.List;
-import java.util.Optional;
+import java.util.Map;
+import java.util.stream.Collectors;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -60,28 +62,71 @@ public class ChatService {
 
     @Transactional(readOnly = true)
     public ChatRoomListResponse getChatRooms(long siteUserId) {
-        // todo : n + 1 문제 해결 필요!
-        List<ChatRoom> chatRooms = chatRoomRepository.findOneOnOneChatRoomsByUserId(siteUserId);
-        List<ChatRoomResponse> chatRoomInfos = chatRooms.stream()
-                .map(chatRoom -> toChatRoomResponse(chatRoom, siteUserId))
+        List<ChatRoom> chatRooms = chatRoomRepository.findOneOnOneChatRoomsByUserIdWithParticipants(siteUserId);
+        List<Long> chatRoomIds = chatRooms.stream()
+                .map(ChatRoom::getId)
                 .toList();
-        return ChatRoomListResponse.of(chatRoomInfos);
+
+        List<ChatMessage> latestMessages = chatMessageRepository.findLatestMessagesByChatRoomIds(chatRoomIds);
+        List<UnreadCountDto> unreadCounts = chatMessageRepository.countUnreadMessagesBatch(chatRoomIds, siteUserId);
+        List<Long> partnerUserIds = chatRooms.stream()
+                .map(chatRoom -> findPartner(chatRoom, siteUserId).getSiteUserId())
+                .toList();
+        List<SiteUser> partnerUsers = siteUserRepository.findAllByIdIn(partnerUserIds);
+
+        Map<Long, ChatMessage> latestMessageMap = latestMessages.stream()
+                .collect(Collectors.toMap(
+                        msg -> msg.getChatRoom().getId(),
+                        msg -> msg
+                ));
+        Map<Long, Long> unreadCountMap = unreadCounts.stream()
+                .collect(Collectors.toMap(
+                        UnreadCountDto::chatRoomId,
+                        UnreadCountDto::count
+                ));
+        Map<Long, SiteUser> partnerUserMap = partnerUsers.stream()
+                .collect(Collectors.toMap(SiteUser::getId, user -> user));
+
+        List<ChatRoomResponse> chatRoomResponses = chatRooms.stream()
+                .map(chatRoom -> toChatRoomResponse(
+                        chatRoom,
+                        siteUserId,
+                        latestMessageMap,
+                        unreadCountMap,
+                        partnerUserMap
+                ))
+                .toList();
+
+        return ChatRoomListResponse.of(chatRoomResponses);
     }
 
-    private ChatRoomResponse toChatRoomResponse(ChatRoom chatRoom, long siteUserId) {
-        Optional<ChatMessage> latestMessage = chatMessageRepository.findFirstByChatRoomIdOrderByCreatedAtDesc(chatRoom.getId());
-        String lastChatMessage = latestMessage.map(ChatMessage::getContent).orElse("");
-        ZonedDateTime lastReceivedTime = latestMessage.map(ChatMessage::getCreatedAt).orElse(null);
+    private ChatRoomResponse toChatRoomResponse(
+            ChatRoom chatRoom,
+            long siteUserId,
+            Map<Long, ChatMessage> latestMessageMap,
+            Map<Long, Long> unreadCountMap,
+            Map<Long, SiteUser> partnerUserMap) {
+
+        ChatMessage latestMessage = latestMessageMap.get(chatRoom.getId());
+        String lastChatMessage = latestMessage != null ? latestMessage.getContent() : "";
+        ZonedDateTime lastReceivedTime = latestMessage != null ? latestMessage.getCreatedAt() : null;
 
         ChatParticipant partnerParticipant = findPartner(chatRoom, siteUserId);
+        SiteUser partnerUser = partnerUserMap.get(partnerParticipant.getSiteUserId());
 
-        SiteUser siteUser = siteUserRepository.findById(partnerParticipant.getSiteUserId())
-                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
-        ChatParticipantResponse partner = ChatParticipantResponse.of(siteUser.getId(), siteUser.getNickname(), siteUser.getProfileImageUrl());
+        if (partnerUser == null) {
+            throw new CustomException(USER_NOT_FOUND);
+        }
 
-        long unReadCount = chatRoomRepository.countUnreadMessages(chatRoom.getId(), siteUserId);
+        ChatParticipantResponse partner = ChatParticipantResponse.of(
+                partnerUser.getId(),
+                partnerUser.getNickname(),
+                partnerUser.getProfileImageUrl()
+        );
 
-        return ChatRoomResponse.of(chatRoom.getId(), lastChatMessage, lastReceivedTime, partner, unReadCount);
+        long unreadCount = unreadCountMap.getOrDefault(chatRoom.getId(), 0L);
+
+        return ChatRoomResponse.of(chatRoom.getId(), lastChatMessage, lastReceivedTime, partner, unreadCount);
     }
 
     private ChatParticipant findPartner(ChatRoom chatRoom, long siteUserId) {

--- a/src/main/java/com/example/solidconnection/siteuser/repository/SiteUserRepository.java
+++ b/src/main/java/com/example/solidconnection/siteuser/repository/SiteUserRepository.java
@@ -19,4 +19,6 @@ public interface SiteUserRepository extends JpaRepository<SiteUser, Long> {
 
     @Query("SELECT u FROM SiteUser u WHERE u.quitedAt <= :cutoffDate")
     List<SiteUser> findUsersToBeRemoved(@Param("cutoffDate") LocalDate cutoffDate);
+
+    List<SiteUser> findAllByIdIn(List<Long> ids);
 }


### PR DESCRIPTION
## 관련 이슈

- resolves: #458

## 작업 내용

채팅방 조회 n + 1 문제를 개선하였습니다.

### AS-IS
- 1 + 3N 쿼리 발생
- 사용자 조회 (1개)
- 채팅방 조회 (1개)
- 각 채팅방별 반복 (3N개) -> 최신 메시지 조회(N), 사용자 조회(N), 안읽은 메시지 수 조회(N)
- 참가자 배치 조회(1개) - @BatchSize(10)

### TO-BE
- 5개 쿼리 발생(고정)
- 사용자 조회 (1개) - 동일
- 채팅방 + 참가자 한번에 조회 (1개)
- 최신 메시지들 배치 조회 (1개)
- 안읽은 메시지 수들 배치 조회 (1개)
- 파트너 사용자들 배치 조회 (1개)

### 해결 방법

1. JOIN FETCH 활용

기존: 채팅방 조회 → 참가자 개별 조회 (N+1)
개선: 채팅방 + 참가자 한번에 조회

2. 배치 활용:

기존: 각 채팅방별로 개별 쿼리 (× 3)
개선: WHERE ... IN (chatRoomIds) 로 배치 처리

3. 메모리 + Map 활용:

DB에서 가져온 데이터를 Map으로 변환 후 메모리에서 조합
추가 DB 접근 없이 Response 생성

채팅방 만약 20개였다면 62개(1 + 1 + 3N + 2)가 나가던 쿼리가 5개로 줄어들었습니다.
<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
