### PR TITLE
feat: Blue/Green 배포 시 Prometheus 스크랩 타겟 자동 업데이트

### DIFF
--- a/.github/workflows/dev-cd.yml
+++ b/.github/workflows/dev-cd.yml
@@ -189,12 +189,8 @@ jobs:
 
           if [ "$UPSTREAM_PORT" = "8080" ]; then NEW_MGMT_PORT=8081; else NEW_MGMT_PORT=9081; fi
 
-          PRIVATE_IP=$(ssh -i deploy_key.pem -o StrictHostKeyChecking=no \
-            "${{ secrets.DEV_USERNAME }}@${{ secrets.DEV_HOST }}" \
-            "hostname -I | awk '{print \$1}'")
-
           ssh -i monitoring_key.pem -o StrictHostKeyChecking=no \
             "${{ secrets.MONITORING_USERNAME }}@${{ secrets.MONITORING_HOST }}" \
-            "echo '[{\"targets\":[\"${PRIVATE_IP}:${NEW_MGMT_PORT}\"]}]' \
+            "echo '[{\"targets\":[\"${{ secrets.DEV_HOST }}:${NEW_MGMT_PORT}\"]}]' \
               | tee ~/solid-connection-monitor/prometheus/targets/stage.json > /dev/null \
-            && echo 'Prometheus target updated: ${PRIVATE_IP}:${NEW_MGMT_PORT}'"
+            && echo 'Prometheus target updated: ${{ secrets.DEV_HOST }}:${NEW_MGMT_PORT}'"

--- a/.github/workflows/dev-cd.yml
+++ b/.github/workflows/dev-cd.yml
@@ -185,7 +185,12 @@ jobs:
 
           UPSTREAM_PORT=$(ssh -i deploy_key.pem -o StrictHostKeyChecking=no \
             "${{ secrets.DEV_USERNAME }}@${{ secrets.DEV_HOST }}" \
-            "grep -oE 'server 127\.0\.0\.1:[0-9]+' /etc/nginx/conf.d/upstream.conf 2>/dev/null | grep -oE '[0-9]+$' || echo 9080")
+            "grep -oE 'server 127\.0\.0\.1:[0-9]+' /etc/nginx/conf.d/upstream.conf 2>/dev/null | grep -oE '[0-9]+$'")
+
+          if [ "$UPSTREAM_PORT" != "8080" ] && [ "$UPSTREAM_PORT" != "9080" ]; then
+            echo "Unexpected UPSTREAM_PORT: '${UPSTREAM_PORT}'" >&2
+            exit 1
+          fi
 
           if [ "$UPSTREAM_PORT" = "8080" ]; then NEW_MGMT_PORT=8081; else NEW_MGMT_PORT=9081; fi
 

--- a/.github/workflows/dev-cd.yml
+++ b/.github/workflows/dev-cd.yml
@@ -177,3 +177,24 @@ jobs:
 
               echo "Deployment complete. Active: ${NEW_SLOT}(${NEW_PORT})"
             '
+
+      - name: Update Prometheus scrape target (stage)
+        run: |
+          echo "${{ secrets.MONITORING_PRIVATE_KEY }}" > monitoring_key.pem
+          chmod 600 monitoring_key.pem
+
+          UPSTREAM_PORT=$(ssh -i deploy_key.pem -o StrictHostKeyChecking=no \
+            "${{ secrets.DEV_USERNAME }}@${{ secrets.DEV_HOST }}" \
+            "grep -oE 'server 127\.0\.0\.1:[0-9]+' /etc/nginx/conf.d/upstream.conf 2>/dev/null | grep -oE '[0-9]+$' || echo 9080")
+
+          if [ "$UPSTREAM_PORT" = "8080" ]; then NEW_MGMT_PORT=8081; else NEW_MGMT_PORT=9081; fi
+
+          PRIVATE_IP=$(ssh -i deploy_key.pem -o StrictHostKeyChecking=no \
+            "${{ secrets.DEV_USERNAME }}@${{ secrets.DEV_HOST }}" \
+            "hostname -I | awk '{print \$1}'")
+
+          ssh -i monitoring_key.pem -o StrictHostKeyChecking=no \
+            "${{ secrets.MONITORING_USERNAME }}@${{ secrets.MONITORING_HOST }}" \
+            "echo '[{\"targets\":[\"${PRIVATE_IP}:${NEW_MGMT_PORT}\"]}]' \
+              | tee ~/solid-connection-monitor/prometheus/targets/stage.json > /dev/null \
+            && echo 'Prometheus target updated: ${PRIVATE_IP}:${NEW_MGMT_PORT}'"

--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -196,7 +196,12 @@ jobs:
 
           UPSTREAM_PORT=$(ssh -i deploy_key.pem -o StrictHostKeyChecking=no \
             "${{ secrets.USERNAME }}@${{ secrets.HOST }}" \
-            "grep -oE 'server 127\.0\.0\.1:[0-9]+' /etc/nginx/conf.d/upstream.conf 2>/dev/null | grep -oE '[0-9]+$' || echo 9080")
+            "grep -oE 'server 127\.0\.0\.1:[0-9]+' /etc/nginx/conf.d/upstream.conf 2>/dev/null | grep -oE '[0-9]+$'")
+
+          if [ "$UPSTREAM_PORT" != "8080" ] && [ "$UPSTREAM_PORT" != "9080" ]; then
+            echo "Unexpected UPSTREAM_PORT: '${UPSTREAM_PORT}'" >&2
+            exit 1
+          fi
 
           if [ "$UPSTREAM_PORT" = "8080" ]; then NEW_MGMT_PORT=8081; else NEW_MGMT_PORT=9081; fi
 

