### PR TITLE
feat: 차단 관련 api 구현

### DIFF
--- a/src/main/java/com/example/solidconnection/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/solidconnection/common/exception/ErrorCode.java
@@ -47,6 +47,7 @@ public enum ErrorCode {
     REPORT_TARGET_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "존재하지 않는 신고 대상입니다."),
     CHAT_PARTNER_NOT_FOUND(HttpStatus.BAD_REQUEST.value(), "채팅 상대를 찾을 수 없습니다."),
     CHAT_PARTICIPANT_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "채팅 참여자를 찾을 수 없습니다."),
+    BLOCK_USER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "차단 대상 사용자를 찾을 수 없습니다."),
 
     // auth
     USER_ALREADY_SIGN_OUT(HttpStatus.UNAUTHORIZED.value(), "로그아웃 되었습니다."),

--- a/src/main/java/com/example/solidconnection/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/solidconnection/common/exception/ErrorCode.java
@@ -126,6 +126,10 @@ public enum ErrorCode {
     // report
     ALREADY_REPORTED_BY_CURRENT_USER(HttpStatus.BAD_REQUEST.value(), "이미 신고한 상태입니다."),
 
+    // block
+    ALREADY_BLOCKED_BY_CURRENT_USER(HttpStatus.BAD_REQUEST.value(), "이미 차단한 상태입니다."),
+    CANNOT_BLOCK_YOURSELF(HttpStatus.BAD_REQUEST.value(), "자기 자신을 차단할 수 없습니다."),
+
     // chat
     INVALID_CHAT_ROOM_STATE(HttpStatus.BAD_REQUEST.value(), "잘못된 채팅방 상태입니다."),
 

--- a/src/main/java/com/example/solidconnection/community/board/controller/BoardController.java
+++ b/src/main/java/com/example/solidconnection/community/board/controller/BoardController.java
@@ -33,11 +33,11 @@ public class BoardController {
 
     @GetMapping("/{code}")
     public ResponseEntity<?> findPostsByCodeAndCategory(
-            @AuthorizedUser long siteUserId, // todo: '사용하지 않는 인자'로 인증된 유저만 접근하게 하기보다는, 다른 방식으로 접근하는것이 좋을 것 같다
+            @AuthorizedUser(required = false) Long siteUserId,
             @PathVariable(value = "code") String code,
             @RequestParam(value = "category", defaultValue = "전체") String category) {
         List<PostListResponse> postsByCodeAndPostCategory = postQueryService
-                .findPostsByCodeAndPostCategory(code, category);
+                .findPostsByCodeAndPostCategory(code, category, siteUserId);
         return ResponseEntity.ok().body(postsByCodeAndPostCategory);
     }
 }

--- a/src/main/java/com/example/solidconnection/community/comment/repository/CommentRepository.java
+++ b/src/main/java/com/example/solidconnection/community/comment/repository/CommentRepository.java
@@ -36,7 +36,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
                SELECT * FROM CommentTree
                ORDER BY path
                """, nativeQuery = true)
-    List<Comment> findCommentTreeByPostId(@Param("postId") Long postId, @Param("siteUserId") Long siteUserId);
+    List<Comment> findCommentTreeByPostIdExcludingBlockedUsers(@Param("postId") Long postId, @Param("siteUserId") Long siteUserId);
 
     default Comment getById(Long id) {
         return findById(id)

--- a/src/main/java/com/example/solidconnection/community/comment/repository/CommentRepository.java
+++ b/src/main/java/com/example/solidconnection/community/comment/repository/CommentRepository.java
@@ -12,25 +12,31 @@ import org.springframework.data.repository.query.Param;
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     @Query(value = """
-                   WITH RECURSIVE CommentTree AS (
-                           SELECT
-                                   id, parent_id, post_id, site_user_id, content,
-                                   created_at, updated_at, is_deleted,
-                                   0 AS level, CAST(id AS CHAR(255)) AS path
-                           FROM comment
-                           WHERE post_id = :postId AND parent_id IS NULL
-                           UNION ALL
-                           SELECT
-                                   c.id, c.parent_id, c.post_id, c.site_user_id, c.content,
-                                   c.created_at, c.updated_at, c.is_deleted,
-                                   ct.level + 1, CONCAT(ct.path, '->', c.id)
-                           FROM comment c
-                           INNER JOIN CommentTree ct ON c.parent_id = ct.id
-                   )
-                   SELECT * FROM CommentTree
-                   ORDER BY path
-                   """, nativeQuery = true)
-    List<Comment> findCommentTreeByPostId(@Param("postId") Long postId);
+               WITH RECURSIVE CommentTree AS (
+                       SELECT
+                               id, parent_id, post_id, site_user_id, content,
+                               created_at, updated_at, is_deleted,
+                               0 AS level, CAST(id AS CHAR(255)) AS path
+                       FROM comment
+                       WHERE post_id = :postId AND parent_id IS NULL
+                       AND site_user_id NOT IN (
+                           SELECT blocked_id FROM user_block WHERE blocker_id = :siteUserId
+                       )
+                       UNION ALL
+                       SELECT
+                               c.id, c.parent_id, c.post_id, c.site_user_id, c.content,
+                               c.created_at, c.updated_at, c.is_deleted,
+                               ct.level + 1, CONCAT(ct.path, '->', c.id)
+                       FROM comment c
+                       INNER JOIN CommentTree ct ON c.parent_id = ct.id
+                       WHERE c.site_user_id NOT IN (
+                           SELECT blocked_id FROM user_block WHERE blocker_id = :siteUserId
+                       )
+               )
+               SELECT * FROM CommentTree
+               ORDER BY path
+               """, nativeQuery = true)
+    List<Comment> findCommentTreeByPostId(@Param("postId") Long postId, @Param("siteUserId") Long siteUserId);
 
     default Comment getById(Long id) {
         return findById(id)

--- a/src/main/java/com/example/solidconnection/community/comment/service/CommentService.java
+++ b/src/main/java/com/example/solidconnection/community/comment/service/CommentService.java
@@ -40,7 +40,7 @@ public class CommentService {
     public List<PostFindCommentResponse> findCommentsByPostId(long siteUserId, Long postId) {
         SiteUser siteUser = siteUserRepository.findById(siteUserId)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
-        List<Comment> allComments = commentRepository.findCommentTreeByPostId(postId, siteUserId);
+        List<Comment> allComments = commentRepository.findCommentTreeByPostIdExcludingBlockedUsers(postId, siteUserId);
         List<Comment> filteredComments = filterCommentsByDeletionRules(allComments);
 
         Set<Long> userIds = filteredComments.stream()

--- a/src/main/java/com/example/solidconnection/community/comment/service/CommentService.java
+++ b/src/main/java/com/example/solidconnection/community/comment/service/CommentService.java
@@ -40,7 +40,7 @@ public class CommentService {
     public List<PostFindCommentResponse> findCommentsByPostId(long siteUserId, Long postId) {
         SiteUser siteUser = siteUserRepository.findById(siteUserId)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
-        List<Comment> allComments = commentRepository.findCommentTreeByPostId(postId);
+        List<Comment> allComments = commentRepository.findCommentTreeByPostId(postId, siteUserId);
         List<Comment> filteredComments = filterCommentsByDeletionRules(allComments);
 
         Set<Long> userIds = filteredComments.stream()

--- a/src/main/java/com/example/solidconnection/community/post/repository/PostRepository.java
+++ b/src/main/java/com/example/solidconnection/community/post/repository/PostRepository.java
@@ -16,6 +16,15 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     List<Post> findByBoardCode(String boardCode);
 
+    @Query("""
+       SELECT p FROM Post p
+       WHERE p.boardCode = :boardCode
+       AND p.siteUserId NOT IN (
+           SELECT ub.blockedId FROM UserBlock ub WHERE ub.blockerId = :siteUserId
+       )
+       """)
+    List<Post> findByBoardCodeExcludingBlockedUsers(@Param("boardCode") String boardCode, @Param("siteUserId") Long siteUserId);
+
     @EntityGraph(attributePaths = {"postImageList"})
     Optional<Post> findPostById(Long id);
 

--- a/src/main/java/com/example/solidconnection/community/post/service/PostQueryService.java
+++ b/src/main/java/com/example/solidconnection/community/post/service/PostQueryService.java
@@ -43,13 +43,18 @@ public class PostQueryService {
     private final RedisUtils redisUtils;
 
     @Transactional(readOnly = true)
-    public List<PostListResponse> findPostsByCodeAndPostCategory(String code, String category) {
+    public List<PostListResponse> findPostsByCodeAndPostCategory(String code, String category, Long siteUserId) {
 
         String boardCode = validateCode(code);
         PostCategory postCategory = validatePostCategory(category);
         boardRepository.getByCode(boardCode);
-        List<Post> postList = postRepository.findByBoardCode(boardCode);
 
+        List<Post> postList; // todo : 추후 개선 필요(현재 최신순으로 응답나가지 않고 있음)
+        if (siteUserId != null) {
+            postList = postRepository.findByBoardCodeExcludingBlockedUsers(boardCode, siteUserId);
+        } else {
+            postList = postRepository.findByBoardCode(boardCode);
+        }
         return PostListResponse.from(getPostListByPostCategory(postList, postCategory));
     }
 

--- a/src/main/java/com/example/solidconnection/community/post/service/PostQueryService.java
+++ b/src/main/java/com/example/solidconnection/community/post/service/PostQueryService.java
@@ -67,10 +67,7 @@ public class PostQueryService {
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
         Post post = postRepository.getByIdUsingEntityGraph(postId);
 
-        boolean isBlockedByMe = userBlockRepository.existsByBlockerIdAndBlockedId(siteUserId, post.getSiteUserId());
-        if (isBlockedByMe) {
-            throw new CustomException(ACCESS_DENIED);
-        }
+        validatedIsBlockedByMe(post, siteUser);
 
         Boolean isOwner = getIsOwner(post, siteUser);
         Boolean isLiked = getIsLiked(post, siteUser);
@@ -124,5 +121,11 @@ public class PostQueryService {
         return postList.stream()
                 .filter(post -> post.getCategory().equals(postCategory))
                 .collect(Collectors.toList());
+    }
+
+    private void validatedIsBlockedByMe(Post post, SiteUser siteUser) {
+        if (userBlockRepository.existsByBlockerIdAndBlockedId(siteUser.getId(), post.getSiteUserId())) {
+            throw new CustomException(ACCESS_DENIED);
+        }
     }
 }

--- a/src/main/java/com/example/solidconnection/siteuser/controller/SiteUserController.java
+++ b/src/main/java/com/example/solidconnection/siteuser/controller/SiteUserController.java
@@ -1,9 +1,14 @@
 package com.example.solidconnection.siteuser.controller;
 
+import com.example.solidconnection.common.dto.SliceResponse;
 import com.example.solidconnection.common.resolver.AuthorizedUser;
 import com.example.solidconnection.siteuser.dto.NicknameExistsResponse;
+import com.example.solidconnection.siteuser.dto.UserBlockResponse;
 import com.example.solidconnection.siteuser.service.SiteUserService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -26,6 +31,15 @@ public class SiteUserController {
     ) {
         NicknameExistsResponse nicknameExistsResponse = siteUserService.checkNicknameExists(nickname);
         return ResponseEntity.ok(nicknameExistsResponse);
+    }
+
+    @GetMapping("/blocks")
+    public ResponseEntity<SliceResponse<UserBlockResponse>> getBlockedUsers(
+            @AuthorizedUser long siteUserId,
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        SliceResponse<UserBlockResponse> response = siteUserService.getBlockedUsers(siteUserId, pageable);
+        return ResponseEntity.ok(response);
     }
 
     @PostMapping("/block/{blocked-id}")

--- a/src/main/java/com/example/solidconnection/siteuser/controller/SiteUserController.java
+++ b/src/main/java/com/example/solidconnection/siteuser/controller/SiteUserController.java
@@ -5,6 +5,7 @@ import com.example.solidconnection.siteuser.dto.NicknameExistsResponse;
 import com.example.solidconnection.siteuser.service.SiteUserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -33,6 +34,15 @@ public class SiteUserController {
             @PathVariable("blocked-id") Long blockedId
     ) {
         siteUserService.blockUser(siteUserId, blockedId);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/block/{blocked-id}")
+    public ResponseEntity<Void> cancelUserBlock(
+            @AuthorizedUser long siteUserId,
+            @PathVariable("blocked-id") Long blockedId
+    ) {
+        siteUserService.cancelUserBlock(siteUserId, blockedId);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/example/solidconnection/siteuser/controller/SiteUserController.java
+++ b/src/main/java/com/example/solidconnection/siteuser/controller/SiteUserController.java
@@ -1,10 +1,13 @@
 package com.example.solidconnection.siteuser.controller;
 
+import com.example.solidconnection.common.resolver.AuthorizedUser;
 import com.example.solidconnection.siteuser.dto.NicknameExistsResponse;
 import com.example.solidconnection.siteuser.service.SiteUserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,5 +25,14 @@ public class SiteUserController {
     ) {
         NicknameExistsResponse nicknameExistsResponse = siteUserService.checkNicknameExists(nickname);
         return ResponseEntity.ok(nicknameExistsResponse);
+    }
+
+    @PostMapping("/block/{blocked-id}")
+    public ResponseEntity<Void> blockUser(
+            @AuthorizedUser long siteUserId,
+            @PathVariable("blocked-id") Long blockedId
+    ) {
+        siteUserService.blockUser(siteUserId, blockedId);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/example/solidconnection/siteuser/domain/UserBlock.java
+++ b/src/main/java/com/example/solidconnection/siteuser/domain/UserBlock.java
@@ -34,4 +34,9 @@ public class UserBlock extends BaseEntity {
 
     @Column(name = "blocked_id", nullable = false)
     private long blockedId;
+
+    public UserBlock(long blockerId, long blockedId) {
+        this.blockerId = blockerId;
+        this.blockedId = blockedId;
+    }
 }

--- a/src/main/java/com/example/solidconnection/siteuser/dto/UserBlockResponse.java
+++ b/src/main/java/com/example/solidconnection/siteuser/dto/UserBlockResponse.java
@@ -1,0 +1,12 @@
+package com.example.solidconnection.siteuser.dto;
+
+import java.time.ZonedDateTime;
+
+public record UserBlockResponse(
+        long id,
+        long blockedId,
+        String nickname,
+        ZonedDateTime createdAt
+) {
+
+}

--- a/src/main/java/com/example/solidconnection/siteuser/repository/UserBlockRepository.java
+++ b/src/main/java/com/example/solidconnection/siteuser/repository/UserBlockRepository.java
@@ -1,9 +1,12 @@
 package com.example.solidconnection.siteuser.repository;
 
 import com.example.solidconnection.siteuser.domain.UserBlock;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserBlockRepository extends JpaRepository<UserBlock, Long> {
 
     boolean existsByBlockerIdAndBlockedId(long blockerId, long blockedId);
+
+    Optional<UserBlock> findByBlockerIdAndBlockedId(long blockerId, long blockedId);
 }

--- a/src/main/java/com/example/solidconnection/siteuser/repository/UserBlockRepository.java
+++ b/src/main/java/com/example/solidconnection/siteuser/repository/UserBlockRepository.java
@@ -1,12 +1,27 @@
 package com.example.solidconnection.siteuser.repository;
 
 import com.example.solidconnection.siteuser.domain.UserBlock;
+import com.example.solidconnection.siteuser.dto.UserBlockResponse;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface UserBlockRepository extends JpaRepository<UserBlock, Long> {
 
     boolean existsByBlockerIdAndBlockedId(long blockerId, long blockedId);
 
     Optional<UserBlock> findByBlockerIdAndBlockedId(long blockerId, long blockedId);
+
+    @Query("""
+           SELECT new com.example.solidconnection.siteuser.dto.UserBlockResponse(
+               ub.id, ub.blockedId, su.nickname, ub.createdAt
+           )
+           FROM UserBlock ub
+           JOIN SiteUser su ON ub.blockedId = su.id
+           WHERE ub.blockerId = :blockerId
+           """)
+    Slice<UserBlockResponse> findBlockedUsersWithNickname(@Param("blockerId") long blockerId, Pageable pageable);
 }

--- a/src/main/java/com/example/solidconnection/siteuser/repository/UserBlockRepository.java
+++ b/src/main/java/com/example/solidconnection/siteuser/repository/UserBlockRepository.java
@@ -1,0 +1,9 @@
+package com.example.solidconnection.siteuser.repository;
+
+import com.example.solidconnection.siteuser.domain.UserBlock;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserBlockRepository extends JpaRepository<UserBlock, Long> {
+
+    boolean existsByBlockerIdAndBlockedId(long blockerId, long blockedId);
+}

--- a/src/main/java/com/example/solidconnection/siteuser/service/SiteUserService.java
+++ b/src/main/java/com/example/solidconnection/siteuser/service/SiteUserService.java
@@ -1,6 +1,7 @@
 package com.example.solidconnection.siteuser.service;
 
 import static com.example.solidconnection.common.exception.ErrorCode.ALREADY_BLOCKED_BY_CURRENT_USER;
+import static com.example.solidconnection.common.exception.ErrorCode.BLOCK_USER_NOT_FOUND;
 import static com.example.solidconnection.common.exception.ErrorCode.CANNOT_BLOCK_YOURSELF;
 import static com.example.solidconnection.common.exception.ErrorCode.USER_NOT_FOUND;
 
@@ -43,5 +44,15 @@ public class SiteUserService {
         if (userBlockRepository.existsByBlockerIdAndBlockedId(blockerId, blockedId)) {
             throw new CustomException(ALREADY_BLOCKED_BY_CURRENT_USER);
         }
+    }
+
+    @Transactional
+    public void cancelUserBlock(long blockerId, long blockedId) {
+        if (!siteUserRepository.existsById(blockedId)) {
+            throw new CustomException(USER_NOT_FOUND);
+        }
+        UserBlock userBlock = userBlockRepository.findByBlockerIdAndBlockedId(blockerId, blockedId)
+                .orElseThrow(() -> new CustomException(BLOCK_USER_NOT_FOUND));
+        userBlockRepository.delete(userBlock);
     }
 }

--- a/src/main/java/com/example/solidconnection/siteuser/service/SiteUserService.java
+++ b/src/main/java/com/example/solidconnection/siteuser/service/SiteUserService.java
@@ -5,15 +5,20 @@ import static com.example.solidconnection.common.exception.ErrorCode.BLOCK_USER_
 import static com.example.solidconnection.common.exception.ErrorCode.CANNOT_BLOCK_YOURSELF;
 import static com.example.solidconnection.common.exception.ErrorCode.USER_NOT_FOUND;
 
+import com.example.solidconnection.common.dto.SliceResponse;
 import com.example.solidconnection.common.exception.CustomException;
 import com.example.solidconnection.siteuser.domain.UserBlock;
 import com.example.solidconnection.siteuser.dto.NicknameExistsResponse;
+import com.example.solidconnection.siteuser.dto.UserBlockResponse;
 import com.example.solidconnection.siteuser.repository.SiteUserRepository;
 import com.example.solidconnection.siteuser.repository.UserBlockRepository;
-import jakarta.transaction.Transactional;
+import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
@@ -25,6 +30,14 @@ public class SiteUserService {
     public NicknameExistsResponse checkNicknameExists(String nickname) {
         boolean exists = siteUserRepository.existsByNickname(nickname);
         return NicknameExistsResponse.from(exists);
+    }
+
+    @Transactional(readOnly = true)
+    public SliceResponse<UserBlockResponse> getBlockedUsers(long siteUserId, Pageable pageable) {
+        Slice<UserBlockResponse> slice = userBlockRepository.findBlockedUsersWithNickname(siteUserId, pageable);
+
+        List<UserBlockResponse> content = slice.getContent();
+        return SliceResponse.of(content, slice);
     }
 
     @Transactional

--- a/src/main/java/com/example/solidconnection/siteuser/service/SiteUserService.java
+++ b/src/main/java/com/example/solidconnection/siteuser/service/SiteUserService.java
@@ -1,7 +1,16 @@
 package com.example.solidconnection.siteuser.service;
 
+import static com.example.solidconnection.common.exception.ErrorCode.ALREADY_BLOCKED_BY_CURRENT_USER;
+import static com.example.solidconnection.common.exception.ErrorCode.CANNOT_BLOCK_YOURSELF;
+import static com.example.solidconnection.common.exception.ErrorCode.USER_NOT_FOUND;
+
+import com.example.solidconnection.common.exception.CustomException;
+import com.example.solidconnection.siteuser.domain.UserBlock;
 import com.example.solidconnection.siteuser.dto.NicknameExistsResponse;
 import com.example.solidconnection.siteuser.repository.SiteUserRepository;
+import com.example.solidconnection.siteuser.repository.UserBlockRepository;
+import jakarta.transaction.Transactional;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -10,9 +19,29 @@ import org.springframework.stereotype.Service;
 public class SiteUserService {
 
     private final SiteUserRepository siteUserRepository;
+    private final UserBlockRepository userBlockRepository;
 
     public NicknameExistsResponse checkNicknameExists(String nickname) {
         boolean exists = siteUserRepository.existsByNickname(nickname);
         return NicknameExistsResponse.from(exists);
+    }
+
+    @Transactional
+    public void blockUser(long blockerId, long blockedId) {
+        validateBlockUser(blockerId, blockedId);
+        UserBlock userBlock = new UserBlock(blockerId, blockedId);
+        userBlockRepository.save(userBlock);
+    }
+
+    private void validateBlockUser(long blockerId, long blockedId) {
+        if (Objects.equals(blockerId, blockedId)) {
+            throw new CustomException(CANNOT_BLOCK_YOURSELF);
+        }
+        if (!siteUserRepository.existsById(blockedId)) {
+            throw new CustomException(USER_NOT_FOUND);
+        }
+        if (userBlockRepository.existsByBlockerIdAndBlockedId(blockerId, blockedId)) {
+            throw new CustomException(ALREADY_BLOCKED_BY_CURRENT_USER);
+        }
     }
 }

--- a/src/test/java/com/example/solidconnection/community/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/example/solidconnection/community/comment/service/CommentServiceTest.java
@@ -205,7 +205,7 @@ class CommentServiceTest {
 
 
             // when
-            List<PostFindCommentResponse> responses = commentService.findCommentsByPostId(post.getId(), user1.getId());
+            List<PostFindCommentResponse> responses = commentService.findCommentsByPostId(user1.getId(), post.getId());
 
             // then
             assertAll(

--- a/src/test/java/com/example/solidconnection/community/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/example/solidconnection/community/comment/service/CommentServiceTest.java
@@ -215,8 +215,8 @@ class CommentServiceTest {
                         .containsExactly(parentComment1.getId(), childComment1.getId()),
                 () -> assertThat(responses)
                         .extracting(PostFindCommentResponse::id)
-                        .doesNotContain(childComment2.getId(), parentCommen2.getId(), childComment3.getId(), childComment4.getId()))
-            ;
+                        .doesNotContain(childComment2.getId(), parentCommen2.getId(), childComment3.getId(), childComment4.getId())
+            );
         }
     }
 

--- a/src/test/java/com/example/solidconnection/community/post/service/PostQueryServiceTest.java
+++ b/src/test/java/com/example/solidconnection/community/post/service/PostQueryServiceTest.java
@@ -189,7 +189,6 @@ class PostQueryServiceTest {
         assertThatCode(() -> postQueryService.findPostById(user.getId(), post.getId()))
                 .isInstanceOf(CustomException.class)
                 .hasMessage(ACCESS_DENIED.getMessage());
-
     }
 
     @Test

--- a/src/test/java/com/example/solidconnection/community/post/service/PostQueryServiceTest.java
+++ b/src/test/java/com/example/solidconnection/community/post/service/PostQueryServiceTest.java
@@ -3,6 +3,7 @@ package com.example.solidconnection.community.post.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.example.solidconnection.community.board.domain.Board;
 import com.example.solidconnection.community.board.domain.BoardCode;
 import com.example.solidconnection.community.board.fixture.BoardFixture;
 import com.example.solidconnection.community.comment.domain.Comment;
@@ -15,6 +16,7 @@ import com.example.solidconnection.community.post.fixture.PostFixture;
 import com.example.solidconnection.community.post.fixture.PostImageFixture;
 import com.example.solidconnection.siteuser.domain.SiteUser;
 import com.example.solidconnection.siteuser.fixture.SiteUserFixture;
+import com.example.solidconnection.siteuser.fixture.UserBlockFixture;
 import com.example.solidconnection.support.TestContainerSpringBootTest;
 import com.example.solidconnection.util.RedisUtils;
 import java.time.ZonedDateTime;
@@ -51,6 +53,9 @@ class PostQueryServiceTest {
 
     @Autowired
     private CommentFixture commentFixture;
+
+    @Autowired
+    private UserBlockFixture userBlockFixture;
 
     private SiteUser user;
     private Post post1;
@@ -99,7 +104,8 @@ class PostQueryServiceTest {
         // when
         List<PostListResponse> actualResponses = postQueryService.findPostsByCodeAndPostCategory(
                 BoardCode.FREE.name(),
-                PostCategory.자유.name()
+                PostCategory.자유.name(),
+                null
         );
 
         // then
@@ -121,7 +127,8 @@ class PostQueryServiceTest {
         // when
         List<PostListResponse> actualResponses = postQueryService.findPostsByCodeAndPostCategory(
                 BoardCode.FREE.name(),
-                PostCategory.전체.name()
+                PostCategory.전체.name(),
+                null
         );
 
         // then
@@ -178,7 +185,8 @@ class PostQueryServiceTest {
         // when
         List<PostListResponse> actualResponses = postQueryService.findPostsByCodeAndPostCategory(
                 BoardCode.FREE.name(),
-                PostCategory.전체.name()
+                PostCategory.전체.name(),
+                null
         );
 
         // then
@@ -195,7 +203,8 @@ class PostQueryServiceTest {
         // when
         List<PostListResponse> actualResponses = postQueryService.findPostsByCodeAndPostCategory(
                 BoardCode.FREE.name(),
-                PostCategory.전체.name()
+                PostCategory.전체.name(),
+                null
         );
 
         // then
@@ -205,5 +214,29 @@ class PostQueryServiceTest {
                 .orElseThrow();
 
         assertThat(postResponse.postThumbnailUrl()).isNull();
+    }
+
+    @Test
+    void 차단한_사용자의_게시글은_제외된다() {
+        // given
+        SiteUser blockedUser = siteUserFixture.사용자(1, "blockedUser");
+        SiteUser notBlockedUser = siteUserFixture.사용자(2, "notBlockedUser");
+        userBlockFixture.유저_차단(user.getId(), blockedUser.getId());
+        Board board = boardFixture.자유게시판();
+        Post blockedPost = postFixture.게시글(board, blockedUser);
+        Post notBlockedPost = postFixture.게시글(board, notBlockedUser);
+
+        // when
+        List<PostListResponse> response = postQueryService.findPostsByCodeAndPostCategory(
+                BoardCode.FREE.name(),
+                PostCategory.전체.name(),
+                user.getId()
+        );
+
+        // then
+        assertAll(
+                () -> assertThat(response).extracting(PostListResponse::id).contains(notBlockedPost.getId()),
+                () -> assertThat(response).extracting(PostListResponse::id).doesNotContain(blockedPost.getId())
+        );
     }
 }

--- a/src/test/java/com/example/solidconnection/community/post/service/PostQueryServiceTest.java
+++ b/src/test/java/com/example/solidconnection/community/post/service/PostQueryServiceTest.java
@@ -1,8 +1,11 @@
 package com.example.solidconnection.community.post.service;
 
+import static com.example.solidconnection.common.exception.ErrorCode.ACCESS_DENIED;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.example.solidconnection.common.exception.CustomException;
 import com.example.solidconnection.community.board.domain.Board;
 import com.example.solidconnection.community.board.domain.BoardCode;
 import com.example.solidconnection.community.board.fixture.BoardFixture;
@@ -172,6 +175,21 @@ class PostQueryServiceTest {
                 () -> assertThat(redisService.isKeyExists(viewCountKey)).isTrue(),
                 () -> assertThat(redisService.isKeyExists(validateKey)).isTrue()
         );
+    }
+
+    @Test
+    void 차단한_사용자의_게시글을_조회하면_예외가_발생한다() {
+        // given
+        SiteUser blockedUser = siteUserFixture.사용자(1, "blockedUser");
+        userBlockFixture.유저_차단(user.getId(), blockedUser.getId());
+        Board board = boardFixture.자유게시판();
+        Post post = postFixture.게시글(board, blockedUser);
+
+        // when & then
+        assertThatCode(() -> postQueryService.findPostById(user.getId(), post.getId()))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(ACCESS_DENIED.getMessage());
+
     }
 
     @Test

--- a/src/test/java/com/example/solidconnection/siteuser/fixture/UserBlockFixture.java
+++ b/src/test/java/com/example/solidconnection/siteuser/fixture/UserBlockFixture.java
@@ -1,0 +1,20 @@
+package com.example.solidconnection.siteuser.fixture;
+
+import com.example.solidconnection.siteuser.domain.UserBlock;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.test.context.TestComponent;
+
+@TestComponent
+@RequiredArgsConstructor
+public class UserBlockFixture {
+
+    private final UserBlockFixtureBuilder userBlockFixtureBuilder;
+
+    public UserBlock 유저_차단(long blockerId, long blockedId) {
+        return userBlockFixtureBuilder.userBlock()
+                .blockerId(blockerId)
+                .blockedId(blockedId)
+                .create();
+    }
+
+}

--- a/src/test/java/com/example/solidconnection/siteuser/fixture/UserBlockFixture.java
+++ b/src/test/java/com/example/solidconnection/siteuser/fixture/UserBlockFixture.java
@@ -16,5 +16,4 @@ public class UserBlockFixture {
                 .blockedId(blockedId)
                 .create();
     }
-
 }

--- a/src/test/java/com/example/solidconnection/siteuser/fixture/UserBlockFixtureBuilder.java
+++ b/src/test/java/com/example/solidconnection/siteuser/fixture/UserBlockFixtureBuilder.java
@@ -1,0 +1,35 @@
+package com.example.solidconnection.siteuser.fixture;
+
+import com.example.solidconnection.siteuser.domain.UserBlock;
+import com.example.solidconnection.siteuser.repository.UserBlockRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.test.context.TestComponent;
+
+@TestComponent
+@RequiredArgsConstructor
+public class UserBlockFixtureBuilder {
+
+    private final UserBlockRepository userBlockRepository;
+
+    private long blockerId;
+    private long blockedId;
+
+    public UserBlockFixtureBuilder userBlock() {
+        return new UserBlockFixtureBuilder(userBlockRepository);
+    }
+
+    public UserBlockFixtureBuilder blockerId(long blockerId) {
+        this.blockerId = blockerId;
+        return this;
+    }
+
+    public UserBlockFixtureBuilder blockedId(long blockedId) {
+        this.blockedId = blockedId;
+        return this;
+    }
+
+    public UserBlock create() {
+        UserBlock userBlock = new UserBlock(blockerId, blockedId);
+        return userBlockRepository.save(userBlock);
+    }
+}

--- a/src/test/java/com/example/solidconnection/siteuser/service/SiteUserServiceTest.java
+++ b/src/test/java/com/example/solidconnection/siteuser/service/SiteUserServiceTest.java
@@ -5,10 +5,14 @@ import static com.example.solidconnection.common.exception.ErrorCode.BLOCK_USER_
 import static com.example.solidconnection.common.exception.ErrorCode.CANNOT_BLOCK_YOURSELF;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.example.solidconnection.common.dto.SliceResponse;
 import com.example.solidconnection.common.exception.CustomException;
 import com.example.solidconnection.siteuser.domain.SiteUser;
+import com.example.solidconnection.siteuser.domain.UserBlock;
 import com.example.solidconnection.siteuser.dto.NicknameExistsResponse;
+import com.example.solidconnection.siteuser.dto.UserBlockResponse;
 import com.example.solidconnection.siteuser.fixture.SiteUserFixture;
 import com.example.solidconnection.siteuser.fixture.UserBlockFixture;
 import com.example.solidconnection.siteuser.repository.UserBlockRepository;
@@ -18,6 +22,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 
 @TestContainerSpringBootTest
 @DisplayName("유저 서비스 테스트")
@@ -61,6 +68,54 @@ class SiteUserServiceTest {
 
             // then
             assertThat(response.exists()).isFalse();
+        }
+    }
+
+    @Nested
+    class 유저_차단_조회 {
+
+        private static final int NO_NEXT_PAGE_NUMBER = -1;
+
+        private SiteUser blockedUser1;
+        private SiteUser blockedUser2;
+        private Pageable pageable;
+
+        @BeforeEach
+        void setUp() {
+            blockedUser1 = siteUserFixture.사용자(1, "blockedUser1");
+            blockedUser2 = siteUserFixture.사용자(2, "blockedUser2");
+            pageable = PageRequest.of(0, 20, Sort.by(Sort.Direction.DESC, "createdAt"));
+        }
+
+        @Test
+        void 최신순으로_차단한_사용자를_정상적으로_조회한다() {
+            // given
+            UserBlock userBlock1 = userBlockFixture.유저_차단(user.getId(), blockedUser1.getId());
+            UserBlock userBlock2 = userBlockFixture.유저_차단(user.getId(), blockedUser2.getId());
+
+            // when
+            SliceResponse<UserBlockResponse> response = siteUserService.getBlockedUsers(user.getId(), pageable);
+
+            // then
+            assertAll(
+                    () -> assertThat(response.content()).hasSize(2),
+                    () -> assertThat(response.content().get(0).id()).isEqualTo(userBlock2.getId()),
+                    () -> assertThat(response.content().get(0).blockedId()).isEqualTo(blockedUser2.getId()),
+                    () -> assertThat(response.content().get(1).id()).isEqualTo(userBlock1.getId()),
+                    () -> assertThat(response.content().get(1).blockedId()).isEqualTo(blockedUser1.getId())
+            );
+        }
+
+        @Test
+        void 차단한_사용자가_없으면_빈_목록을_반환한다() {
+            // when
+            SliceResponse<UserBlockResponse> response = siteUserService.getBlockedUsers(user.getId(), pageable);
+
+            // then
+            assertAll(
+                    () -> assertThat(response.content()).isEmpty(),
+                    () -> assertThat(response.nextPageNumber()).isEqualTo(NO_NEXT_PAGE_NUMBER)
+            );
         }
     }
 

--- a/src/test/java/com/example/solidconnection/siteuser/service/SiteUserServiceTest.java
+++ b/src/test/java/com/example/solidconnection/siteuser/service/SiteUserServiceTest.java
@@ -1,10 +1,15 @@
 package com.example.solidconnection.siteuser.service;
 
+import static com.example.solidconnection.common.exception.ErrorCode.ALREADY_BLOCKED_BY_CURRENT_USER;
+import static com.example.solidconnection.common.exception.ErrorCode.CANNOT_BLOCK_YOURSELF;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
 
+import com.example.solidconnection.common.exception.CustomException;
 import com.example.solidconnection.siteuser.domain.SiteUser;
 import com.example.solidconnection.siteuser.dto.NicknameExistsResponse;
 import com.example.solidconnection.siteuser.fixture.SiteUserFixture;
+import com.example.solidconnection.siteuser.repository.UserBlockRepository;
 import com.example.solidconnection.support.TestContainerSpringBootTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -18,6 +23,9 @@ class SiteUserServiceTest {
 
     @Autowired
     private SiteUserService siteUserService;
+
+    @Autowired
+    private UserBlockRepository userBlockRepository;
 
     @Autowired
     private SiteUserFixture siteUserFixture;
@@ -48,6 +56,45 @@ class SiteUserServiceTest {
 
             // then
             assertThat(response.exists()).isFalse();
+        }
+    }
+
+    @Nested
+    class 유저_차단 {
+
+        private SiteUser blockedUser;
+
+        @BeforeEach
+        void setUp() {
+            blockedUser = siteUserFixture.사용자(1, "blockedUser");
+        }
+
+        @Test
+        void 성공적으로_유저를_차단한다() {
+            // when
+            siteUserService.blockUser(user.getId(), blockedUser.getId());
+
+            // then
+            assertThat(userBlockRepository.existsByBlockerIdAndBlockedId(user.getId(), blockedUser.getId())).isTrue();
+        }
+
+        @Test
+        void 자기_자신을_차단하면_예외가_발생한다() {
+            // when & then
+            assertThatCode(() -> siteUserService.blockUser(user.getId(), user.getId()))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(CANNOT_BLOCK_YOURSELF.getMessage());
+        }
+
+        @Test
+        void 이미_차단했으면_예외가_발생한다() {
+            // given
+            siteUserService.blockUser(user.getId(), blockedUser.getId());
+
+            // when & then
+            assertThatCode(() -> siteUserService.blockUser(user.getId(), blockedUser.getId()))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(ALREADY_BLOCKED_BY_CURRENT_USER.getMessage());
         }
     }
 }

--- a/src/test/java/com/example/solidconnection/siteuser/service/SiteUserServiceTest.java
+++ b/src/test/java/com/example/solidconnection/siteuser/service/SiteUserServiceTest.java
@@ -1,6 +1,7 @@
 package com.example.solidconnection.siteuser.service;
 
 import static com.example.solidconnection.common.exception.ErrorCode.ALREADY_BLOCKED_BY_CURRENT_USER;
+import static com.example.solidconnection.common.exception.ErrorCode.BLOCK_USER_NOT_FOUND;
 import static com.example.solidconnection.common.exception.ErrorCode.CANNOT_BLOCK_YOURSELF;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
@@ -9,6 +10,7 @@ import com.example.solidconnection.common.exception.CustomException;
 import com.example.solidconnection.siteuser.domain.SiteUser;
 import com.example.solidconnection.siteuser.dto.NicknameExistsResponse;
 import com.example.solidconnection.siteuser.fixture.SiteUserFixture;
+import com.example.solidconnection.siteuser.fixture.UserBlockFixture;
 import com.example.solidconnection.siteuser.repository.UserBlockRepository;
 import com.example.solidconnection.support.TestContainerSpringBootTest;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,6 +31,9 @@ class SiteUserServiceTest {
 
     @Autowired
     private SiteUserFixture siteUserFixture;
+
+    @Autowired
+    private UserBlockFixture userBlockFixture;
 
     private SiteUser user;
 
@@ -95,6 +100,26 @@ class SiteUserServiceTest {
             assertThatCode(() -> siteUserService.blockUser(user.getId(), blockedUser.getId()))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(ALREADY_BLOCKED_BY_CURRENT_USER.getMessage());
+        }
+
+        @Test
+        void 성공적으로_유저_차단을_취소한다() {
+            // given
+            userBlockFixture.유저_차단(user.getId(), blockedUser.getId());
+
+            // when
+            siteUserService.cancelUserBlock(user.getId(), blockedUser.getId());
+
+            // then
+            assertThat(userBlockRepository.existsByBlockerIdAndBlockedId(user.getId(), blockedUser.getId())).isFalse();
+        }
+
+        @Test
+        void 차단하지_않았으면_예외가_발생한다() {
+            // when & then
+            assertThatCode(() -> siteUserService.cancelUserBlock(user.getId(), blockedUser.getId()))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(BLOCK_USER_NOT_FOUND.getMessage());
         }
     }
 }


### PR DESCRIPTION
## 관련 이슈

- resolves: #512

## 작업 내용

차단 관련 API를 구현하였습니다.

- 로그인한 유저의 차단 목록 조회 API
- 차단 API
- 차단 취소 API

급하게 구현을 하다보니 커밋을 완전 많이 쪼개진 못했는데 그래도 노력은 했습니다 ㅎㅎ..
그래도 커밋 따라가면 이해하기 편하실겁니다!

커뮤니티 부분은 현재 인성님이 수정해주고 계신 거 같아서 최대한 기존코드 유지하면서 로직 추가했습니다!
(커뮤니티 쪽 코드가 엄청 지저분하네요 :smiling_face_with_tear: 앞으로 개선될 것이라고 생각합니다!)

1. 우선 차단을 했을 때 게시글 목록에서 차단한 유저의 게시글은 보이지 않도록 했습니다!
2. 그럼에도 게시글을 조회하려한다면 예외를 던지게 했습니다!
3. 특정 게시글에 차단한 유저의 댓글이 있다면 보이지 않게 했습니다!


관련 명세서 : https://github.com/solid-connection/api-docs/pull/51
<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

## 특이 사항

만욱님의 요청으로 여기서 변경할 사항은 아니지만.. 로그인하지 않은 유저도 게시글 목록 볼 수 있게 수정했습니다!
너무 간단한 pr이 될 거 같아 그냥 같이 작업했습니다!
<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

## 리뷰 요구사항 (선택)

#### 1. 차단 api의 위치
우선 siteUser쪽에 구현했는데 괜찮은가요? 커뮤니티쪽에 구현할까도 생각했는데 추후 채팅 등 다른곳에서도 차단이 생길 수 있다고 생각해 가장 범용적으로 사용될 수 있는 siteUser쪽으로 구현했습니다.

#### 2. 단방향 차단 vs 양방향 차단
우선은 단방향으로 본인이 차단한 유저의 게시글 및 댓글만 보이지 않게 했는데 이래도 문제 없을까요?

#### 3. 댓글 관련 차단
여기가 가장 고민이 되었던 지점인데.. 차단한 유저의 댓글에 차단하지 않은 유저의 대댓글이 있다면 어떻게 해야할까요?
1. 차단한 유저의 댓글만 숨기고 대댓글은 보이게한다 -> 이때 그럼 그 부모댓글은 어떻게 보여야할까요?
2. 그냥 차단하지 않은 유저의 대댓글이더라도 부모댓글은 차단한 유저이기에 모두 숨긴다

사실 2번이 간단해보여서 2번으로 구현했습니다 ㅎㅎ.. 그런데 구현하고 나니 2번도 나쁘지 않아보인다는 생각이 드네요
<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
