### PR TITLE
fix: DataSourceConfig 클래스 이름을 DataSourceProxyConfig로 revert 하여 충돌 유도

### DIFF
--- a/src/main/java/com/example/solidconnection/common/config/datasource/DataSourceProxyConfig.java
+++ b/src/main/java/com/example/solidconnection/common/config/datasource/DataSourceProxyConfig.java
@@ -14,7 +14,7 @@ import org.springframework.context.annotation.Primary;
 
 @RequiredArgsConstructor
 @Configuration
-public class DataSourceConfig {
+public class DataSourceProxyConfig {
 
     private final QueryMetricsListener queryMetricsListener;
 


### PR DESCRIPTION
## 관련 이슈

- resolves: #이슈 번호

## 작업 내용
반복되는 문제 발생 죄송합니다...

현재 release 브랜치에 존재하는 DataSourceProxyConfig 클래스와
develop에 존재하는 DataSourceConfig 클래스(DataSourceProxyConfig 를 수정한 클래스)
가 relesae 로 merge 시 공존해버리는 문제가 발생하여 빈 등록 문제가 생겼습니다.

이를 해결하기 위해, develop에서 가지 친 브랜치에 relesae 브랜치를 rebase 해서 공존하는 DataSource 클래스 중 이전 버전의 클래스를 변경하도록 이력을 남기려고 했으나, develop 브랜치에서 release 브랜치의 커밋내역을 알게 되는 문제가 발생하여 다른 방식으로 처리 해야할 듯 합니다.

그래서 현재 문제는 클래스 이름이 달라서 충돌이 나지 않고, 각 datasource 들이 공동으로 존재하는 문제이므로, 충돌을 발생시키기 위해 다시 클래스 이름을 동일하게 하여 develop -> release 로 merge 시 충돌을 발생시켜 conflict 를 해결하는 방식이 가능할 듯 하여 이름을 revert 하였습니다.

## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