--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -200,12 +200,8 @@ jobs:
 
           if [ "$UPSTREAM_PORT" = "8080" ]; then NEW_MGMT_PORT=8081; else NEW_MGMT_PORT=9081; fi
 
-          PRIVATE_IP=$(ssh -i deploy_key.pem -o StrictHostKeyChecking=no \
-            "${{ secrets.USERNAME }}@${{ secrets.HOST }}" \
-            "hostname -I | awk '{print \$1}'")
-
           ssh -i monitoring_key.pem -o StrictHostKeyChecking=no \
             "${{ secrets.MONITORING_USERNAME }}@${{ secrets.MONITORING_HOST }}" \
-            "echo '[{\"targets\":[\"${PRIVATE_IP}:${NEW_MGMT_PORT}\"]}]' \
+            "echo '[{\"targets\":[\"${{ secrets.HOST }}:${NEW_MGMT_PORT}\"]}]' \
               | tee ~/solid-connection-monitor/prometheus/targets/prod.json > /dev/null \
-            && echo 'Prometheus target updated: ${PRIVATE_IP}:${NEW_MGMT_PORT}'"
+            && echo 'Prometheus target updated: ${{ secrets.HOST }}:${NEW_MGMT_PORT}'"

--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -188,3 +188,24 @@ jobs:
 
               echo "Deployment complete. Active: ${NEW_SLOT}(${NEW_PORT})"
             '
+
+      - name: Update Prometheus scrape target (prod)
+        run: |
+          echo "${{ secrets.MONITORING_PRIVATE_KEY }}" > monitoring_key.pem
+          chmod 600 monitoring_key.pem
+
+          UPSTREAM_PORT=$(ssh -i deploy_key.pem -o StrictHostKeyChecking=no \
+            "${{ secrets.USERNAME }}@${{ secrets.HOST }}" \
+            "grep -oE 'server 127\.0\.0\.1:[0-9]+' /etc/nginx/conf.d/upstream.conf 2>/dev/null | grep -oE '[0-9]+$' || echo 9080")
+
+          if [ "$UPSTREAM_PORT" = "8080" ]; then NEW_MGMT_PORT=8081; else NEW_MGMT_PORT=9081; fi
+
+          PRIVATE_IP=$(ssh -i deploy_key.pem -o StrictHostKeyChecking=no \
+            "${{ secrets.USERNAME }}@${{ secrets.HOST }}" \
+            "hostname -I | awk '{print \$1}'")
+
+          ssh -i monitoring_key.pem -o StrictHostKeyChecking=no \
+            "${{ secrets.MONITORING_USERNAME }}@${{ secrets.MONITORING_HOST }}" \
+            "echo '[{\"targets\":[\"${PRIVATE_IP}:${NEW_MGMT_PORT}\"]}]' \
+              | tee ~/solid-connection-monitor/prometheus/targets/prod.json > /dev/null \
+            && echo 'Prometheus target updated: ${PRIVATE_IP}:${NEW_MGMT_PORT}'"


### PR DESCRIPTION
## 관련 이슈

- resolves: #762

## 작업 내용

Blue/Green 슬롯 전환 완료 후 monitoring 서버의 Prometheus 타겟 파일을 자동으로 갱신하는 스텝을 CD 워크플로우에 추가했습니다.

- **`prod-cd.yml`**: nginx 전환 완료 후 `prod.json` 타겟 파일 업데이트 스텝 추가
- **`dev-cd.yml`**: nginx 전환 완료 후 `stage.json` 타겟 파일 업데이트 스텝 추가

**동작 방식**

1. app 서버에 SSH 접속 → nginx `upstream.conf`에서 현재 활성 포트 확인 → management 포트 결정 (blue: 8081 / green: 9081)
2. monitoring 서버에 SSH 접속 → 기존 `HOST` / `DEV_HOST` 시크릿의 퍼블릭 IP와 결정된 management 포트로 타겟 JSON 파일(`prod.json` / `stage.json`) 갱신

타겟 파일 경로는 `~/solid-connection-monitor/prometheus/targets/`로, docker-compose 볼륨 마운트(`./prometheus:/etc/prometheus`)에 의해 컨테이너 내부 `/etc/prometheus/targets/`에 반영됩니다.

## 특이 사항

- 사전에 등록된 Secrets(`MONITORING_HOST`, `MONITORING_USERNAME`, `MONITORING_PRIVATE_KEY`)를 사용합니다.
- app 서버 IP는 기존 `HOST` / `DEV_HOST` 시크릿을 그대로 활용하므로 별도 SSH로 IP를 조회하지 않습니다.
- monitoring 서버의 홈 디렉토리 하위 경로이므로 `sudo` 없이 파일 쓰기가 가능합니다.
- Prometheus의 `file_sd_configs` 방식은 타겟 파일 변경을 주기적으로 감지하므로, 파일 갱신 후 별도 reload 없이 자동 반영됩니다.