### PR TITLE
refactor: prod/stage 환경 nginx 블루/그린 배포 방식 도입

### DIFF
--- a/.github/workflows/dev-cd.yml
+++ b/.github/workflows/dev-cd.yml
@@ -153,11 +153,10 @@ jobs:
                 docker compose -p "${CONTAINER_BASE}-${NEW_SLOT}" -f docker-compose.dev.yml up -d solid-connection-dev
 
               # 8. 헬스 체크 (앱 기동 대기, 최대 150초)
-              # /actuator/health 미노출로 포트 응답 여부로 확인 (HTTP 000 = 연결 불가)
-              echo "Waiting for app on port ${NEW_PORT}..."
+              echo "Waiting for app on management port ${MANAGEMENT_PORT}..."
               for i in $(seq 1 30); do
-                HTTP=$(curl -s --connect-timeout 2 -o /dev/null -w "%{http_code}" "http://localhost:${NEW_PORT}/" || true)
-                [ "$HTTP" != "000" ] && { echo "App responding (HTTP ${HTTP}, attempt ${i})"; break; }
+                STATUS=$(curl -s --connect-timeout 2 "http://localhost:${MANAGEMENT_PORT}/actuator/health" | grep -o '"status":"UP"' || true)
+                [ "$STATUS" = '"status":"UP"' ] && { echo "App healthy (attempt ${i})"; break; }
                 [ "$i" = "30" ] && {
                   echo "Health check timed out after 150s" >&2
                   docker stop "${CONTAINER_BASE}-${NEW_SLOT}" 2>/dev/null || true

--- a/.github/workflows/dev-cd.yml
+++ b/.github/workflows/dev-cd.yml
@@ -122,35 +122,37 @@ jobs:
               # 1. Active 슬롯 확인 (upstream.conf 기준)
               UPSTREAM_PORT=$(grep -oE "server 127\.0\.0\.1:[0-9]+" /etc/nginx/conf.d/upstream.conf 2>/dev/null | grep -oE "[0-9]+$" || echo "8081")
               if [ "$UPSTREAM_PORT" = "8080" ]; then
-                ACTIVE_SLOT="blue"; ACTIVE_PORT=8080; NEW_SLOT="green"; NEW_PORT=8081
+                ACTIVE_SLOT="blue"; ACTIVE_PORT=8080; NEW_SLOT="green"; NEW_PORT=8081; MANAGEMENT_PORT=9081
               else
-                ACTIVE_SLOT="green"; ACTIVE_PORT=8081; NEW_SLOT="blue"; NEW_PORT=8080
+                ACTIVE_SLOT="green"; ACTIVE_PORT=8081; NEW_SLOT="blue"; NEW_PORT=8080; MANAGEMENT_PORT=9080
               fi
-              echo "Active: ${ACTIVE_SLOT}(${ACTIVE_PORT}) → Deploy: ${NEW_SLOT}(${NEW_PORT})"
+              echo "Active: ${ACTIVE_SLOT}(${ACTIVE_PORT}) → Deploy: ${NEW_SLOT}(${NEW_PORT}), management: ${MANAGEMENT_PORT}"
 
-              # 2. MySQL 기동 확인 (블루/그린 전환 대상 아님)
+              # 2. 작업 디렉토리 이동 (이후 모든 compose 명령 기준)
+              cd "${WORK_DIR}"
+
+              # 3. MySQL 기동 확인 (블루/그린 전환 대상 아님)
               docker compose -f docker-compose.dev.yml up -d mysql 2>/dev/null || true
 
-              # 3. Pull 전 디스크 정리 (태그 이미지 최근 2개 유지)
+              # 4. Pull 전 디스크 정리 (태그 이미지 최근 2개 유지)
               docker images "${IMAGE_NAME_BASE}" --format "{{.Tag}}" | \
                 grep -v buildcache | sort -r | tail -n +3 | \
                 xargs -I {} docker rmi "${IMAGE_NAME_BASE}:{}" 2>/dev/null || true
               docker image prune -f
 
-              # 4. GHCR 로그인 & Pull
+              # 5. GHCR 로그인 & Pull
               echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
               docker pull "${FULL_IMAGE_NAME}"
 
-              # 5. 새 슬롯 잔여 컨테이너 정리
+              # 6. 새 슬롯 잔여 컨테이너 정리
               docker stop "${CONTAINER_BASE}-${NEW_SLOT}" 2>/dev/null || true
               docker rm   "${CONTAINER_BASE}-${NEW_SLOT}" 2>/dev/null || true
 
-              # 6. 새 컨테이너 시작
-              cd "${WORK_DIR}"
-              SLOT="${NEW_SLOT}" APP_PORT="${NEW_PORT}" OWNER_LOWERCASE="${OWNER_LOWERCASE}" IMAGE_TAG="${IMAGE_TAG_ONLY}" \
+              # 7. 새 컨테이너 시작
+              SLOT="${NEW_SLOT}" APP_PORT="${NEW_PORT}" MANAGEMENT_PORT="${MANAGEMENT_PORT}" OWNER_LOWERCASE="${OWNER_LOWERCASE}" IMAGE_TAG="${IMAGE_TAG_ONLY}" \
                 docker compose -p "${CONTAINER_BASE}-${NEW_SLOT}" -f docker-compose.dev.yml up -d solid-connection-dev
 
-              # 7. 헬스 체크 (앱 기동 대기, 최대 150초)
+              # 8. 헬스 체크 (앱 기동 대기, 최대 150초)
               # /actuator/health 미노출로 포트 응답 여부로 확인 (HTTP 000 = 연결 불가)
               echo "Waiting for app on port ${NEW_PORT}..."
               for i in $(seq 1 30); do
@@ -165,12 +167,12 @@ jobs:
                 sleep 5
               done
 
-              # 8. Nginx upstream 전환 (무중단)
+              # 9. Nginx upstream 전환 (무중단)
               sudo sed -i "s|server 127.0.0.1:[0-9]*;|server 127.0.0.1:${NEW_PORT};|" /etc/nginx/conf.d/upstream.conf
               sudo nginx -s reload
               echo "Traffic switched → ${NEW_SLOT}(${NEW_PORT})"
 
-              # 9. 구 컨테이너 종료
+              # 10. 구 컨테이너 종료
               docker compose -p "${CONTAINER_BASE}-${ACTIVE_SLOT}" -f docker-compose.dev.yml down 2>/dev/null || true
 
               echo "Deployment complete. Active: ${NEW_SLOT}(${NEW_PORT})"

--- a/.github/workflows/dev-cd.yml
+++ b/.github/workflows/dev-cd.yml
@@ -66,7 +66,7 @@ jobs:
           cache-from: type=registry,ref=${{ steps.image_meta.outputs.image_name }}:buildcache
           cache-to: type=registry,ref=${{ steps.image_meta.outputs.image_name }}:buildcache,mode=max
 
-      # --- 이미지 정리 (이전 Job에 있던 것) ---
+      # --- 이미지 정리 ---
       - name: Clean up old image versions from GHCR
         uses: snok/container-retention-policy@v2
         with:
@@ -87,7 +87,6 @@ jobs:
       packages: read
 
     steps:
-      # 설정 파일 전송을 위해 코드 체크아웃 (서브모듈 불필요)
       - name: Checkout config files
         uses: actions/checkout@v4
         with:
@@ -96,52 +95,83 @@ jobs:
             docs/infra-config
           sparse-checkout-cone-mode: false
 
-      # --- 설정 파일 전송 ---
       - name: Copy config files to remote
         run: |
           echo "${{ secrets.DEV_PRIVATE_KEY }}" > deploy_key.pem
           chmod 600 deploy_key.pem
-          
+
           scp -i deploy_key.pem \
             -o StrictHostKeyChecking=no \
             ./docker-compose.dev.yml \
             ${{ secrets.DEV_USERNAME }}@${{ secrets.DEV_HOST }}:/home/${{ secrets.DEV_USERNAME }}/solid-connection-dev/
 
-      # --- 서버에서 Docker Pull 및 재시작 ---
-      - name: Run deployment on server
+      - name: Blue/Green deploy
         run: |
           ssh -i deploy_key.pem \
-           -o StrictHostKeyChecking=no \
-           ${{ secrets.DEV_USERNAME }}@${{ secrets.DEV_HOST }} \
-           '
-            set -e
-          
-            # 1. 환경 변수 설정 (이전 Job의 Output 사용)
-            export OWNER_LOWERCASE=$(echo "${{ github.repository_owner }}" | tr "[:upper:]" "[:lower:]")
-            export IMAGE_TAG_ONLY="${{ needs.build-and-push.outputs.image_tag }}"
-            export FULL_IMAGE_NAME="ghcr.io/${OWNER_LOWERCASE}/solid-connection-dev:${IMAGE_TAG_ONLY}"
-            export IMAGE_NAME_BASE="ghcr.io/${OWNER_LOWERCASE}/solid-connection-dev"
+            -o StrictHostKeyChecking=no \
+            ${{ secrets.DEV_USERNAME }}@${{ secrets.DEV_HOST }} \
+            '
+              set -e
+              OWNER_LOWERCASE=$(echo "${{ github.repository_owner }}" | tr "[:upper:]" "[:lower:]")
+              IMAGE_TAG_ONLY="${{ needs.build-and-push.outputs.image_tag }}"
+              FULL_IMAGE_NAME="ghcr.io/${OWNER_LOWERCASE}/solid-connection-dev:${IMAGE_TAG_ONLY}"
+              IMAGE_NAME_BASE="ghcr.io/${OWNER_LOWERCASE}/solid-connection-dev"
+              WORK_DIR="/home/${{ secrets.DEV_USERNAME }}/solid-connection-dev"
+              CONTAINER_BASE="solid-connection-dev"
 
-            # 2. Pull 전 정리 (디스크 공간 확보)
-            echo "Cleaning up old tagged images (keeping last 2)..."
-            docker images "${IMAGE_NAME_BASE}" --format "{{.Tag}}" | \
-            sort -r | \
-            tail -n +3 | \
-            xargs -I {} docker rmi "${IMAGE_NAME_BASE}:{}" || true
+              # 1. Active 슬롯 확인 (upstream.conf 기준)
+              UPSTREAM_PORT=$(grep -oE "server 127\.0\.0\.1:[0-9]+" /etc/nginx/conf.d/upstream.conf 2>/dev/null | grep -oE "[0-9]+$" || echo "8081")
+              if [ "$UPSTREAM_PORT" = "8080" ]; then
+                ACTIVE_SLOT="blue"; ACTIVE_PORT=8080; NEW_SLOT="green"; NEW_PORT=8081
+              else
+                ACTIVE_SLOT="green"; ACTIVE_PORT=8081; NEW_SLOT="blue"; NEW_PORT=8080
+              fi
+              echo "Active: ${ACTIVE_SLOT}(${ACTIVE_PORT}) → Deploy: ${NEW_SLOT}(${NEW_PORT})"
 
-            echo "Pruning dangling images..."
-            docker image prune -f
+              # 2. MySQL 기동 확인 (블루/그린 전환 대상 아님)
+              docker compose -f docker-compose.dev.yml up -d mysql 2>/dev/null || true
 
-            # 3. GHCR 로그인 & Pull
-            echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-            echo "Pulling new image: $FULL_IMAGE_NAME"
-            docker pull $FULL_IMAGE_NAME
+              # 3. Pull 전 디스크 정리 (태그 이미지 최근 2개 유지)
+              docker images "${IMAGE_NAME_BASE}" --format "{{.Tag}}" | \
+                grep -v buildcache | sort -r | tail -n +3 | \
+                xargs -I {} docker rmi "${IMAGE_NAME_BASE}:{}" 2>/dev/null || true
+              docker image prune -f
 
-            # 4. Spring Boot 앱 재시작
-            echo "Restarting Docker Compose with tag: $IMAGE_TAG_ONLY"
-            cd /home/${{ secrets.DEV_USERNAME }}/solid-connection-dev
-            docker compose -f docker-compose.dev.yml down || true
-            OWNER_LOWERCASE=$OWNER_LOWERCASE IMAGE_TAG=$IMAGE_TAG_ONLY docker compose -f docker-compose.dev.yml up -d
+              # 4. GHCR 로그인 & Pull
+              echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+              docker pull "${FULL_IMAGE_NAME}"
 
-            echo "Deployment finished successfully."
-            '     
+              # 5. 새 슬롯 잔여 컨테이너 정리
+              docker stop "${CONTAINER_BASE}-${NEW_SLOT}" 2>/dev/null || true
+              docker rm   "${CONTAINER_BASE}-${NEW_SLOT}" 2>/dev/null || true
+
+              # 6. 새 컨테이너 시작
+              cd "${WORK_DIR}"
+              SLOT="${NEW_SLOT}" APP_PORT="${NEW_PORT}" OWNER_LOWERCASE="${OWNER_LOWERCASE}" IMAGE_TAG="${IMAGE_TAG_ONLY}" \
+                docker compose -p "${CONTAINER_BASE}-${NEW_SLOT}" -f docker-compose.dev.yml up -d solid-connection-dev
+
+              # 7. 헬스 체크 (앱 기동 대기, 최대 150초)
+              # /actuator/health 미노출로 포트 응답 여부로 확인 (HTTP 000 = 연결 불가)
+              echo "Waiting for app on port ${NEW_PORT}..."
+              for i in $(seq 1 30); do
+                HTTP=$(curl -s --connect-timeout 2 -o /dev/null -w "%{http_code}" "http://localhost:${NEW_PORT}/" || true)
+                [ "$HTTP" != "000" ] && { echo "App responding (HTTP ${HTTP}, attempt ${i})"; break; }
+                [ "$i" = "30" ] && {
+                  echo "Health check timed out after 150s" >&2
+                  docker stop "${CONTAINER_BASE}-${NEW_SLOT}" 2>/dev/null || true
+                  docker rm   "${CONTAINER_BASE}-${NEW_SLOT}" 2>/dev/null || true
+                  exit 1
+                }
+                sleep 5
+              done
+
+              # 8. Nginx upstream 전환 (무중단)
+              sudo sed -i "s|server 127.0.0.1:[0-9]*;|server 127.0.0.1:${NEW_PORT};|" /etc/nginx/conf.d/upstream.conf
+              sudo nginx -s reload
+              echo "Traffic switched → ${NEW_SLOT}(${NEW_PORT})"
+
+              # 9. 구 컨테이너 종료
+              docker compose -p "${CONTAINER_BASE}-${ACTIVE_SLOT}" -f docker-compose.dev.yml down 2>/dev/null || true
+
+              echo "Deployment complete. Active: ${NEW_SLOT}(${NEW_PORT})"
+            '

--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -161,14 +161,13 @@ jobs:
               # 5. 새 컨테이너 시작
               cd "${WORK_DIR}"
               SLOT="${NEW_SLOT}" APP_PORT="${NEW_PORT}" MANAGEMENT_PORT="${MANAGEMENT_PORT}" OWNER_LOWERCASE="${OWNER_LOWERCASE}" IMAGE_TAG="${IMAGE_TAG_ONLY}" \
-                docker compose -p "${CONTAINER_BASE}-${NEW_SLOT}" -f docker-compose.prod.yml up -d
+                docker compose -p "${CONTAINER_BASE}-${NEW_SLOT}" -f docker-compose.prod.yml up -d solid-connection-server
 
               # 6. 헬스 체크 (앱 기동 대기, 최대 150초)
-              # /actuator/health 미노출로 포트 응답 여부로 확인 (HTTP 000 = 연결 불가)
-              echo "Waiting for app on port ${NEW_PORT}..."
+              echo "Waiting for app on management port ${MANAGEMENT_PORT}..."
               for i in $(seq 1 30); do
-                HTTP=$(curl -s --connect-timeout 2 -o /dev/null -w "%{http_code}" "http://localhost:${NEW_PORT}/" || true)
-                [ "$HTTP" != "000" ] && { echo "App responding (HTTP ${HTTP}, attempt ${i})"; break; }
+                STATUS=$(curl -s --connect-timeout 2 "http://localhost:${MANAGEMENT_PORT}/actuator/health" | grep -o '"status":"UP"' || true)
+                [ "$STATUS" = '"status":"UP"' ] && { echo "App healthy (attempt ${i})"; break; }
                 [ "$i" = "30" ] && {
                   echo "Health check timed out after 150s" >&2
                   docker stop "${CONTAINER_BASE}-${NEW_SLOT}" 2>/dev/null || true

--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -138,11 +138,11 @@ jobs:
               # 1. Active 슬롯 확인 (upstream.conf 기준)
               UPSTREAM_PORT=$(grep -oE "server 127\.0\.0\.1:[0-9]+" /etc/nginx/conf.d/upstream.conf 2>/dev/null | grep -oE "[0-9]+$" || echo "8081")
               if [ "$UPSTREAM_PORT" = "8080" ]; then
-                ACTIVE_SLOT="blue"; ACTIVE_PORT=8080; NEW_SLOT="green"; NEW_PORT=8081
+                ACTIVE_SLOT="blue"; ACTIVE_PORT=8080; NEW_SLOT="green"; NEW_PORT=8081; MANAGEMENT_PORT=9081
               else
-                ACTIVE_SLOT="green"; ACTIVE_PORT=8081; NEW_SLOT="blue"; NEW_PORT=8080
+                ACTIVE_SLOT="green"; ACTIVE_PORT=8081; NEW_SLOT="blue"; NEW_PORT=8080; MANAGEMENT_PORT=9080
               fi
-              echo "Active: ${ACTIVE_SLOT}(${ACTIVE_PORT}) → Deploy: ${NEW_SLOT}(${NEW_PORT})"
+              echo "Active: ${ACTIVE_SLOT}(${ACTIVE_PORT}) → Deploy: ${NEW_SLOT}(${NEW_PORT}), management: ${MANAGEMENT_PORT}"
 
               # 2. Pull 전 디스크 정리 (태그 이미지 최근 2개 유지)
               docker images "${IMAGE_NAME_BASE}" --format "{{.Tag}}" | \
@@ -160,7 +160,7 @@ jobs:
 
               # 5. 새 컨테이너 시작
               cd "${WORK_DIR}"
-              SLOT="${NEW_SLOT}" APP_PORT="${NEW_PORT}" OWNER_LOWERCASE="${OWNER_LOWERCASE}" IMAGE_TAG="${IMAGE_TAG_ONLY}" \
+              SLOT="${NEW_SLOT}" APP_PORT="${NEW_PORT}" MANAGEMENT_PORT="${MANAGEMENT_PORT}" OWNER_LOWERCASE="${OWNER_LOWERCASE}" IMAGE_TAG="${IMAGE_TAG_ONLY}" \
                 docker compose -p "${CONTAINER_BASE}-${NEW_SLOT}" -f docker-compose.prod.yml up -d
 
               # 6. 헬스 체크 (앱 기동 대기, 최대 150초)

--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -57,7 +57,7 @@ jobs:
         id: image_meta
         run: |
           OWNER_LOWERCASE=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
-          
+
           # Trigger가 Release인 경우: Release의 Tag Name (예: v1.0.0) 사용
           if [ "${{ github.event_name }}" == "release" ]; then
             IMAGE_TAG="${{ github.ref_name }}"
@@ -65,9 +65,9 @@ jobs:
           else
             IMAGE_TAG="${{ inputs.tag_name }}"
           fi
-          
+
           echo "Docker Image Tag: $IMAGE_TAG"
-          
+
           echo "image_name=ghcr.io/${OWNER_LOWERCASE}/solid-connection-server" >> $GITHUB_OUTPUT
           echo "image_tag=${IMAGE_TAG}" >> $GITHUB_OUTPUT
 
@@ -103,7 +103,6 @@ jobs:
       packages: read
 
     steps:
-      # 설정 파일 전송을 위해 코드 체크아웃 (서브모듈 불필요)
       - name: Checkout config files
         uses: actions/checkout@v4
         with:
@@ -112,44 +111,80 @@ jobs:
             docs/infra-config
           sparse-checkout-cone-mode: false
 
-      # --- 설정 파일 전송 ---
       - name: Copy config files to remote
         run: |
           echo "${{ secrets.PRIVATE_KEY }}" > deploy_key.pem
           chmod 600 deploy_key.pem
-          
+
           scp -i deploy_key.pem \
             -o StrictHostKeyChecking=no \
             ./docker-compose.prod.yml \
             ${{ secrets.USERNAME }}@${{ secrets.HOST }}:/home/${{ secrets.USERNAME }}/solid-connection-prod/
 
-      # --- 서버에서 Docker Pull 및 재시작 ---
-      - name: Run docker compose and apply nginx config
+      - name: Blue/Green deploy
         run: |
           ssh -i deploy_key.pem \
-           -o StrictHostKeyChecking=no \
-           ${{ secrets.USERNAME }}@${{ secrets.HOST }} \
-           '
-            set -e
-          
-            # 1. 변수 설정 (이전 Job의 Output 사용)
-            export OWNER_LOWERCASE=$(echo "${{ github.repository_owner }}" | tr "[:upper:]" "[:lower:]")
-            export IMAGE_TAG_ONLY="${{ needs.build-and-push.outputs.image_tag }}"
-            export FULL_IMAGE_NAME="ghcr.io/${OWNER_LOWERCASE}/solid-connection-server:${IMAGE_TAG_ONLY}"
-          
-            # 2. GHCR 로그인 & Pull
-            # App Token 대신 현재 워크플로우의 임시 토큰을 사용합니다.
-            echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-            echo "Pulling new image: $FULL_IMAGE_NAME"
-            docker pull $FULL_IMAGE_NAME
-          
-            # 3. Spring Boot 앱 재시작
-            echo "Restarting Docker Compose with tag: $IMAGE_TAG_ONLY"
-            cd /home/${{ secrets.USERNAME }}/solid-connection-prod
-            docker compose -f docker-compose.prod.yml down || true
-            OWNER_LOWERCASE=$OWNER_LOWERCASE IMAGE_TAG=$IMAGE_TAG_ONLY docker compose -f docker-compose.prod.yml up -d
-          
-            # 6. 정리
-            docker image prune -f
-            echo "Deployment finished successfully."
-           '
+            -o StrictHostKeyChecking=no \
+            ${{ secrets.USERNAME }}@${{ secrets.HOST }} \
+            '
+              set -e
+              OWNER_LOWERCASE=$(echo "${{ github.repository_owner }}" | tr "[:upper:]" "[:lower:]")
+              IMAGE_TAG_ONLY="${{ needs.build-and-push.outputs.image_tag }}"
+              FULL_IMAGE_NAME="ghcr.io/${OWNER_LOWERCASE}/solid-connection-server:${IMAGE_TAG_ONLY}"
+              IMAGE_NAME_BASE="ghcr.io/${OWNER_LOWERCASE}/solid-connection-server"
+              WORK_DIR="/home/${{ secrets.USERNAME }}/solid-connection-prod"
+              CONTAINER_BASE="solid-connection-server"
+
+              # 1. Active 슬롯 확인 (upstream.conf 기준)
+              UPSTREAM_PORT=$(grep -oE "server 127\.0\.0\.1:[0-9]+" /etc/nginx/conf.d/upstream.conf 2>/dev/null | grep -oE "[0-9]+$" || echo "8081")
+              if [ "$UPSTREAM_PORT" = "8080" ]; then
+                ACTIVE_SLOT="blue"; ACTIVE_PORT=8080; NEW_SLOT="green"; NEW_PORT=8081
+              else
+                ACTIVE_SLOT="green"; ACTIVE_PORT=8081; NEW_SLOT="blue"; NEW_PORT=8080
+              fi
+              echo "Active: ${ACTIVE_SLOT}(${ACTIVE_PORT}) → Deploy: ${NEW_SLOT}(${NEW_PORT})"
+
+              # 2. Pull 전 디스크 정리 (태그 이미지 최근 2개 유지)
+              docker images "${IMAGE_NAME_BASE}" --format "{{.Tag}}" | \
+                grep -v buildcache | sort -r | tail -n +3 | \
+                xargs -I {} docker rmi "${IMAGE_NAME_BASE}:{}" 2>/dev/null || true
+              docker image prune -f
+
+              # 3. GHCR 로그인 & Pull
+              echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+              docker pull "${FULL_IMAGE_NAME}"
+
+              # 4. 새 슬롯 잔여 컨테이너 정리
+              docker stop "${CONTAINER_BASE}-${NEW_SLOT}" 2>/dev/null || true
+              docker rm   "${CONTAINER_BASE}-${NEW_SLOT}" 2>/dev/null || true
+
+              # 5. 새 컨테이너 시작
+              cd "${WORK_DIR}"
+              SLOT="${NEW_SLOT}" APP_PORT="${NEW_PORT}" OWNER_LOWERCASE="${OWNER_LOWERCASE}" IMAGE_TAG="${IMAGE_TAG_ONLY}" \
+                docker compose -p "${CONTAINER_BASE}-${NEW_SLOT}" -f docker-compose.prod.yml up -d
+
+              # 6. 헬스 체크 (앱 기동 대기, 최대 150초)
+              # /actuator/health 미노출로 포트 응답 여부로 확인 (HTTP 000 = 연결 불가)
+              echo "Waiting for app on port ${NEW_PORT}..."
+              for i in $(seq 1 30); do
+                HTTP=$(curl -s --connect-timeout 2 -o /dev/null -w "%{http_code}" "http://localhost:${NEW_PORT}/" || true)
+                [ "$HTTP" != "000" ] && { echo "App responding (HTTP ${HTTP}, attempt ${i})"; break; }
+                [ "$i" = "30" ] && {
+                  echo "Health check timed out after 150s" >&2
+                  docker stop "${CONTAINER_BASE}-${NEW_SLOT}" 2>/dev/null || true
+                  docker rm   "${CONTAINER_BASE}-${NEW_SLOT}" 2>/dev/null || true
+                  exit 1
+                }
+                sleep 5
+              done
+
+              # 7. Nginx upstream 전환 (무중단)
+              sudo sed -i "s|server 127.0.0.1:[0-9]*;|server 127.0.0.1:${NEW_PORT};|" /etc/nginx/conf.d/upstream.conf
+              sudo nginx -s reload
+              echo "Traffic switched → ${NEW_SLOT}(${NEW_PORT})"
+
+              # 8. 구 컨테이너 종료
+              docker compose -p "${CONTAINER_BASE}-${ACTIVE_SLOT}" -f docker-compose.prod.yml down 2>/dev/null || true
+
+              echo "Deployment complete. Active: ${NEW_SLOT}(${NEW_PORT})"
+            '

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -8,6 +8,7 @@ services:
     environment:
       - SPRING_PROFILES_ACTIVE=dev
       - SERVER_PORT=${APP_PORT:-8080}
+      - MANAGEMENT_SERVER_PORT=${MANAGEMENT_PORT:-9080}
       - AWS_REGION=ap-northeast-2
       - SPRING_DATA_REDIS_HOST=127.0.0.1
       - SPRING_DATA_REDIS_PORT=6379

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -3,10 +3,11 @@ version: '3.8'
 services:
   solid-connection-dev:
     image: ghcr.io/${OWNER_LOWERCASE}/solid-connection-dev:${IMAGE_TAG:-latest}
-    container_name: solid-connection-dev
+    container_name: solid-connection-dev-${SLOT:-blue}
     network_mode: "host"
     environment:
       - SPRING_PROFILES_ACTIVE=dev
+      - SERVER_PORT=${APP_PORT:-8080}
       - AWS_REGION=ap-northeast-2
       - SPRING_DATA_REDIS_HOST=127.0.0.1
       - SPRING_DATA_REDIS_PORT=6379

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -3,10 +3,11 @@ version: '3.8'
 services:
   solid-connection-server:
     image: ghcr.io/${OWNER_LOWERCASE}/solid-connection-server:${IMAGE_TAG:-latest}
-    container_name: solid-connection-server
+    container_name: solid-connection-server-${SLOT:-blue}
     network_mode: "host"
     environment:
       - SPRING_PROFILES_ACTIVE=prod
+      - SERVER_PORT=${APP_PORT:-8080}
       - AWS_REGION=ap-northeast-2
       - SPRING_DATA_REDIS_HOST=127.0.0.1
       - SPRING_DATA_REDIS_PORT=6379

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -8,6 +8,7 @@ services:
     environment:
       - SPRING_PROFILES_ACTIVE=prod
       - SERVER_PORT=${APP_PORT:-8080}
+      - MANAGEMENT_SERVER_PORT=${MANAGEMENT_PORT:-9080}
       - AWS_REGION=ap-northeast-2
       - SPRING_DATA_REDIS_HOST=127.0.0.1
       - SPRING_DATA_REDIS_PORT=6379

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,7 +23,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: prometheus
+        include: prometheus, health
 
 ---
 spring:


### PR DESCRIPTION
## 관련 이슈

- resolves: #607

## 작업 내용

인프라 레포 PR [solid-connection-infra#37](https://github.com/solid-connection/solid-connection-infra/pull/37)에서 nginx upstream 방식으로 전환된 것을 바탕으로, **dev-cd / prod-cd 워크플로우를 블루/그린 무중단 배포 방식으로 변경**합니다.

**변경 파일**: `docker-compose.dev.yml`, `docker-compose.prod.yml`, `.github/workflows/dev-cd.yml`, `.github/workflows/prod-cd.yml`

**블루/그린 배포 플로우**
- Blue 슬롯: port 8080 / Green 슬롯: port 8081
- `/etc/nginx/conf.d/upstream.conf`를 읽어 현재 active 슬롯을 판별, 비활성 슬롯에 신규 컨테이너를 기동
- 헬스 체크 통과(포트 응답 확인, 최대 150초) 후 `upstream.conf` 포트 교체 + `nginx -s reload`로 트래픽 무중단 전환
- 헬스 체크 실패 시 신규 컨테이너를 제거하고 구 컨테이너 유지(자동 롤백)
- nginx 전환 완료 후 구 컨테이너 종료

**docker-compose 변경**
- `container_name: ...-${SLOT:-blue}` — 슬롯별 컨테이너 이름 분리
- `SERVER_PORT=${APP_PORT:-8080}` — Spring Boot 포트 환경 변수로 제어
- dev-cd: MySQL은 블루/그린 대상에서 제외, 앱 컨테이너만 슬롯 전환

**prod EC2 디스크 공간 관리 개선**
- 기존 prod-cd는 `docker image prune -f`(dangling 이미지만 정리)만 수행 → 배포마다 태그 이미지 무한 누적
- dev-cd와 동일하게 **최근 2개 태그 이미지만 EC2에 유지**하는 정리 로직 추가

## 특이 사항

- 이 PR이 머지되어 첫 배포가 실행되면, 현재 `solid-connection-server` / `solid-connection-dev` 컨테이너(단일 컨테이너 방식)는 더 이상 관리되지 않습니다. **첫 배포 전 기존 컨테이너를 수동으로 종료**하거나, 첫 배포 이후 수동 정리가 필요합니다
- `management.endpoints.web.exposure.include: prometheus`로 `/actuator/health`가 미노출 상태여서, 헬스 체크는 포트 응답 여부(HTTP 상태코드 `000` 여부)로 대체하였습니다

## 리뷰 요구사항 (선택)

- **upstream.conf 경로 하드코딩**: 워크플로우에서 `/etc/nginx/conf.d/upstream.conf` 경로를 하드코딩하고 있습니다. 인프라 레포의 `nginx_setup.sh.tftpl`도 동일 경로를 사용하며, 경로 변경 시 두 레포를 동시에 수정해야 합니다. 현재는 허용 가능한 수준이라 판단했으나, 팀 의견을 확인하고 싶습니다
- **헬스 체크 방식**: 현재 포트 응답 여부(HTTP `000` != 응답 존재)로 확인합니다. 실제 앱 준비 상태를 정확히 확인하려면 `/actuator/health` 노출이 필요합니다(`management.endpoints.web.exposure.include`에 `health` 추가). 엔드포인트 노출 여부에 대한 의견을 부탁드립니다