### PR TITLE
feat: 게시글 카테고리에 동행, 중고거래 추가

### DIFF
--- a/src/main/java/com/example/solidconnection/community/post/domain/PostCategory.java
+++ b/src/main/java/com/example/solidconnection/community/post/domain/PostCategory.java
@@ -5,7 +5,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 public enum PostCategory {
-    전체, 자유, 질문;
+    전체, 자유, 질문, 동행, 중고거래;
 
     private static final Set<String> NAMES = Arrays.stream(values())
             .map(Enum::name)

--- a/src/main/resources/db/migration/V52__add_companion_and_used_trade_to_post_category.sql
+++ b/src/main/resources/db/migration/V52__add_companion_and_used_trade_to_post_category.sql
@@ -1,0 +1,2 @@
+ALTER TABLE post
+    MODIFY COLUMN category ENUM ('자유', '전체', '질문', '동행', '중고거래') NULL;

--- a/src/test/java/com/example/solidconnection/community/post/service/PostCommandServiceTest.java
+++ b/src/test/java/com/example/solidconnection/community/post/service/PostCommandServiceTest.java
@@ -38,8 +38,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -164,22 +162,6 @@ class PostCommandServiceTest {
                             .extracting(PostImage::getUrl)
                             .containsExactly(expectedImageUrl)
             );
-        }
-
-        @ParameterizedTest
-        @ValueSource(strings = {"자유", "질문", "동행", "중고거래"})
-        @Transactional
-        void 전체를_제외한_카테고리로_게시글을_생성한다(String category) {
-            // given
-            PostCreateRequest request = createPostCreateRequest(category);
-            List<MultipartFile> imageFiles = List.of();
-
-            // when
-            PostCreateResponse response = postCommandService.createPost(user1.getId(), request, imageFiles);
-
-            // then
-            Post savedPost = postRepository.findById(response.id()).orElseThrow();
-            assertThat(savedPost.getCategory()).isEqualTo(PostCategory.valueOf(category));
         }
 
         @Test

--- a/src/test/java/com/example/solidconnection/community/post/service/PostCommandServiceTest.java
+++ b/src/test/java/com/example/solidconnection/community/post/service/PostCommandServiceTest.java
@@ -38,6 +38,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -162,6 +164,22 @@ class PostCommandServiceTest {
                             .extracting(PostImage::getUrl)
                             .containsExactly(expectedImageUrl)
             );
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"자유", "질문", "동행", "중고거래"})
+        @Transactional
+        void 전체를_제외한_카테고리로_게시글을_생성한다(String category) {
+            // given
+            PostCreateRequest request = createPostCreateRequest(category);
+            List<MultipartFile> imageFiles = List.of();
+
+            // when
+            PostCreateResponse response = postCommandService.createPost(user1.getId(), request, imageFiles);
+
+            // then
+            Post savedPost = postRepository.findById(response.id()).orElseThrow();
+            assertThat(savedPost.getCategory()).isEqualTo(PostCategory.valueOf(category));
         }
 
         @Test

--- a/src/test/java/com/example/solidconnection/community/post/service/PostQueryServiceTest.java
+++ b/src/test/java/com/example/solidconnection/community/post/service/PostQueryServiceTest.java
@@ -136,6 +136,56 @@ class PostQueryServiceTest {
     }
 
     @Test
+    void 동행_카테고리로_조회시_해당_카테고리의_게시글만_조회한다() {
+        // given
+        Post 동행_게시글 = postFixture.게시글(
+                "동행 제목",
+                "동행 내용",
+                false,
+                PostCategory.동행,
+                boardFixture.자유게시판(),
+                user
+        );
+
+        // when
+        List<PostListResponse> actualResponses = postQueryService.findPostsByCodeAndPostCategoryOrderByCreatedAtDesc(
+                BoardCode.FREE.name(),
+                PostCategory.동행.name(),
+                null
+        );
+
+        // then
+        assertThat(actualResponses)
+                .extracting(PostListResponse::id)
+                .containsExactly(동행_게시글.getId());
+    }
+
+    @Test
+    void 중고거래_카테고리로_조회시_해당_카테고리의_게시글만_조회한다() {
+        // given
+        Post 중고거래_게시글 = postFixture.게시글(
+                "중고거래 제목",
+                "중고거래 내용",
+                false,
+                PostCategory.중고거래,
+                boardFixture.자유게시판(),
+                user
+        );
+
+        // when
+        List<PostListResponse> actualResponses = postQueryService.findPostsByCodeAndPostCategoryOrderByCreatedAtDesc(
+                BoardCode.FREE.name(),
+                PostCategory.중고거래.name(),
+                null
+        );
+
+        // then
+        assertThat(actualResponses)
+                .extracting(PostListResponse::id)
+                .containsExactly(중고거래_게시글.getId());
+    }
+
+    @Test
     void 전체_카테고리로_조회시_해당_게시판의_모든_게시글을_조회한다() {
         // given
         List<Post> posts = List.of(post4, post3, post2, post1);


### PR DESCRIPTION
## 관련 이슈

- resolves: #764

## 작업 내용

게시글 카테고리(`PostCategory`)에 **동행**, **중고거래** 두 가지를 추가했습니다.

- `PostCategory` enum에 `동행`, `중고거래` 추가
- `post` 테이블 `category` ENUM 컬럼에 신규 값 추가 마이그레이션 (`V52`)
- 테스트 추가
  - `PostCommandServiceTest`: 신규 카테고리로 게시글 생성 (`@ValueSource`에 `동행`, `중고거래` 추가)
  - `PostQueryServiceTest`: `동행` / `중고거래` 카테고리별 조회 필터링 검증

## 특이 사항

- 검증·필터링 로직은 `PostCategory.values()` 기반으로 동적 동작하므로, enum 값 추가만으로 생성/조회 로직에 자동 반영됩니다. 별도 서비스/리포지토리 로직 수정은 필요하지 않습니다.
- `category` 컬럼은 `@Enumerated(EnumType.STRING)`으로 문자열 저장되며, 마이그레이션의 ENUM 값과 enum 이름이 일치합니다.
