### PR TITLE
refactor: EnumUtils 제거 후 PostCategory에 직접 검증 메서드 추가

### DIFF
--- a/src/main/java/com/example/solidconnection/community/post/domain/PostCategory.java
+++ b/src/main/java/com/example/solidconnection/community/post/domain/PostCategory.java
@@ -1,5 +1,17 @@
 package com.example.solidconnection.community.post.domain;
 
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 public enum PostCategory {
-    전체, 자유, 질문
+    전체, 자유, 질문;
+
+    private static final Set<String> NAMES = Arrays.stream(values())
+            .map(Enum::name)
+            .collect(Collectors.toSet());
+
+    public static boolean isValid(String name){
+        return name != null && NAMES.contains(name);
+    }
 }

--- a/src/main/java/com/example/solidconnection/community/post/service/PostCommandService.java
+++ b/src/main/java/com/example/solidconnection/community/post/service/PostCommandService.java
@@ -27,7 +27,6 @@ import com.example.solidconnection.siteuser.repository.SiteUserRepository;
 import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
-import org.apache.commons.lang3.EnumUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -137,7 +136,7 @@ public class PostCommandService {
     }
 
     private void validatePostCategory(String category) {
-        if (!EnumUtils.isValidEnum(PostCategory.class, category) || category.equals(PostCategory.전체.toString())) {
+        if (!PostCategory.isValid(category) || category.equals(PostCategory.전체.toString())) {
             throw new CustomException(INVALID_POST_CATEGORY);
         }
     }

--- a/src/main/java/com/example/solidconnection/community/post/service/PostCommandService.java
+++ b/src/main/java/com/example/solidconnection/community/post/service/PostCommandService.java
@@ -74,6 +74,7 @@ public class PostCommandService {
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
         // 유효성 검증
         Post post = postRepository.getById(postId);
+        validatePostCategory(postUpdateRequest.postCategory());
         validateOwnership(post, siteUser);
         validateQuestion(post);
         validateFileSize(imageFile);

--- a/src/main/java/com/example/solidconnection/community/post/service/PostQueryService.java
+++ b/src/main/java/com/example/solidconnection/community/post/service/PostQueryService.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.apache.commons.lang3.EnumUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -103,7 +102,7 @@ public class PostQueryService {
     }
 
     private PostCategory validatePostCategory(String category) {
-        if (!EnumUtils.isValidEnum(PostCategory.class, category)) {
+        if (!PostCategory.isValid(category)) {
             throw new CustomException(INVALID_POST_CATEGORY);
         }
         return PostCategory.valueOf(category);


### PR DESCRIPTION
## 관련 이슈

- resolves: #706 

## 작업 내용
EnumUtils.isValidEnum()에 의존하던 Enum 검증 로직을 Enum 내부로 
1. 추후 버전업에서 발생할 수 있는 common-lang3 의존성을 추가 할 필요가 없음
2. 유연한 확장 가능
3. 높은 응집도

## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
