### PR TITLE
fix: Github App이 발행한 임시 토큰에 대해 읽기 권한 명시

### DIFF
--- a/.github/workflows/dev-cd.yml
+++ b/.github/workflows/dev-cd.yml
@@ -73,6 +73,7 @@ jobs:
         with:
           app-id: ${{ secrets.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          permissions: "packages:read"
 
       # --- 5. 설정 파일들만 scp로 전송 ---
       - name: Copy config files to remote

--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -71,6 +71,7 @@ jobs:
         with:
           app-id: ${{ secrets.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          permissions: "packages:read"
           
       # --- 5. 설정 파일들만 scp로 전송 ---
       - name: Copy config files to remote


### PR DESCRIPTION
## 관련 이슈

- resolves: #564

## 작업 내용

<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

1. 현재 반영된 CD 로직에서 Github App을 사용해 최소 권한 원칙을 적용한 상태입니다.
2. 하지만 CD과정에서 권한이 명시되어 있지 않아 제대로 GHCR에 올라간 이미지를 pull하지 못하는 상황입니다.
3. 때문에 Github App이 발급하는 토큰에 대해 읽기 권한을 명시하였습니다.

## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->

- 잘 작동하는지 테스트를 위해서는 머지가 먼저 되어야 합니다... 이 부분 양해 부탁드립니다.
