### PR TITLE
test: flyway 스크립트를 검증하는 테스트 코드 작성

### DIFF
--- a/src/test/java/com/example/solidconnection/database/FlywayMigrationTest.java
+++ b/src/test/java/com/example/solidconnection/database/FlywayMigrationTest.java
@@ -9,11 +9,8 @@ import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.testcontainers.containers.MySQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 @SpringBootTest
-@Testcontainers
 @ContextConfiguration(initializers = {RedisTestContainer.class, FlywayMigrationTest.FlywayMySQLInitializer.class})
 @TestPropertySource(properties = {
         "spring.flyway.enabled=true",
@@ -22,20 +19,23 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 })
 class FlywayMigrationTest {
 
-    @Container
-    private static final MySQLContainer<?> MYSQL = new MySQLContainer<>("mysql:8.0")
+    private static final MySQLContainer<?> CONTAINER = new MySQLContainer<>("mysql:8.0")
             .withDatabaseName("flyway_test")
             .withUsername("flyway_user")
             .withPassword("flyway_password");
 
+    static {
+        CONTAINER.start();
+    }
+
     static class FlywayMySQLInitializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
         @Override
-        public void initialize(ConfigurableApplicationContext ctx) {
+        public void initialize(ConfigurableApplicationContext applicationContext) {
             TestPropertyValues.of(
-                    "spring.datasource.url=" + MYSQL.getJdbcUrl(),
-                    "spring.datasource.username=" + MYSQL.getUsername(),
-                    "spring.datasource.password=" + MYSQL.getPassword()
-            ).applyTo(ctx.getEnvironment());
+                    "spring.datasource.url=" + CONTAINER.getJdbcUrl(),
+                    "spring.datasource.username=" + CONTAINER.getUsername(),
+                    "spring.datasource.password=" + CONTAINER.getPassword()
+            ).applyTo(applicationContext.getEnvironment());
         }
     }
 


### PR DESCRIPTION
## 관련 이슈

- resolves: #587 

## 작업 내용

<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

flyway는 `dev`, `prod` 프로파일에만 사용하고 있고, `ddl-auto: validate`로 스크립트와 JPA 간 명세 불일치를 감지합니다. 기존에는 `local` 환경에서 스크립트를 작성하고 이에 대한 검증을 수행하기 위해서 [`application-db.yml`의 `local` 프로파일을 수정](https://github.com/solid-connection/solid-connect-server/pull/359#pullrequestreview-2971448767)해야 했습니다.

스크립트의 버전 충돌이 발생하거나 파일명 형식이 일치하지 않으면 [스크립트가 실행되지 않거나](https://github.com/solid-connection/solid-connect-server/pull/405), [런타임 에러가 발생](https://github.com/solid-connection/solid-connect-server/pull/389)하게 됩니다.

따라서 [빌드 시점에 스크립트 검증을 수행](https://github.com/solid-connection/solid-connect-server/pull/393)하도록 gradle `flyway` 플러그인과 H2 데이터베이스를 사용하였습니다.
> 스크립트 내 SQL 문법을 확인하는 것이 목적이 아니었으므로 H2 인메모리 데이터베이스를 사용했습니다.
>

---

그러나 **스크립트 가 잘못 작성되어**, [런타임 에러가 발생하여 서버가 다운되는 상황](https://github.com/solid-connection/solid-connect-server/pull/530)이 있었습니다.

이에 관련 테스트 클래스를 생성하였고, `@TestPropertySource` 를 사용하여 flyway 설정을 사용하도록 구현했습니다.

## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

<img width="1915" height="1024" alt="Pasted image 20251221201924" src="https://github.com/user-attachments/assets/d51d655d-a27d-40a8-be8b-5d129584dba2" />

실제 동작입니다. 문법 오류를 잘 감지합니다.

---

이제 애플리케이션 빌드하면 스크립트 파일명 관련 검증이 가능하며, 테스트 코드를 실행하면 스크립트 SQL문 관련 검증이 가능합니다. 이제 스크립트로 인해 고통(?)받는 일은 없으면 좋겠네요 ..!

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->

로컬에서는 테스트 통과했는데 ... 깃허브 액션에서는 실패했습니다. 테스트 순서에 영향을 받나 싶어 컨텍스트를 날리고 수행하도록 했지만 실패해서, 별도의 MySQL 컨테이너를 만들어 수행하는 방법으로 구현했습니다.

현재로서는 지금 방법이 간단한 거 같긴 합니다. 더 좋은 방법이 있다면 말씀해주세요 !
