### PR TITLE
feat: 매칭된 멘티/멘토 정보 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/solidconnection/mentor/controller/MentoringForMenteeController.java
+++ b/src/main/java/com/example/solidconnection/mentor/controller/MentoringForMenteeController.java
@@ -5,6 +5,7 @@ import com.example.solidconnection.common.dto.SliceResponse;
 import com.example.solidconnection.common.resolver.AuthorizedUser;
 import com.example.solidconnection.mentor.dto.CheckMentoringRequest;
 import com.example.solidconnection.mentor.dto.CheckedMentoringsResponse;
+import com.example.solidconnection.mentor.dto.MatchedMentorResponse;
 import com.example.solidconnection.mentor.dto.MentoringApplyRequest;
 import com.example.solidconnection.mentor.dto.MentoringApplyResponse;
 import com.example.solidconnection.mentor.dto.MentoringForMenteeResponse;
@@ -37,6 +38,21 @@ public class MentoringForMenteeController {
     private final MentoringCommandService mentoringCommandService;
     private final MentoringQueryService mentoringQueryService;
     private final MentoringCheckService mentoringCheckService;
+
+    @RequireRoleAccess(roles = Role.MENTEE)
+    @GetMapping("/matched-mentors")
+    public ResponseEntity<SliceResponse<MatchedMentorResponse>> getMatchedMentors(
+            @AuthorizedUser long siteUserId,
+            @PageableDefault
+            @SortDefaults({
+                    @SortDefault(sort = "menteeCount", direction = Sort.Direction.DESC),
+                    @SortDefault(sort = "id", direction = Sort.Direction.ASC)
+            })
+            Pageable pageable
+    ) {
+        SliceResponse<MatchedMentorResponse> response = mentoringQueryService.getMatchedMentors(siteUserId, pageable);
+        return ResponseEntity.ok(response);
+    }
 
     @RequireRoleAccess(roles = Role.MENTEE)
     @PostMapping

--- a/src/main/java/com/example/solidconnection/mentor/controller/MentoringForMenteeController.java
+++ b/src/main/java/com/example/solidconnection/mentor/controller/MentoringForMenteeController.java
@@ -45,8 +45,8 @@ public class MentoringForMenteeController {
             @AuthorizedUser long siteUserId,
             @PageableDefault
             @SortDefaults({
-                    @SortDefault(sort = "menteeCount", direction = Sort.Direction.DESC),
-                    @SortDefault(sort = "id", direction = Sort.Direction.ASC)
+                    @SortDefault(sort = "confirmedAt", direction = Sort.Direction.DESC),
+                    @SortDefault(sort = "id", direction = Sort.Direction.DESC)
             })
             Pageable pageable
     ) {

--- a/src/main/java/com/example/solidconnection/mentor/dto/MatchedMentorResponse.java
+++ b/src/main/java/com/example/solidconnection/mentor/dto/MatchedMentorResponse.java
@@ -1,0 +1,46 @@
+package com.example.solidconnection.mentor.dto;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+import com.example.solidconnection.mentor.domain.Mentor;
+import com.example.solidconnection.siteuser.domain.SiteUser;
+import com.example.solidconnection.university.domain.University;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.List;
+
+public record MatchedMentorResponse(
+        long id,
+
+        @JsonInclude(NON_NULL)
+        Long roomId,
+
+        String nickname,
+        String profileImageUrl,
+        String country,
+        String universityName,
+        String term,
+        int menteeCount,
+        boolean hasBadge,
+        String introduction,
+        List<ChannelResponse> channels,
+        boolean isApplied
+) {
+
+    public static MatchedMentorResponse of(Mentor mentor, SiteUser mentorUser,
+                                           University university, boolean isApplied, Long roomId) {
+        return new MatchedMentorResponse(
+                mentor.getId(),
+                roomId,
+                mentorUser.getNickname(),
+                mentorUser.getProfileImageUrl(),
+                university.getCountry().getKoreanName(),
+                university.getKoreanName(),
+                mentor.getTerm(),
+                mentor.getMenteeCount(),
+                mentor.isHasBadge(),
+                mentor.getIntroduction(),
+                mentor.getChannels().stream().map(ChannelResponse::from).toList(),
+                isApplied
+        );
+    }
+}

--- a/src/main/java/com/example/solidconnection/mentor/repository/MentorRepository.java
+++ b/src/main/java/com/example/solidconnection/mentor/repository/MentorRepository.java
@@ -1,5 +1,6 @@
 package com.example.solidconnection.mentor.repository;
 
+import com.example.solidconnection.common.VerifyStatus;
 import com.example.solidconnection.location.region.domain.Region;
 import com.example.solidconnection.mentor.domain.Mentor;
 import java.util.Optional;
@@ -23,4 +24,14 @@ public interface MentorRepository extends JpaRepository<Mentor, Long> {
            WHERE u.region = :region
            """)
     Slice<Mentor> findAllByRegion(@Param("region") Region region, Pageable pageable);
+
+    @Query("""
+           SELECT m FROM Mentor m
+           WHERE m.id IN (
+               SELECT mt.mentorId FROM Mentoring mt
+               WHERE mt.menteeId = :menteeId
+               AND mt.verifyStatus = :verifyStatus
+           )
+           """)
+    Slice<Mentor> findApprovedMentorsByMenteeId(@Param("menteeId") long menteeId, @Param("verifyStatus") VerifyStatus verifyStatus, Pageable pageable);
 }

--- a/src/main/java/com/example/solidconnection/mentor/repository/MentorRepository.java
+++ b/src/main/java/com/example/solidconnection/mentor/repository/MentorRepository.java
@@ -1,6 +1,5 @@
 package com.example.solidconnection.mentor.repository;
 
-import com.example.solidconnection.common.VerifyStatus;
 import com.example.solidconnection.location.region.domain.Region;
 import com.example.solidconnection.mentor.domain.Mentor;
 import java.util.Optional;
@@ -24,14 +23,4 @@ public interface MentorRepository extends JpaRepository<Mentor, Long> {
            WHERE u.region = :region
            """)
     Slice<Mentor> findAllByRegion(@Param("region") Region region, Pageable pageable);
-
-    @Query("""
-           SELECT m FROM Mentor m
-           WHERE m.id IN (
-               SELECT mt.mentorId FROM Mentoring mt
-               WHERE mt.menteeId = :menteeId
-               AND mt.verifyStatus = :verifyStatus
-           )
-           """)
-    Slice<Mentor> findApprovedMentorsByMenteeId(@Param("menteeId") long menteeId, @Param("verifyStatus") VerifyStatus verifyStatus, Pageable pageable);
 }

--- a/src/main/java/com/example/solidconnection/mentor/repository/MentoringRepository.java
+++ b/src/main/java/com/example/solidconnection/mentor/repository/MentoringRepository.java
@@ -28,4 +28,12 @@ public interface MentoringRepository extends JpaRepository<Mentoring, Long> {
            WHERE m.mentorId IN :mentorIds AND m.menteeId = :menteeId
            """)
     List<Mentoring> findAllByMentorIdInAndMenteeId(@Param("mentorIds") List<Long> mentorIds, @Param("menteeId") long menteeId);
+
+    @Query("""
+           SELECT m FROM Mentoring m
+           WHERE m.menteeId = :menteeId
+           AND m.mentorId IN :mentorIds
+           AND m.verifyStatus = :verifyStatus
+           """)
+    List<Mentoring> findApprovedMentoringsByMenteeIdAndMentorIds(@Param("menteeId") long menteeId, @Param("verifyStatus") VerifyStatus verifyStatus, @Param("mentorIds") List<Long> mentorIds);
 }

--- a/src/main/java/com/example/solidconnection/mentor/repository/MentoringRepository.java
+++ b/src/main/java/com/example/solidconnection/mentor/repository/MentoringRepository.java
@@ -36,4 +36,7 @@ public interface MentoringRepository extends JpaRepository<Mentoring, Long> {
            AND m.verifyStatus = :verifyStatus
            """)
     List<Mentoring> findApprovedMentoringsByMenteeIdAndMentorIds(@Param("menteeId") long menteeId, @Param("verifyStatus") VerifyStatus verifyStatus, @Param("mentorIds") List<Long> mentorIds);
+
+    @Query("SELECT m FROM Mentoring m WHERE m.menteeId = :menteeId AND m.verifyStatus = :verifyStatus")
+    Slice<Mentoring> findApprovedMentoringsByMenteeId(long menteeId, @Param("verifyStatus") VerifyStatus verifyStatus, Pageable pageable);
 }


### PR DESCRIPTION
## 관련 이슈

- resolves: #478

## 작업 내용
매칭된 멘티/멘토 정보 조회 기능 구현합니다.
<img width="1596" height="1370" alt="스크린샷 2025-08-25 오후 10 42 02" src="https://github.com/user-attachments/assets/6960e0ff-5f50-4461-85ca-620557057d4c" />

[브루노 pr](https://github.com/solid-connection/api-docs/pull/50)
<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
