### PR TITLE
feat: Prometheus 스크랩 타겟을 EC2 프라이빗 IP로 변경

### DIFF
--- a/.github/workflows/dev-cd.yml
+++ b/.github/workflows/dev-cd.yml
@@ -194,8 +194,12 @@ jobs:
 
           if [ "$UPSTREAM_PORT" = "8080" ]; then NEW_MGMT_PORT=8081; else NEW_MGMT_PORT=9081; fi
 
+          PRIVATE_IP=$(ssh -i deploy_key.pem -o StrictHostKeyChecking=no \
+            "${{ secrets.DEV_USERNAME }}@${{ secrets.DEV_HOST }}" \
+            "curl -sf http://169.254.169.254/latest/meta-data/local-ipv4")
+
           ssh -i monitoring_key.pem -o StrictHostKeyChecking=no \
             "${{ secrets.MONITORING_USERNAME }}@${{ secrets.MONITORING_HOST }}" \
-            "echo '[{\"targets\":[\"${{ secrets.DEV_HOST }}:${NEW_MGMT_PORT}\"]}]' \
+            "echo '[{\"targets\":[\"${PRIVATE_IP}:${NEW_MGMT_PORT}\"]}]' \
               | tee ~/solid-connection-monitor/prometheus/targets/stage.json > /dev/null \
-            && echo 'Prometheus target updated: ${{ secrets.DEV_HOST }}:${NEW_MGMT_PORT}'"
+            && echo 'Prometheus target updated: ${PRIVATE_IP}:${NEW_MGMT_PORT}'"

--- a/.github/workflows/dev-cd.yml
+++ b/.github/workflows/dev-cd.yml
@@ -196,7 +196,12 @@ jobs:
 
           PRIVATE_IP=$(ssh -i deploy_key.pem -o StrictHostKeyChecking=no \
             "${{ secrets.DEV_USERNAME }}@${{ secrets.DEV_HOST }}" \
-            "curl -sf http://169.254.169.254/latest/meta-data/local-ipv4")
+            "TOKEN=\$(curl -sf -X PUT 'http://169.254.169.254/latest/api/token' -H 'X-aws-ec2-metadata-token-ttl-seconds: 21600') && curl -sf -H \"X-aws-ec2-metadata-token: \$TOKEN\" http://169.254.169.254/latest/meta-data/local-ipv4")
+
+          if [ -z "$PRIVATE_IP" ]; then
+            echo "Failed to retrieve private IP" >&2
+            exit 1
+          fi
 
           ssh -i monitoring_key.pem -o StrictHostKeyChecking=no \
             "${{ secrets.MONITORING_USERNAME }}@${{ secrets.MONITORING_HOST }}" \

--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -205,8 +205,12 @@ jobs:
 
           if [ "$UPSTREAM_PORT" = "8080" ]; then NEW_MGMT_PORT=8081; else NEW_MGMT_PORT=9081; fi
 
+          PRIVATE_IP=$(ssh -i deploy_key.pem -o StrictHostKeyChecking=no \
+            "${{ secrets.USERNAME }}@${{ secrets.HOST }}" \
+            "curl -sf http://169.254.169.254/latest/meta-data/local-ipv4")
+
           ssh -i monitoring_key.pem -o StrictHostKeyChecking=no \
             "${{ secrets.MONITORING_USERNAME }}@${{ secrets.MONITORING_HOST }}" \
-            "echo '[{\"targets\":[\"${{ secrets.HOST }}:${NEW_MGMT_PORT}\"]}]' \
+            "echo '[{\"targets\":[\"${PRIVATE_IP}:${NEW_MGMT_PORT}\"]}]' \
               | tee ~/solid-connection-monitor/prometheus/targets/prod.json > /dev/null \
-            && echo 'Prometheus target updated: ${{ secrets.HOST }}:${NEW_MGMT_PORT}'"
+            && echo 'Prometheus target updated: ${PRIVATE_IP}:${NEW_MGMT_PORT}'"

--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -207,7 +207,12 @@ jobs:
 
           PRIVATE_IP=$(ssh -i deploy_key.pem -o StrictHostKeyChecking=no \
             "${{ secrets.USERNAME }}@${{ secrets.HOST }}" \
-            "curl -sf http://169.254.169.254/latest/meta-data/local-ipv4")
+            "TOKEN=\$(curl -sf -X PUT 'http://169.254.169.254/latest/api/token' -H 'X-aws-ec2-metadata-token-ttl-seconds: 21600') && curl -sf -H \"X-aws-ec2-metadata-token: \$TOKEN\" http://169.254.169.254/latest/meta-data/local-ipv4")
+
+          if [ -z "$PRIVATE_IP" ]; then
+            echo "Failed to retrieve private IP" >&2
+            exit 1
+          fi
 
           ssh -i monitoring_key.pem -o StrictHostKeyChecking=no \
             "${{ secrets.MONITORING_USERNAME }}@${{ secrets.MONITORING_HOST }}" \


### PR DESCRIPTION
## 관련 이슈

- resolves: #766

## 작업 내용

`prod-cd.yml` / `dev-cd.yml`의 Prometheus 타겟 파일 갱신 시 사용하는 app 서버 IP를 퍼블릭 IP(`HOST` / `DEV_HOST` 시크릿)에서 **EC2 프라이빗 IP**로 변경했습니다.

프라이빗 IP는 EC2 IMDS(Instance Metadata Service) 엔드포인트를 통해 조회합니다.

```bash
PRIVATE_IP=$(ssh -i deploy_key.pem -o StrictHostKeyChecking=no \
  "$USERNAME@$HOST" \
  "curl -sf http://169.254.169.254/latest/meta-data/local-ipv4")
```

## 작업 근거

기존 방식은 monitoring 서버와 app 서버가 동일 VPC에 있음에도 퍼블릭 IP를 Prometheus 타겟으로 사용하고 있었습니다. 이 경우 Prometheus 스크랩 트래픽이 인터넷 게이트웨이를 경유하게 되어 아래 문제가 발생합니다.

- **네트워크 비용**: AWS는 인터넷 게이트웨이를 통한 아웃바운드 트래픽에 데이터 전송 비용을 부과합니다. Prometheus는 기본 15~30초 주기로 스크랩하므로 장기적으로 불필요한 비용이 누적됩니다.
- **성능**: 외부망을 경유하면 VPC 백본 네트워크 직접 통신 대비 레이턴시가 높아지고, 인터넷 게이트웨이를 통한 라우팅 경로가 추가됩니다.

프라이빗 IP를 사용하면 트래픽이 VPC 내부에서만 통신하므로 두 문제 모두 해결됩니다.

## 특이 사항

**IMDS 주소(`169.254.169.254`) 하드코딩에 대해**

`169.254.x.x`는 link-local 주소 대역으로 인터넷 라우팅이 불가능하며, EC2 인스턴스 내부에서만 접근할 수 있습니다. 또한 모든 EC2 인스턴스에 동일하게 적용되는 AWS 공식 문서 공개 엔드포인트이므로, 코드에 노출되어도 특정 인프라 정보가 드러나지 않아 보안상 문제없습니다.

조회 경로를 `/latest/meta-data/local-ipv4`로 한정하므로 반환값은 프라이빗 IP뿐이며, IAM 자격증명 등 민감 정보와는 무관합니다.