### PR TITLE
fix: 헬스체크 grep 쿼팅 버그 수정

### DIFF
--- a/.github/workflows/dev-cd.yml
+++ b/.github/workflows/dev-cd.yml
@@ -153,10 +153,11 @@ jobs:
                 docker compose -p "${CONTAINER_BASE}-${NEW_SLOT}" -f docker-compose.dev.yml up -d solid-connection-dev
 
               # 8. 헬스 체크 (앱 기동 대기, 최대 150초)
+              # HTTP 200 = UP, 503 = DOWN (single-quote 내부 quoting 문제 없이 상태코드로 판단)
               echo "Waiting for app on management port ${MANAGEMENT_PORT}..."
               for i in $(seq 1 30); do
-                STATUS=$(curl -s --connect-timeout 2 "http://localhost:${MANAGEMENT_PORT}/actuator/health" | grep -o '"status":"UP"' || true)
-                [ "$STATUS" = '"status":"UP"' ] && { echo "App healthy (attempt ${i})"; break; }
+                HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --connect-timeout 2 "http://localhost:${MANAGEMENT_PORT}/actuator/health" || true)
+                [ "$HTTP_CODE" = "200" ] && { echo "App healthy (attempt ${i})"; break; }
                 [ "$i" = "30" ] && {
                   echo "Health check timed out after 150s" >&2
                   docker stop "${CONTAINER_BASE}-${NEW_SLOT}" 2>/dev/null || true

--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -164,10 +164,11 @@ jobs:
                 docker compose -p "${CONTAINER_BASE}-${NEW_SLOT}" -f docker-compose.prod.yml up -d solid-connection-server
 
               # 6. 헬스 체크 (앱 기동 대기, 최대 150초)
+              # HTTP 200 = UP, 503 = DOWN (single-quote 내부 quoting 문제 없이 상태코드로 판단)
               echo "Waiting for app on management port ${MANAGEMENT_PORT}..."
               for i in $(seq 1 30); do
-                STATUS=$(curl -s --connect-timeout 2 "http://localhost:${MANAGEMENT_PORT}/actuator/health" | grep -o '"status":"UP"' || true)
-                [ "$STATUS" = '"status":"UP"' ] && { echo "App healthy (attempt ${i})"; break; }
+                HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --connect-timeout 2 "http://localhost:${MANAGEMENT_PORT}/actuator/health" || true)
+                [ "$HTTP_CODE" = "200" ] && { echo "App healthy (attempt ${i})"; break; }
                 [ "$i" = "30" ] && {
                   echo "Health check timed out after 150s" >&2
                   docker stop "${CONTAINER_BASE}-${NEW_SLOT}" 2>/dev/null || true


### PR DESCRIPTION
## 관련 이슈

- related: #607

## 작업 내용

SSH 단일 인용부호 내부에서 `'"status":"UP"'` 패턴이 올바르게 전달되지 않는 쉘 쿼팅 버그를 수정합니다.

**문제**

SSH 명령이 single-quote로 감싸진 상태에서 내부의 `'"status":"UP"'`가 파싱될 때, bash가 single-quote를 닫았다 열면서 `grep -o status:UP`으로 해석됩니다. `{"status":"UP"}` 응답에서 `status:UP`은 매칭되지 않아 헬스체크가 항상 실패했습니다.

**변경 내용**

`grep -o '"status":"UP"'` 방식 → HTTP 상태코드 확인 방식으로 변경

```bash
# AS-IS (quoting 버그)
STATUS=$(curl ... | grep -o '"status":"UP"' || true)
[ "$STATUS" = '"status":"UP"' ] && break

# TO-BE (quoting 문제 없음)
HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" ... || true)
[ "$HTTP_CODE" = "200" ] && break
```

Spring Boot는 상태가 UP이면 HTTP 200, DOWN이면 503을 반환하므로 상태코드로 판단합니다.

**변경 파일**: `.github/workflows/dev-cd.yml`, `.github/workflows/prod-cd.yml`

## 특이 사항

- 로직 변경 없음, 쿼팅 방식만 변경
- `%{http_code}`는 single-quote 내부에서도 올바르게 전달됨

## 리뷰 요구사항 (선택)

- SSH heredoc 내부 single-quote 쿼팅 이슈가 원인이 맞는지 확인 부탁드립니다