### PR TITLE
chore: claude Notification Hook이 Windows 환경에서도 동작하도록

### DIFF
--- a/.claude/hooks/notify.ps1
+++ b/.claude/hooks/notify.ps1
@@ -1,0 +1,9 @@
+Add-Type -AssemblyName System.Windows.Forms
+$n = New-Object System.Windows.Forms.NotifyIcon
+$n.Icon = [System.Drawing.SystemIcons]::Information
+$n.Visible = $true
+$n.BalloonTipTitle = "Claude Code"
+$n.BalloonTipText = "Awaiting your input"
+$n.ShowBalloonTip(5000)
+Start-Sleep -Milliseconds 5100
+$n.Dispose()

--- a/.claude/hooks/notify.py
+++ b/.claude/hooks/notify.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+import os
+import platform
+import subprocess
+
+system = platform.system()
+script_dir = os.path.dirname(os.path.abspath(__file__))
+
+if system == "Darwin":
+    subprocess.run([
+        "osascript", "-e",
+        'display notification "Awaiting your input" with title "Claude Code"'
+    ])
+elif system == "Windows":
+    ps1_path = os.path.join(script_dir, "notify.ps1")
+    subprocess.run([
+        "powershell", "-NoProfile", "-ExecutionPolicy", "Bypass",
+        "-File", ps1_path
+    ])

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,7 +9,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "osascript -e 'display notification \"Awaiting your input\" with title \"Claude Code\"'"
+            "command": "python3 .claude/hooks/notify.py 2>/dev/null || python .claude/hooks/notify.py"
           }
         ]
       }
@@ -20,7 +20,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 .claude/hooks/post-edit-check.py"
+            "command": "python3 .claude/hooks/post-edit-check.py 2>/dev/null || python .claude/hooks/post-edit-check.py"
           }
         ]
       }


### PR DESCRIPTION
## 관련 이슈

- resolves: #654 

## 작업 내용

<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

`settings.json` 에 작성된 hooks는 masOS 기준으로 작성되어, windows에서도 정상 동작하도록 수정했습니다.

별도의 알림 파이썬 스크립트를 작성하여 OS별로 작업을 선택합니다.

스크립트를 수행 시 `python` 으로 실행하는 구문을 추가했는데, windows 환경에서 `python3` 는 `C:\Users\chosh\AppData\Local\Microsoft\WindowsApps\python3` 를 가리키기에, 두 방식 모두 시도하도록 변경했습니다. 일단 `python` 으로 스크립트 수행하고, 제대로 동작하지 않으면(python이 설치되어 있지 않은 경우, macOS는 `python3`가 기본 설치되어 있음) `python3` 로 스크립트를 수행합니다.

## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
