### PR TITLE
feat: 멘토 승격 요청 횟수 제한 추가

### DIFF
--- a/src/main/java/com/example/solidconnection/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/solidconnection/common/exception/ErrorCode.java
@@ -1,6 +1,7 @@
 package com.example.solidconnection.common.exception;
 
 import static com.example.solidconnection.application.service.ApplicationSubmissionService.APPLICATION_UPDATE_COUNT_LIMIT;
+import static com.example.solidconnection.mentor.service.MentorApplicationService.MENTOR_APPLICATION_COUNT_LIMIT;
 import static com.example.solidconnection.siteuser.service.MyPageService.MIN_DAYS_BETWEEN_NICKNAME_CHANGES;
 
 import lombok.AllArgsConstructor;
@@ -133,6 +134,7 @@ public enum ErrorCode {
     UNAUTHORIZED_MENTORING(HttpStatus.FORBIDDEN.value(), "멘토링 권한이 없습니다."),
     MENTORING_ALREADY_CONFIRMED(HttpStatus.BAD_REQUEST.value(), "이미 승인 또는 거절된 멘토링입니다."),
     MENTOR_APPLICATION_ALREADY_EXISTED(HttpStatus.CONFLICT.value(), "멘토 승격 요청이 이미 존재합니다."),
+    MENTOR_APPLICATION_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST.value(), "멘토 승격 요청은 " + MENTOR_APPLICATION_COUNT_LIMIT + "회까지만 가능합니다."),
     INVALID_EXCHANGE_STATUS_FOR_MENTOR(HttpStatus.BAD_REQUEST.value(), "멘토 승격 지원 가능한 교환학생 상태가 아닙니다."),
     UNIVERSITY_ID_REQUIRED_FOR_CATALOG(HttpStatus.BAD_REQUEST.value(), "목록에서 학교를 선택한 경우 학교 정보가 필요합니다."),
     UNIVERSITY_ID_MUST_BE_NULL_FOR_OTHER(HttpStatus.BAD_REQUEST.value(), "기타 학교를 선택한 경우 학교 정보를 입력할 수 없습니다."),

--- a/src/main/java/com/example/solidconnection/mentor/service/MentorApplicationService.java
+++ b/src/main/java/com/example/solidconnection/mentor/service/MentorApplicationService.java
@@ -1,6 +1,7 @@
 package com.example.solidconnection.mentor.service;
 
 import static com.example.solidconnection.common.exception.ErrorCode.MENTOR_APPLICATION_ALREADY_EXISTED;
+import static com.example.solidconnection.common.exception.ErrorCode.MENTOR_APPLICATION_LIMIT_EXCEEDED;
 import static com.example.solidconnection.common.exception.ErrorCode.TERM_NOT_FOUND;
 import static com.example.solidconnection.common.exception.ErrorCode.USER_NOT_FOUND;
 
@@ -28,6 +29,8 @@ import org.springframework.web.multipart.MultipartFile;
 @Slf4j
 public class MentorApplicationService {
 
+    public static final int MENTOR_APPLICATION_COUNT_LIMIT = 5;
+
     private final MentorApplicationRepository mentorApplicationRepository;
     private final SiteUserRepository siteUserRepository;
     private final S3Service s3Service;
@@ -40,6 +43,7 @@ public class MentorApplicationService {
             MultipartFile file
     ) {
         ensureNoPendingOrApprovedMentorApplication(siteUserId);
+        ensureApplicationCountNotExceeded(siteUserId);
 
         SiteUser siteUser = siteUserRepository.findById(siteUserId)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
@@ -64,6 +68,12 @@ public class MentorApplicationService {
                 List.of(MentorApplicationStatus.PENDING, MentorApplicationStatus.APPROVED))
         ) {
             throw new CustomException(MENTOR_APPLICATION_ALREADY_EXISTED);
+        }
+    }
+
+    private void ensureApplicationCountNotExceeded(long siteUserId) {
+        if (mentorApplicationRepository.countBySiteUserId(siteUserId) >= MENTOR_APPLICATION_COUNT_LIMIT) {
+            throw new CustomException(MENTOR_APPLICATION_LIMIT_EXCEEDED);
         }
     }
 }

