### PR TITLE
refactor: 엔티티가 BaseEntity를 상속하도록

### DIFF
--- a/src/main/java/com/example/solidconnection/application/domain/Application.java
+++ b/src/main/java/com/example/solidconnection/application/domain/Application.java
@@ -2,6 +2,7 @@ package com.example.solidconnection.application.domain;
 
 import static com.example.solidconnection.common.VerifyStatus.PENDING;
 
+import com.example.solidconnection.common.BaseEntity;
 import com.example.solidconnection.common.VerifyStatus;
 import com.example.solidconnection.siteuser.domain.SiteUser;
 import jakarta.persistence.Column;
@@ -35,7 +36,7 @@ import org.hibernate.annotations.DynamicUpdate;
         @Index(name = "idx_app_third_choice_search",
                 columnList = "verify_status, term, is_delete, third_choice_university_info_for_apply_id")
 })
-public class Application {
+public class Application extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/solidconnection/application/domain/Gpa.java
+++ b/src/main/java/com/example/solidconnection/application/domain/Gpa.java
@@ -1,5 +1,6 @@
 package com.example.solidconnection.application.domain;
 
+import com.example.solidconnection.common.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AllArgsConstructor;
@@ -12,7 +13,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 @Embeddable
 @EqualsAndHashCode(of = {"gpa", "gpaCriteria", "gpaReportUrl"})
-public class Gpa {
+public class Gpa extends BaseEntity {
 
     @Column(nullable = false, name = "gpa")
     private Double gpa;

--- a/src/main/java/com/example/solidconnection/application/domain/LanguageTest.java
+++ b/src/main/java/com/example/solidconnection/application/domain/LanguageTest.java
@@ -1,5 +1,6 @@
 package com.example.solidconnection.application.domain;
 
+import com.example.solidconnection.common.BaseEntity;
 import com.example.solidconnection.university.domain.LanguageTestType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
@@ -15,7 +16,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 @Embeddable
 @EqualsAndHashCode(of = {"languageTestType", "languageTestScore", "languageTestReportUrl"})
-public class LanguageTest {
+public class LanguageTest extends BaseEntity {
 
     @Column(nullable = false, name = "language_test_type", length = 10)
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/example/solidconnection/community/board/domain/Board.java
+++ b/src/main/java/com/example/solidconnection/community/board/domain/Board.java
@@ -1,5 +1,6 @@
 package com.example.solidconnection.community.board.domain;
 
+import com.example.solidconnection.common.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
@@ -9,7 +10,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor
-public class Board {
+public class Board extends BaseEntity {
 
     @Id
     @Column(length = 20)

--- a/src/main/java/com/example/solidconnection/community/post/domain/PostImage.java
+++ b/src/main/java/com/example/solidconnection/community/post/domain/PostImage.java
@@ -1,5 +1,6 @@
 package com.example.solidconnection.community.post.domain;
 
+import com.example.solidconnection.common.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -14,7 +15,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor
-public class PostImage {
+public class PostImage extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/solidconnection/community/post/domain/PostLike.java
+++ b/src/main/java/com/example/solidconnection/community/post/domain/PostLike.java
@@ -1,5 +1,6 @@
 package com.example.solidconnection.community.post.domain;
 
+import com.example.solidconnection.common.BaseEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -15,7 +16,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @EqualsAndHashCode(of = "id")
-public class PostLike {
+public class PostLike extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/solidconnection/location/country/domain/Country.java
+++ b/src/main/java/com/example/solidconnection/location/country/domain/Country.java
@@ -1,5 +1,6 @@
 package com.example.solidconnection.location.country.domain;
 
+import com.example.solidconnection.common.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
@@ -12,7 +13,7 @@ import lombok.NoArgsConstructor;
 @EqualsAndHashCode(of = {"code", "koreanName"})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-public class Country {
+public class Country extends BaseEntity {
 
     @Id
     @Column(length = 2)

--- a/src/main/java/com/example/solidconnection/location/country/domain/InterestedCountry.java
+++ b/src/main/java/com/example/solidconnection/location/country/domain/InterestedCountry.java
@@ -1,5 +1,6 @@
 package com.example.solidconnection.location.country.domain;
 
+import com.example.solidconnection.common.BaseEntity;
 import com.example.solidconnection.siteuser.domain.SiteUser;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -21,7 +22,7 @@ import lombok.NoArgsConstructor;
                 columnNames = {"site_user_id", "country_code"}
         )
 })
-public class InterestedCountry {
+public class InterestedCountry extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/solidconnection/location/region/domain/InterestedRegion.java
+++ b/src/main/java/com/example/solidconnection/location/region/domain/InterestedRegion.java
@@ -1,5 +1,6 @@
 package com.example.solidconnection.location.region.domain;
 
+import com.example.solidconnection.common.BaseEntity;
 import com.example.solidconnection.siteuser.domain.SiteUser;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -21,7 +22,7 @@ import lombok.NoArgsConstructor;
                 columnNames = {"site_user_id", "region_code"}
         )
 })
-public class InterestedRegion {
+public class InterestedRegion extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/solidconnection/location/region/domain/Region.java
+++ b/src/main/java/com/example/solidconnection/location/region/domain/Region.java
@@ -1,5 +1,6 @@
 package com.example.solidconnection.location.region.domain;
 
+import com.example.solidconnection.common.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
@@ -12,7 +13,7 @@ import lombok.NoArgsConstructor;
 @EqualsAndHashCode(of = {"code", "koreanName"})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-public class Region {
+public class Region extends BaseEntity {
 
     @Id
     @Column(length = 10)

--- a/src/main/java/com/example/solidconnection/mentor/domain/Channel.java
+++ b/src/main/java/com/example/solidconnection/mentor/domain/Channel.java
@@ -1,5 +1,6 @@
 package com.example.solidconnection.mentor.domain;
 
+import com.example.solidconnection.common.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -26,7 +27,7 @@ import lombok.NoArgsConstructor;
                 columnNames = {"mentor_id", "sequence"}
         )
 })
-public class Channel {
+public class Channel extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/solidconnection/mentor/domain/Mentor.java
+++ b/src/main/java/com/example/solidconnection/mentor/domain/Mentor.java
@@ -1,5 +1,6 @@
 package com.example.solidconnection.mentor.domain;
 
+import com.example.solidconnection.common.BaseEntity;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -20,7 +21,7 @@ import org.hibernate.annotations.BatchSize;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Mentor {
+public class Mentor extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/solidconnection/mentor/domain/Mentoring.java
+++ b/src/main/java/com/example/solidconnection/mentor/domain/Mentoring.java
@@ -3,6 +3,7 @@ package com.example.solidconnection.mentor.domain;
 import static java.time.ZoneOffset.UTC;
 import static java.time.temporal.ChronoUnit.MICROS;
 
+import com.example.solidconnection.common.BaseEntity;
 import com.example.solidconnection.common.VerifyStatus;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -27,7 +28,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @DynamicInsert
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Mentoring {
+public class Mentoring extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/solidconnection/news/domain/LikedNews.java
+++ b/src/main/java/com/example/solidconnection/news/domain/LikedNews.java
@@ -1,5 +1,6 @@
 package com.example.solidconnection.news.domain;
 
+import com.example.solidconnection.common.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -22,7 +23,7 @@ import lombok.NoArgsConstructor;
                 columnNames = {"site_user_id", "news_id"}
         )
 })
-public class LikedNews {
+public class LikedNews extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/solidconnection/report/domain/Report.java
+++ b/src/main/java/com/example/solidconnection/report/domain/Report.java
@@ -1,5 +1,6 @@
 package com.example.solidconnection.report.domain;
 
+import com.example.solidconnection.common.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -22,7 +23,7 @@ import lombok.NoArgsConstructor;
                 columnNames = {"reporter_id", "target_type", "target_id"}
         )
 })
-public class Report {
+public class Report extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/solidconnection/siteuser/domain/SiteUser.java
+++ b/src/main/java/com/example/solidconnection/siteuser/domain/SiteUser.java
@@ -1,5 +1,6 @@
 package com.example.solidconnection.siteuser.domain;
 
+import com.example.solidconnection.common.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -31,7 +32,7 @@ import lombok.Setter;
                 columnNames = {"nickname"}
         )
 })
-public class SiteUser {
+public class SiteUser extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/solidconnection/university/domain/LanguageRequirement.java
+++ b/src/main/java/com/example/solidconnection/university/domain/LanguageRequirement.java
@@ -1,5 +1,6 @@
 package com.example.solidconnection.university.domain;
 
+import com.example.solidconnection.common.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -19,7 +20,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-public class LanguageRequirement {
+public class LanguageRequirement extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/solidconnection/university/domain/LikedUnivApplyInfo.java
+++ b/src/main/java/com/example/solidconnection/university/domain/LikedUnivApplyInfo.java
@@ -1,5 +1,6 @@
 package com.example.solidconnection.university.domain;
 
+import com.example.solidconnection.common.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -25,7 +26,7 @@ import lombok.NoArgsConstructor;
                         columnNames = {"site_user_id", "university_info_for_apply_id"}
                 )
         })
-public class LikedUnivApplyInfo {
+public class LikedUnivApplyInfo extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/solidconnection/university/domain/UnivApplyInfo.java
+++ b/src/main/java/com/example/solidconnection/university/domain/UnivApplyInfo.java
@@ -1,5 +1,6 @@
 package com.example.solidconnection.university.domain;
 
+import com.example.solidconnection.common.BaseEntity;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -26,7 +27,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "university_info_for_apply")
-public class UnivApplyInfo {
+public class UnivApplyInfo extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/solidconnection/university/domain/University.java
+++ b/src/main/java/com/example/solidconnection/university/domain/University.java
@@ -1,5 +1,6 @@
 package com.example.solidconnection.university.domain;
 
+import com.example.solidconnection.common.BaseEntity;
 import com.example.solidconnection.location.country.domain.Country;
 import com.example.solidconnection.location.region.domain.Region;
 import jakarta.persistence.Column;
@@ -17,7 +18,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class University {
+public class University extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/resources/db/migration/V33__add_baseentity_related_fields.sql
+++ b/src/main/resources/db/migration/V33__add_baseentity_related_fields.sql
@@ -1,0 +1,79 @@
+ALTER TABLE application
+    ADD COLUMN created_at DATETIME(6),
+    ADD COLUMN updated_at DATETIME(6);
+
+ALTER TABLE gpa
+    ADD COLUMN created_at DATETIME(6),
+    ADD COLUMN updated_at DATETIME(6);
+
+ALTER TABLE language_test
+    ADD COLUMN created_at DATETIME(6),
+    ADD COLUMN updated_at DATETIME(6);
+
+ALTER TABLE board
+    ADD COLUMN created_at DATETIME(6),
+    ADD COLUMN updated_at DATETIME(6);
+
+ALTER TABLE post_image
+    ADD COLUMN created_at DATETIME(6),
+    ADD COLUMN updated_at DATETIME(6);
+
+ALTER TABLE post_like
+    ADD COLUMN created_at DATETIME(6),
+    ADD COLUMN updated_at DATETIME(6);
+
+ALTER TABLE country
+    ADD COLUMN created_at DATETIME(6),
+    ADD COLUMN updated_at DATETIME(6);
+
+ALTER TABLE interested_country
+    ADD COLUMN created_at DATETIME(6),
+    ADD COLUMN updated_at DATETIME(6);
+
+ALTER TABLE region
+    ADD COLUMN created_at DATETIME(6),
+    ADD COLUMN updated_at DATETIME(6);
+
+ALTER TABLE interested_region
+    ADD COLUMN created_at DATETIME(6),
+    ADD COLUMN updated_at DATETIME(6);
+
+ALTER TABLE channel
+    ADD COLUMN created_at DATETIME(6),
+    ADD COLUMN updated_at DATETIME(6);
+
+ALTER TABLE mentor
+    ADD COLUMN created_at DATETIME(6),
+    ADD COLUMN updated_at DATETIME(6);
+
+ALTER TABLE mentoring
+    ADD COLUMN created_at DATETIME(6),
+    ADD COLUMN updated_at DATETIME(6);
+
+ALTER TABLE liked_news
+    ADD COLUMN created_at DATETIME(6),
+    ADD COLUMN updated_at DATETIME(6);
+
+ALTER TABLE report
+    ADD COLUMN created_at DATETIME(6),
+    ADD COLUMN updated_at DATETIME(6);
+
+ALTER TABLE site_user
+    ADD COLUMN created_at DATETIME(6),
+    ADD COLUMN updated_at DATETIME(6);
+
+ALTER TABLE language_requirement
+    ADD COLUMN created_at DATETIME(6),
+    ADD COLUMN updated_at DATETIME(6);
+
+ALTER TABLE liked_university_info_for_apply
+    ADD COLUMN created_at DATETIME(6),
+    ADD COLUMN updated_at DATETIME(6);
+
+ALTER TABLE university_info_for_apply
+    ADD COLUMN created_at DATETIME(6),
+    ADD COLUMN updated_at DATETIME(6);
+
+ALTER TABLE university
+    ADD COLUMN created_at DATETIME(6),
+    ADD COLUMN updated_at DATETIME(6);


### PR DESCRIPTION
## 관련 이슈

- resolves: #505 

## 작업 내용

<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

모든 엔티티가 `BaseEntity`를 상속하도록 리팩토링합니다.

## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->

- DDL의 테이블 이름이 잘 매핑되었는지
- `BaseEntity` 상속이 불필요한 엔티티가 있을까요 ? 저는 없다고 생각하고, 있어도 나쁠 건 없다고 생각하는데, 다른 의견이 있으신지 궁금합니다.
