### PR TITLE
fix: dev(stage) 환경의 refreshToken 쿠키 이름 분리

### DIFF
--- a/src/main/java/com/example/solidconnection/auth/controller/RefreshTokenCookieManager.java
+++ b/src/main/java/com/example/solidconnection/auth/controller/RefreshTokenCookieManager.java
@@ -20,7 +20,6 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class RefreshTokenCookieManager {
 
-    private static final String COOKIE_NAME = "refreshToken";
     private static final String PATH = "/";
 
     private final RefreshTokenCookieProperties properties;
@@ -44,7 +43,7 @@ public class RefreshTokenCookieManager {
     private void setRefreshTokenCookie(
             HttpServletResponse response, String refreshToken, long maxAge
     ) {
-        ResponseCookie cookie = ResponseCookie.from(COOKIE_NAME, refreshToken)
+        ResponseCookie cookie = ResponseCookie.from(properties.cookieName(), refreshToken)
                 .httpOnly(true)
                 .secure(true)
                 .path(PATH)
@@ -64,7 +63,7 @@ public class RefreshTokenCookieManager {
 
         // refreshToken 쿠키가 없는 경우 예외 발생
         Cookie refreshTokenCookie = Arrays.stream(cookies)
-                .filter(cookie -> COOKIE_NAME.equals(cookie.getName()))
+                .filter(cookie -> properties.cookieName().equals(cookie.getName()))
                 .findFirst()
                 .orElseThrow(() -> new CustomException(REFRESH_TOKEN_NOT_EXISTS));
 

--- a/src/main/java/com/example/solidconnection/auth/controller/config/RefreshTokenCookieProperties.java
+++ b/src/main/java/com/example/solidconnection/auth/controller/config/RefreshTokenCookieProperties.java
@@ -4,6 +4,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "token.refresh")
 public record RefreshTokenCookieProperties(
+        String cookieName,
         String cookieDomain
 ) {
 

--- a/src/main/resources/config/application-variable.yml
+++ b/src/main/resources/config/application-variable.yml
@@ -81,6 +81,7 @@ sentry:
 
 token:
   refresh:
+    cookie-name: "refreshToken"
     cookie-domain: ".solid-connection.com"
 
 ---
@@ -118,6 +119,7 @@ sentry:
 
 token:
   refresh:
+    cookie-name: "stageRefreshToken"
     cookie-domain: ".stage.solid-connection.com"
 
 ---
@@ -152,4 +154,5 @@ sentry:
 
 token:
   refresh:
+    cookie-name: "refreshToken"
     cookie-domain: "localhost"

--- a/src/main/resources/config/application-variable.yml
+++ b/src/main/resources/config/application-variable.yml
@@ -81,7 +81,7 @@ sentry:
 
 token:
   refresh:
-    cookie-name: "refreshToken"
+    cookie-name: "prodRefreshToken"
     cookie-domain: ".solid-connection.com"
 
 ---

--- a/src/test/java/com/example/solidconnection/auth/controller/RefreshTokenCookieManagerTest.java
+++ b/src/test/java/com/example/solidconnection/auth/controller/RefreshTokenCookieManagerTest.java
@@ -38,6 +38,7 @@ class RefreshTokenCookieManagerTest {
 
     @BeforeEach
     void setUp() {
+        given(refreshTokenCookieProperties.cookieName()).willReturn(REFRESH_TOKEN_COOKIE_NAME);
         given(refreshTokenCookieProperties.cookieDomain()).willReturn(domain);
     }
 


### PR DESCRIPTION
## 관련 이슈

- resolves: #711 

## 작업 내용
prod 와 stage 의 refreshToken 키 네임이 동일하여 발생하는 로그인 문제를 해결하기 위해 stage 서버의 key name을 **stageRefreshToken** 으로 수정하였습니다.

1. prod 브라우저의 refresthToken 이 stage 브라우저 에서도 유효
2. 프론트 미들웨어에서 refreshToken 을 관리 할 때, prod와 stage 둘다 key name이 동일하여 덮어 씌워지는 문제 발생.

## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