--- a/src/test/java/com/example/solidconnection/mentor/service/MentorApplicationServiceTest.java
+++ b/src/test/java/com/example/solidconnection/mentor/service/MentorApplicationServiceTest.java
@@ -1,8 +1,10 @@
 package com.example.solidconnection.mentor.service;
 
 import static com.example.solidconnection.common.exception.ErrorCode.MENTOR_APPLICATION_ALREADY_EXISTED;
+import static com.example.solidconnection.common.exception.ErrorCode.MENTOR_APPLICATION_LIMIT_EXCEEDED;
 import static com.example.solidconnection.common.exception.ErrorCode.UNIVERSITY_ID_MUST_BE_NULL_FOR_OTHER;
 import static com.example.solidconnection.common.exception.ErrorCode.UNIVERSITY_ID_REQUIRED_FOR_CATALOG;
+import static com.example.solidconnection.mentor.service.MentorApplicationService.MENTOR_APPLICATION_COUNT_LIMIT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
 import static org.mockito.BDDMockito.given;
@@ -161,6 +163,24 @@ public class MentorApplicationServiceTest {
         assertThatCode(() -> mentorApplicationService.submitMentorApplication(user.getId(), request, file))
                 .isInstanceOf(CustomException.class)
                 .hasMessage(MENTOR_APPLICATION_ALREADY_EXISTED.getMessage());
+    }
+
+    @Test
+    void 멘토_승격_신청_횟수가_최대_횟수에_도달하면_예외가_발생한다() {
+        // given
+        for (int i = 0; i < MENTOR_APPLICATION_COUNT_LIMIT; i++) {
+            mentorApplicationFixture.거절된_멘토신청(user.getId(), UniversitySelectType.CATALOG, 1L);
+        }
+
+        UniversitySelectType universitySelectType = UniversitySelectType.CATALOG;
+        Long universityId = 1L;
+        MentorApplicationRequest request = createMentorApplicationRequest(universitySelectType, universityId);
+        MockMultipartFile file = createMentorProofFile();
+
+        // when & then
+        assertThatCode(() -> mentorApplicationService.submitMentorApplication(user.getId(), request, file))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(MENTOR_APPLICATION_LIMIT_EXCEEDED.getMessage());
     }
 
     @Test


### PR DESCRIPTION
유저당 멘토 승격 요청을 최대 5회까지만 가능하도록 제한

## 관련 이슈

- resolves: #667 

## 작업 내용

  MentorApplicationService
  - MENTOR_APPLICATION_COUNT_LIMIT = 5 상수 추가
  - 신청 시 누적 횟수가 한도에 도달하면 예외를 던지는 ensureApplicationCountNotExceeded() 메서드 추가
  - submitMentorApplication() 호출 흐름에 횟수 검증 추가

  ErrorCode
  - MENTOR_APPLICATION_LIMIT_EXCEEDED 에러 코드 추가
    - HTTP 400 Bad Request
    - 메시지: "멘토 승격 요청은 5회까지만 가능합니다."
    - 한도 변경 시 상수만 수정하면 메시지도 자동 반영되도록 MENTOR_APPLICATION_COUNT_LIMIT 참조

  MentorApplicationServiceTest
  - 멘토_승격_신청_횟수가_최대_횟수에_도달하면_예외가_발생한다 테스트 추가


  ### 검증 흐름

  신청 시 아래 순서로 검증합니다.

  1. PENDING 또는 APPROVED 상태의 신청이 존재하는지 확인 (기존)
  2. 누적 신청 횟수가 5회 이상인지 확인 (신규)

  countBySiteUserId()는 MentorApplicationRepository에 기존에 존재하는 메서드를 재사용했습니다.

## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
