### PR TITLE
feat: SiteUser 도메인 엔티티에 homeUniversityId 필드 추가 및 테이블에 컬럼 추가

### DIFF
--- a/src/main/java/com/example/solidconnection/siteuser/domain/SiteUser.java
+++ b/src/main/java/com/example/solidconnection/siteuser/domain/SiteUser.java
@@ -51,6 +51,10 @@ public class SiteUser extends BaseEntity {
     private String nickname;
 
     @Setter
+    @Column(name = "home_university_id", nullable = true)
+    private Long homeUniversityId;
+
+    @Setter
     @Column(name = "profile_image_url", length = 500)
     private String profileImageUrl;
 
@@ -118,6 +122,27 @@ public class SiteUser extends BaseEntity {
             UserStatus userStatus) {
         this.email = email;
         this.nickname = nickname;
+        this.profileImageUrl = profileImageUrl;
+        this.exchangeStatus = exchangeStatus;
+        this.role = role;
+        this.authType = authType;
+        this.password = password;
+        this.userStatus = userStatus;
+    }
+
+    public SiteUser(
+            String email,
+            String nickname,
+            Long homeUniversityId,
+            String profileImageUrl,
+            ExchangeStatus exchangeStatus,
+            Role role,
+            AuthType authType,
+            String password,
+            UserStatus userStatus) {
+        this.email = email;
+        this.nickname = nickname;
+        this.homeUniversityId = homeUniversityId;
         this.profileImageUrl = profileImageUrl;
         this.exchangeStatus = exchangeStatus;
         this.role = role;

--- a/src/main/resources/db/migration/V48__add_home_university_id_to_site_user.sql
+++ b/src/main/resources/db/migration/V48__add_home_university_id_to_site_user.sql
@@ -1,0 +1,6 @@
+ALTER TABLE site_user
+    ADD COLUMN home_university_id BIGINT;
+
+ALTER TABLE site_user
+    ADD CONSTRAINT fk_site_user_home_university
+        FOREIGN KEY (home_university_id) REFERENCES home_university(id) ON DELETE NO ACTION;

--- a/src/test/java/com/example/solidconnection/siteuser/fixture/SiteUserFixtureBuilder.java
+++ b/src/test/java/com/example/solidconnection/siteuser/fixture/SiteUserFixtureBuilder.java
@@ -20,6 +20,7 @@ public class SiteUserFixtureBuilder {
     private String email;
     private AuthType authType;
     private String nickname;
+    private Long homeUniversityId;
     private String profileImageUrl;
     private Role role;
     private String password;
@@ -41,6 +42,11 @@ public class SiteUserFixtureBuilder {
 
     public SiteUserFixtureBuilder nickname(String nickname) {
         this.nickname = nickname;
+        return this;
+    }
+
+    public SiteUserFixtureBuilder homeUniversityId(Long homeUniversityId) {
+        this.homeUniversityId = homeUniversityId;
         return this;
     }
 
@@ -68,6 +74,7 @@ public class SiteUserFixtureBuilder {
         SiteUser siteUser = new SiteUser(
                 email,
                 nickname,
+                homeUniversityId,
                 profileImageUrl,
                 ExchangeStatus.CONSIDERING,
                 role,


### PR DESCRIPTION
## 관련 이슈

- resolves: #717 

## 작업 내용

<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

대학확장논의 #626 에서 나왔던 내용대로 SiteUser 도메인 엔티티에 homeUniversityId를 추가하였습니다.
또한, 컬럼 추가에 따른 Flyway 스크립트를 작성했습니다.

## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

- 이후 작업인 JWT에 homeUniversityId 클레임 추가 작업을 원할하게 하기 위해 먼저 작업을 끝내두었으니, 리뷰어분들은 남은 작업 조정 부탁드립니다.

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->

- 컬럼 추가에 따른 테스트 코드는 추가하지 않았습니다. 해당 컬럼에 대해서 값의 변경이 어떤 API 호출에 의해 정해지는지 아직 전달받은 내용이 없어서 일단 homeUniversityId를 바인딩 할 수 있는 생성자 메서드만 생성하였습니다.