### PR TITLE
refactor: 액세스 토큰 JWT 클레임에 homeUniversityId를 추가 

### DIFF
--- a/src/main/java/com/example/solidconnection/auth/service/AuthTokenProvider.java
+++ b/src/main/java/com/example/solidconnection/auth/service/AuthTokenProvider.java
@@ -10,6 +10,8 @@ import com.example.solidconnection.common.exception.CustomException;
 import com.example.solidconnection.siteuser.domain.Role;
 import com.example.solidconnection.siteuser.domain.SiteUser;
 import com.example.solidconnection.siteuser.repository.SiteUserRepository;
+
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +22,7 @@ import org.springframework.stereotype.Component;
 public class AuthTokenProvider {
 
     private static final String ROLE_CLAIM_KEY = "role";
+    private static final String HOME_UNIVERSITY_CLAIM_KEY = "home_university";
 
     private final TokenProvider tokenProvider;
     private final TokenStorage tokenStorage;
@@ -29,9 +32,14 @@ public class AuthTokenProvider {
     public AccessToken generateAccessToken(SiteUser siteUser) {
         Subject subject = toSubject(siteUser);
         Role role = siteUser.getRole();
+        Map<String, String> claims = new HashMap<>(Map.of(ROLE_CLAIM_KEY, role.name()));
+        if (siteUser.getHomeUniversityId() != null) {
+            claims.put(HOME_UNIVERSITY_CLAIM_KEY, String.valueOf(siteUser.getHomeUniversityId()));
+        }
+
         String token = tokenProvider.generateToken(
                 subject,
-                Map.of(ROLE_CLAIM_KEY, role.name()),
+                claims,
                 tokenProperties.access().expireTime()
         );
         return new AccessToken(token);
@@ -69,6 +77,11 @@ public class AuthTokenProvider {
         long siteUserId = Long.parseLong(subject.value());
         return siteUserRepository.findById(siteUserId)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+    }
+
+    public Long parseHomeUniversityId(String token) {
+        String value = tokenProvider.parseClaims(token, HOME_UNIVERSITY_CLAIM_KEY, String.class);
+        return value != null ? Long.parseLong(value) : null;
     }
 
     public Subject toSubject(SiteUser siteUser) {

--- a/src/main/java/com/example/solidconnection/auth/service/AuthTokenProvider.java
+++ b/src/main/java/com/example/solidconnection/auth/service/AuthTokenProvider.java
@@ -10,7 +10,6 @@ import com.example.solidconnection.common.exception.CustomException;
 import com.example.solidconnection.siteuser.domain.Role;
 import com.example.solidconnection.siteuser.domain.SiteUser;
 import com.example.solidconnection.siteuser.repository.SiteUserRepository;
-
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;

--- a/src/test/java/com/example/solidconnection/auth/service/AuthTokenProviderTest.java
+++ b/src/test/java/com/example/solidconnection/auth/service/AuthTokenProviderTest.java
@@ -10,6 +10,7 @@ import com.example.solidconnection.siteuser.domain.Role;
 import com.example.solidconnection.siteuser.domain.SiteUser;
 import com.example.solidconnection.siteuser.fixture.SiteUserFixture;
 import com.example.solidconnection.support.TestContainerSpringBootTest;
+import com.example.solidconnection.university.fixture.HomeUniversityFixture;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -33,12 +34,19 @@ class AuthTokenProviderTest {
     @Autowired
     private SiteUserFixture siteUserFixture;
 
+    @Autowired
+    private HomeUniversityFixture homeUniversityFixture;
+
     private SiteUser siteUser;
+    private SiteUser siteUserWithHomeUniversity;
+    private Long homeUniversityId;
     private Subject expectedSubject;
 
     @BeforeEach
     void setUp() {
+        homeUniversityId = homeUniversityFixture.인하대학교().getId();
         siteUser = siteUserFixture.사용자();
+        siteUserWithHomeUniversity = siteUserFixture.국내_대학_정보_소지_사용자(homeUniversityId);
         expectedSubject = new Subject(siteUser.getId().toString());
     }
 
@@ -68,6 +76,30 @@ class AuthTokenProviderTest {
 
         // then
         assertThat(actualSitUser.getId()).isEqualTo(siteUser.getId());
+    }
+
+    @Nested
+    class 액세스_토큰_homeUniversityId_클레임 {
+
+        @Test
+        void homeUniversityId가_있는_사용자는_액세스_토큰_클레임에_포함된다() {
+            // when
+            String token = authTokenProvider.generateAccessToken(siteUserWithHomeUniversity).token();
+
+            // then
+            Long actual = authTokenProvider.parseHomeUniversityId(token);
+            assertThat(actual).isEqualTo(homeUniversityId);
+        }
+
+        @Test
+        void homeUniversityId가_없는_사용자는_액세스_토큰_클레임에서_생략된다() {
+            // when
+            String token = authTokenProvider.generateAccessToken(siteUser).token();
+
+            // then
+            Long actual = authTokenProvider.parseHomeUniversityId(token);
+            assertThat(actual).isNull();
+        }
     }
 
     @Nested

--- a/src/test/java/com/example/solidconnection/siteuser/fixture/SiteUserFixture.java
+++ b/src/test/java/com/example/solidconnection/siteuser/fixture/SiteUserFixture.java
@@ -61,6 +61,19 @@ public class SiteUserFixture {
                 .create();
     }
 
+    public SiteUser 국내_대학_정보_소지_사용자(Long homeUniversityId) {
+        return siteUserFixtureBuilder.siteUser()
+                .email("university@example.com")
+                .authType(AuthType.EMAIL)
+                .nickname("국내대학사용자")
+                .homeUniversityId(homeUniversityId)
+                .profileImageUrl("profileImageUrl")
+                .role(Role.MENTEE)
+                .password("password123")
+                .userStatus(UserStatus.ACTIVE)
+                .create();
+    }
+
     public SiteUser 멘토(int index, String nickname) {
         return siteUserFixtureBuilder.siteUser()
                 .email("mentor" + index + "@example.com")


### PR DESCRIPTION
## 관련 이슈

- resolves: #716

## 작업 내용

<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

1. refactor: 액세스 토큰 JWT 클레임에 homeUniversityId를 추가
   - generateAccessToken 메서드에 siteUser가 homeUniversityId가 null이 아니라면 claim에 추가
   - parseHomeUniversityId 메서드 추가

2. test: 액세스 토큰 JWT 클레임에 homeUniversityId를 추가한 것에 대한 테스트 추가
   - SiteUserFixture에 국내_대학_정보_소지_사용자 메서드 추가

## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

#### PostViewCountConcurrencyTest.게시글을_조회할_때_조회수_조작_문제를_해결한다() 메서드 CI 간헐적 실패 오류 발견

1. 게시글을_조회할_때_조회수_동시성_문제를_해결한다 테스트가 먼저 실행됨
2. 그 테스트의 @Async 스케줄러 태스크가 asyncExecutor 큐에 남아있는 상태에서 DatabaseCleaner.clear()가 실행됨
3. flushDb()로 Redis는 지워지지만, asyncExecutor 큐의 태스크는 남아있음
4. 두 번째 테스트에서 같은 key 이름 (post:view:1, auto_increment 리셋)으로 새 viewCountKey 생성
5. 오래된 큐 태스크 + 새 스케줄러 태스크가 동일한 key를 동시에 getAndDelete 시도
6. 하나는 값을 가져가고, 다른 하나는 null을 받아 UPDATE post SET view_count = view_count + null = null 실행

> 근본 원인은 UpdateViewCountService.updateViewCount가 null 방어를 하지 않는 것입니다.

해당 부분은 issue로 정의하여 만들어두겠습니다.

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->

- 현재 homeUniversityId는 최근 추가한 컬럼이기에 대부분 null일 가능성이 높으므로 기존에 배포된 서비스에 영향이 가지 않도록 homeUniversityId가 null일때 예외를 발생하지 않고 넘어가도록 구현했습니다.
- 토큰에 반영된 homeUniversityId에 변경 이벤트 시점에 대해서 기획측에서 전달받은 내용이 없으므로, homeUniversityId 갱신에 따른 토큰 재발급 로직은 해당 기획이 정해져 작업을 할때 같이 반영하는 게 좋다고 생각해서 현재 구현에서 제외했습니다.