### PR TITLE
fix: GHCR 정리 권한을 PAT로 해결

### DIFF
--- a/.github/workflows/dev-cd.yml
+++ b/.github/workflows/dev-cd.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Clean up old image versions from GHCR
         uses: snok/container-retention-policy@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PACKAGE_DELETE_TOKEN }}
           image-names: solid-connection-dev
           delete-untagged: true
           keep-n-tags: 5

--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Clean up old image versions from GHCR
         uses: snok/container-retention-policy@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PACKAGE_DELETE_TOKEN }}
           image-names: solid-connection-server
           delete-untagged: true
           keep-n-tags: 5


### PR DESCRIPTION
## 관련 이슈

- resolves: #572 

## 작업 내용

<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

- GHCR에 올라간 이미지는 Github Action에서 제공하는 권한으로는 삭제할 수 없다고 공식문서에 나와있습니다.
- Github에서 해당 방식을 권장하는 이유는 자동화된 봇이 package 삭제권한을 주기에는 너무 큰 권한을 가지기에, 사용자가 승인한 토큰으로 개발하는게 정석이라고 합니다...
- 때문에 GHCR 이미지 정리(삭제)는 PAT로 구현해두었습니다! 

## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
