### PR TITLE
refactor: 관리자 대학 이미지 업로드 경로 식별자 개선

### DIFF
--- a/src/main/java/com/example/solidconnection/admin/university/controller/AdminHostUniversityController.java
+++ b/src/main/java/com/example/solidconnection/admin/university/controller/AdminHostUniversityController.java
@@ -11,15 +11,17 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RequiredArgsConstructor
 @RequestMapping("/admin/host-universities")
@@ -44,20 +46,33 @@ public class AdminHostUniversityController {
         return ResponseEntity.ok(response);
     }
 
-    @PostMapping
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<AdminHostUniversityDetailResponse> createHostUniversity(
-            @Valid @RequestBody AdminHostUniversityCreateRequest request
+            @Valid @RequestPart("request") AdminHostUniversityCreateRequest request,
+            @RequestPart("logoFile") MultipartFile logoFile,
+            @RequestPart("backgroundFile") MultipartFile backgroundFile
     ) {
-        AdminHostUniversityDetailResponse response = adminHostUniversityService.createHostUniversity(request);
+        AdminHostUniversityDetailResponse response = adminHostUniversityService.createHostUniversity(
+                request,
+                logoFile,
+                backgroundFile
+        );
         return ResponseEntity.ok(response);
     }
 
-    @PutMapping("/{host-university-id}")
+    @PutMapping(value = "/{host-university-id}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<AdminHostUniversityDetailResponse> updateHostUniversity(
             @PathVariable("host-university-id") Long hostUniversityId,
-            @Valid @RequestBody AdminHostUniversityUpdateRequest request
+            @Valid @RequestPart("request") AdminHostUniversityUpdateRequest request,
+            @RequestPart(value = "logoFile", required = false) MultipartFile logoFile,
+            @RequestPart(value = "backgroundFile", required = false) MultipartFile backgroundFile
     ) {
-        AdminHostUniversityDetailResponse response = adminHostUniversityService.updateHostUniversity(hostUniversityId, request);
+        AdminHostUniversityDetailResponse response = adminHostUniversityService.updateHostUniversity(
+                hostUniversityId,
+                request,
+                logoFile,
+                backgroundFile
+        );
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/example/solidconnection/admin/university/dto/AdminHostUniversityCreateRequest.java
+++ b/src/main/java/com/example/solidconnection/admin/university/dto/AdminHostUniversityCreateRequest.java
@@ -25,14 +25,6 @@ public record AdminHostUniversityCreateRequest(
         @Size(max = 500, message = "숙소 URL은 500자 이하여야 합니다")
         String accommodationUrl,
 
-        @NotBlank(message = "로고 이미지 URL은 필수입니다")
-        @Size(max = 500, message = "로고 이미지 URL은 500자 이하여야 합니다")
-        String logoImageUrl,
-
-        @NotBlank(message = "배경 이미지 URL은 필수입니다")
-        @Size(max = 500, message = "배경 이미지 URL은 500자 이하여야 합니다")
-        String backgroundImageUrl,
-
         @Size(max = 1000, message = "상세 정보는 1000자 이하여야 합니다")
         String detailsForLocal,
 

--- a/src/main/java/com/example/solidconnection/admin/university/dto/AdminHostUniversityUpdateRequest.java
+++ b/src/main/java/com/example/solidconnection/admin/university/dto/AdminHostUniversityUpdateRequest.java
@@ -25,14 +25,6 @@ public record AdminHostUniversityUpdateRequest(
         @Size(max = 500, message = "숙소 URL은 500자 이하여야 합니다")
         String accommodationUrl,
 
-        @NotBlank(message = "로고 이미지 URL은 필수입니다")
-        @Size(max = 500, message = "로고 이미지 URL은 500자 이하여야 합니다")
-        String logoImageUrl,
-
-        @NotBlank(message = "배경 이미지 URL은 필수입니다")
-        @Size(max = 500, message = "배경 이미지 URL은 500자 이하여야 합니다")
-        String backgroundImageUrl,
-
         @Size(max = 1000, message = "상세 정보는 1000자 이하여야 합니다")
         String detailsForLocal,
 

--- a/src/main/java/com/example/solidconnection/admin/university/service/AdminHostUniversityService.java
+++ b/src/main/java/com/example/solidconnection/admin/university/service/AdminHostUniversityService.java
@@ -18,18 +18,25 @@ import com.example.solidconnection.location.country.domain.Country;
 import com.example.solidconnection.location.country.repository.CountryRepository;
 import com.example.solidconnection.location.region.domain.Region;
 import com.example.solidconnection.location.region.repository.RegionRepository;
+import com.example.solidconnection.s3.domain.UploadDirectoryName;
+import com.example.solidconnection.s3.domain.UploadPath;
+import com.example.solidconnection.s3.dto.UploadedFileUrlResponse;
+import com.example.solidconnection.s3.service.S3Service;
 import com.example.solidconnection.university.domain.HostUniversity;
 import com.example.solidconnection.university.repository.HostUniversityRepository;
 import com.example.solidconnection.university.repository.UnivApplyInfoRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class AdminHostUniversityService {
 
     private final HostUniversityRepository hostUniversityRepository;
@@ -37,6 +44,7 @@ public class AdminHostUniversityService {
     private final RegionRepository regionRepository;
     private final UnivApplyInfoRepository univApplyInfoRepository;
     private final CustomCacheManager cacheManager;
+    private final S3Service s3Service;
 
     @Transactional(readOnly = true)
     public Page<AdminHostUniversityResponse> getHostUniversities(
@@ -65,29 +73,51 @@ public class AdminHostUniversityService {
             cacheManager = "customCacheManager",
             prefix = true
     )
-    public AdminHostUniversityDetailResponse createHostUniversity(AdminHostUniversityCreateRequest request) {
+    public AdminHostUniversityDetailResponse createHostUniversity(
+            AdminHostUniversityCreateRequest request,
+            MultipartFile logoFile,
+            MultipartFile backgroundFile
+    ) {
         validateKoreanNameNotExists(request.koreanName());
 
         Country country = findCountryByCode(request.countryCode());
         Region region = findRegionByCode(request.regionCode());
+        String directoryName = UploadDirectoryName.fromUniversityNames(request.englishName(), request.koreanName());
+        UploadedFileUrlResponse logoImage = null;
+        UploadedFileUrlResponse backgroundImage = null;
 
-        HostUniversity hostUniversity = new HostUniversity(
-                null,
-                request.koreanName(),
-                request.englishName(),
-                request.formatName(),
-                request.homepageUrl(),
-                request.englishCourseUrl(),
-                request.accommodationUrl(),
-                request.logoImageUrl(),
-                request.backgroundImageUrl(),
-                request.detailsForLocal(),
-                country,
-                region
-        );
+        try {
+            logoImage = uploadUniversityImage(
+                    logoFile,
+                    UploadPath.ADMIN_UNIVERSITY_LOGO,
+                    directoryName
+            );
+            backgroundImage = uploadUniversityImage(
+                    backgroundFile,
+                    UploadPath.ADMIN_UNIVERSITY_BACKGROUND,
+                    directoryName
+            );
 
-        HostUniversity savedHostUniversity = hostUniversityRepository.save(hostUniversity);
-        return AdminHostUniversityDetailResponse.from(savedHostUniversity);
+            HostUniversity hostUniversity = new HostUniversity(
+                    null,
+                    request.koreanName(),
+                    request.englishName(),
+                    request.formatName(),
+                    request.homepageUrl(),
+                    request.englishCourseUrl(),
+                    request.accommodationUrl(),
+                    logoImage.fileUrl(),
+                    backgroundImage.fileUrl(),
+                    request.detailsForLocal(),
+                    country,
+                    region
+            );
+            HostUniversity savedHostUniversity = hostUniversityRepository.saveAndFlush(hostUniversity);
+            return AdminHostUniversityDetailResponse.from(savedHostUniversity);
+        } catch (RuntimeException e) {
+            deleteUploadedImages(logoImage, backgroundImage);
+            throw e;
+        }
     }
 
     private void validateKoreanNameNotExists(String koreanName) {
@@ -103,7 +133,12 @@ public class AdminHostUniversityService {
             cacheManager = "customCacheManager",
             prefix = true
     )
-    public AdminHostUniversityDetailResponse updateHostUniversity(Long id, AdminHostUniversityUpdateRequest request) {
+    public AdminHostUniversityDetailResponse updateHostUniversity(
+            Long id,
+            AdminHostUniversityUpdateRequest request,
+            MultipartFile logoFile,
+            MultipartFile backgroundFile
+    ) {
         HostUniversity hostUniversity = hostUniversityRepository.findById(id)
                 .orElseThrow(() -> new CustomException(UNIVERSITY_NOT_FOUND));
 
@@ -111,24 +146,84 @@ public class AdminHostUniversityService {
 
         Country country = findCountryByCode(request.countryCode());
         Region region = findRegionByCode(request.regionCode());
+        String directoryName = UploadDirectoryName.fromUniversityNames(request.englishName(), request.koreanName());
+        UploadedFileUrlResponse logoImage = null;
+        UploadedFileUrlResponse backgroundImage = null;
 
-        hostUniversity.update(
-                request.koreanName(),
-                request.englishName(),
-                request.formatName(),
-                request.homepageUrl(),
-                request.englishCourseUrl(),
-                request.accommodationUrl(),
-                request.logoImageUrl(),
-                request.backgroundImageUrl(),
-                request.detailsForLocal(),
-                country,
-                region
-        );
+        try {
+            logoImage = uploadUniversityImageIfExists(
+                    logoFile,
+                    UploadPath.ADMIN_UNIVERSITY_LOGO,
+                    directoryName
+            );
+            backgroundImage = uploadUniversityImageIfExists(
+                    backgroundFile,
+                    UploadPath.ADMIN_UNIVERSITY_BACKGROUND,
+                    directoryName
+            );
 
-        evictUnivApplyInfoDetailCaches(id);
+            hostUniversity.update(
+                    request.koreanName(),
+                    request.englishName(),
+                    request.formatName(),
+                    request.homepageUrl(),
+                    request.englishCourseUrl(),
+                    request.accommodationUrl(),
+                    getImageUrlOrDefault(logoImage, hostUniversity.getLogoImageUrl()),
+                    getImageUrlOrDefault(backgroundImage, hostUniversity.getBackgroundImageUrl()),
+                    request.detailsForLocal(),
+                    country,
+                    region
+            );
+            hostUniversityRepository.flush();
+            evictUnivApplyInfoDetailCaches(id);
+            return AdminHostUniversityDetailResponse.from(hostUniversity);
+        } catch (RuntimeException e) {
+            deleteUploadedImages(logoImage, backgroundImage);
+            throw e;
+        }
+    }
 
-        return AdminHostUniversityDetailResponse.from(hostUniversity);
+    private UploadedFileUrlResponse uploadUniversityImage(
+            MultipartFile imageFile,
+            UploadPath uploadPath,
+            String directoryName
+    ) {
+        return s3Service.uploadFile(imageFile, uploadPath, directoryName);
+    }
+
+    private UploadedFileUrlResponse uploadUniversityImageIfExists(
+            MultipartFile imageFile,
+            UploadPath uploadPath,
+            String directoryName
+    ) {
+        if (imageFile == null || imageFile.isEmpty()) {
+            return null;
+        }
+        return uploadUniversityImage(imageFile, uploadPath, directoryName);
+    }
+
+    private String getImageUrlOrDefault(UploadedFileUrlResponse uploadedImage, String defaultImageUrl) {
+        if (uploadedImage == null) {
+            return defaultImageUrl;
+        }
+        return uploadedImage.fileUrl();
+    }
+
+    private void deleteUploadedImages(UploadedFileUrlResponse... uploadedImages) {
+        for (UploadedFileUrlResponse uploadedImage : uploadedImages) {
+            if (uploadedImage != null) {
+                try {
+                    s3Service.deleteUploadedFile(uploadedImage);
+                } catch (RuntimeException deleteException) {
+                    log.warn(
+                            "Failed to delete uploaded university image. fileUrl={}",
+                            uploadedImage.fileUrl(),
+                            deleteException
+                    );
+                }
+            }
+        }
     }
 
     private void validateKoreanNameNotDuplicated(String koreanName, Long excludeId) {

--- a/src/main/java/com/example/solidconnection/s3/controller/S3Controller.java
+++ b/src/main/java/com/example/solidconnection/s3/controller/S3Controller.java
@@ -1,13 +1,10 @@
 package com.example.solidconnection.s3.controller;
 
 import com.example.solidconnection.common.resolver.AuthorizedUser;
-import com.example.solidconnection.s3.domain.UploadDirectoryName;
 import com.example.solidconnection.s3.domain.UploadPath;
 import com.example.solidconnection.s3.dto.UploadedFileUrlResponse;
 import com.example.solidconnection.s3.dto.UrlPrefixResponse;
 import com.example.solidconnection.s3.service.S3Service;
-import com.example.solidconnection.security.annotation.RequireRoleAccess;
-import com.example.solidconnection.siteuser.domain.Role;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -78,38 +75,6 @@ public class S3Controller {
     ) {
         List<UploadedFileUrlResponse> chatImageUrls = s3Service.uploadFiles(files, UploadPath.CHAT);
         return ResponseEntity.ok(chatImageUrls);
-    }
-
-    @RequireRoleAccess(roles = Role.ADMIN)
-    @PostMapping("/admin/university/logo")
-    public ResponseEntity<UploadedFileUrlResponse> uploadAdminUniversityLogo(
-            @AuthorizedUser long adminId,
-            @RequestParam("file") MultipartFile imageFile,
-            @RequestParam("englishName") String englishName
-    ) {
-        String directoryName = UploadDirectoryName.fromUniversityEnglishName(englishName);
-        UploadedFileUrlResponse logoImageUrl = s3Service.uploadFile(
-                imageFile,
-                UploadPath.ADMIN_UNIVERSITY_LOGO,
-                directoryName
-        );
-        return ResponseEntity.ok(logoImageUrl);
-    }
-
-    @RequireRoleAccess(roles = Role.ADMIN)
-    @PostMapping("/admin/university/background")
-    public ResponseEntity<UploadedFileUrlResponse> uploadAdminUniversityBackground(
-            @AuthorizedUser long adminId,
-            @RequestParam("file") MultipartFile imageFile,
-            @RequestParam("englishName") String englishName
-    ) {
-        String directoryName = UploadDirectoryName.fromUniversityEnglishName(englishName);
-        UploadedFileUrlResponse backgroundImageUrl = s3Service.uploadFile(
-                imageFile,
-                UploadPath.ADMIN_UNIVERSITY_BACKGROUND,
-                directoryName
-        );
-        return ResponseEntity.ok(backgroundImageUrl);
     }
 
     @GetMapping("/s3-url-prefix")

--- a/src/main/java/com/example/solidconnection/s3/domain/UploadDirectoryName.java
+++ b/src/main/java/com/example/solidconnection/s3/domain/UploadDirectoryName.java
@@ -14,8 +14,11 @@ public final class UploadDirectoryName {
     private UploadDirectoryName() {
     }
 
-    public static String fromUniversityEnglishName(String englishName) {
+    public static String fromUniversityNames(String englishName, String koreanName) {
         if (englishName == null || englishName.isBlank()) {
+            throw new CustomException(ErrorCode.INVALID_INPUT);
+        }
+        if (koreanName == null || koreanName.isBlank()) {
             throw new CustomException(ErrorCode.INVALID_INPUT);
         }
 
@@ -30,7 +33,7 @@ public final class UploadDirectoryName {
             throw new CustomException(ErrorCode.INVALID_INPUT);
         }
 
-        return directoryName + "_" + hash(englishName.trim());
+        return directoryName + "_" + hash(koreanName.trim());
     }
 
     private static String hash(String value) {

--- a/src/main/java/com/example/solidconnection/s3/dto/UploadedFileUrlResponse.java
+++ b/src/main/java/com/example/solidconnection/s3/dto/UploadedFileUrlResponse.java
@@ -1,6 +1,12 @@
 package com.example.solidconnection.s3.dto;
 
-public record UploadedFileUrlResponse(
-        String fileUrl) {
+import com.fasterxml.jackson.annotation.JsonIgnore;
 
+public record UploadedFileUrlResponse(
+        String fileUrl,
+        @JsonIgnore String deletionKey) {
+
+    public UploadedFileUrlResponse(String fileUrl) {
+        this(fileUrl, fileUrl);
+    }
 }

--- a/src/main/java/com/example/solidconnection/s3/service/S3Service.java
+++ b/src/main/java/com/example/solidconnection/s3/service/S3Service.java
@@ -78,7 +78,7 @@ public class S3Service {
 
         fileUploadService.uploadFile(bucket, originalPath, bytes, contentType);
 
-        return new UploadedFileUrlResponse(returnPath);
+        return new UploadedFileUrlResponse(returnPath, originalPath);
     }
 
     private String createFileName(UploadPath uploadPath, String subDirectory, String baseFileName) {
@@ -139,6 +139,13 @@ public class S3Service {
 
     public void deletePostImage(String url) {
         deleteFile(url);
+    }
+
+    public void deleteUploadedFile(UploadedFileUrlResponse uploadedFile) {
+        if (uploadedFile == null) {
+            return;
+        }
+        deleteFile(uploadedFile.deletionKey());
     }
 
     private void deleteFile(String fileName) {

--- a/src/test/java/com/example/solidconnection/admin/service/AdminHostUniversityServiceTest.java
+++ b/src/test/java/com/example/solidconnection/admin/service/AdminHostUniversityServiceTest.java
@@ -2,7 +2,12 @@ package com.example.solidconnection.admin.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.times;
 
 import com.example.solidconnection.admin.university.dto.AdminHostUniversityCreateRequest;
@@ -18,6 +23,9 @@ import com.example.solidconnection.location.country.domain.Country;
 import com.example.solidconnection.location.country.fixture.CountryFixture;
 import com.example.solidconnection.location.region.domain.Region;
 import com.example.solidconnection.location.region.fixture.RegionFixture;
+import com.example.solidconnection.s3.domain.UploadPath;
+import com.example.solidconnection.s3.dto.UploadedFileUrlResponse;
+import com.example.solidconnection.s3.service.S3Service;
 import com.example.solidconnection.support.TestContainerSpringBootTest;
 import com.example.solidconnection.university.domain.HostUniversity;
 import com.example.solidconnection.university.domain.UnivApplyInfo;
@@ -31,6 +39,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 @TestContainerSpringBootTest
@@ -57,6 +67,29 @@ class AdminHostUniversityServiceTest {
 
     @MockitoSpyBean
     private CustomCacheManager cacheManager;
+
+    @MockitoBean
+    private S3Service s3Service;
+
+    private MockMultipartFile createImageFile(String name) {
+        return new MockMultipartFile("file", name, "image/png", new byte[100]);
+    }
+
+    private void stubUniversityImageUpload() {
+        given(s3Service.uploadFile(any(), eq(UploadPath.ADMIN_UNIVERSITY_LOGO), anyString()))
+                .willReturn(new UploadedFileUrlResponse("admin/logo/test/logo.png"));
+        given(s3Service.uploadFile(any(), eq(UploadPath.ADMIN_UNIVERSITY_BACKGROUND), anyString()))
+                .willReturn(new UploadedFileUrlResponse("admin/background/test/background.png"));
+    }
+
+    private UploadedFileUrlResponse stubLogoUploadAndBackgroundUploadFailure() {
+        UploadedFileUrlResponse logoImage = new UploadedFileUrlResponse("admin/logo/test/logo.png");
+        given(s3Service.uploadFile(any(), eq(UploadPath.ADMIN_UNIVERSITY_LOGO), anyString()))
+                .willReturn(logoImage);
+        given(s3Service.uploadFile(any(), eq(UploadPath.ADMIN_UNIVERSITY_BACKGROUND), anyString()))
+                .willThrow(new RuntimeException("background upload failed"));
+        return logoImage;
+    }
 
     @Nested
     class 목록_조회 {
@@ -206,6 +239,7 @@ class AdminHostUniversityServiceTest {
             // given
             Country country = countryFixture.미국();
             Region region = regionFixture.영미권();
+            stubUniversityImageUpload();
 
             AdminHostUniversityCreateRequest request = new AdminHostUniversityCreateRequest(
                     "테스트 대학",
@@ -214,15 +248,17 @@ class AdminHostUniversityServiceTest {
                     "https://homepage.com",
                     "https://english-course.com",
                     "https://accommodation.com",
-                    "https://logo.com/image.png",
-                    "https://background.com/image.png",
                     "상세 정보",
                     country.getCode(),
                     region.getCode()
             );
 
             // when
-            AdminHostUniversityDetailResponse response = adminHostUniversityService.createHostUniversity(request);
+            AdminHostUniversityDetailResponse response = adminHostUniversityService.createHostUniversity(
+                    request,
+                    createImageFile("logo.png"),
+                    createImageFile("background.png")
+            );
 
             // then
             assertThat(response.koreanName()).isEqualTo(request.koreanName());
@@ -230,6 +266,8 @@ class AdminHostUniversityServiceTest {
 
             HostUniversity savedUniversity = hostUniversityRepository.findById(response.id()).orElseThrow();
             assertThat(savedUniversity.getKoreanName()).isEqualTo(request.koreanName());
+            assertThat(savedUniversity.getLogoImageUrl()).isEqualTo("admin/logo/test/logo.png");
+            assertThat(savedUniversity.getBackgroundImageUrl()).isEqualTo("admin/background/test/background.png");
         }
 
         @Test
@@ -244,15 +282,17 @@ class AdminHostUniversityServiceTest {
                     "New English Name",
                     "표시명",
                     null, null, null,
-                    "https://logo.com/image.png",
-                    "https://background.com/image.png",
                     null,
                     country.getCode(),
                     region.getCode()
             );
 
             // when & then
-            assertThatCode(() -> adminHostUniversityService.createHostUniversity(request))
+            assertThatCode(() -> adminHostUniversityService.createHostUniversity(
+                    request,
+                    createImageFile("logo.png"),
+                    createImageFile("background.png")
+            ))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(ErrorCode.HOST_UNIVERSITY_ALREADY_EXISTS.getMessage());
         }
@@ -263,25 +303,86 @@ class AdminHostUniversityServiceTest {
             HostUniversity existing = universityFixture.괌_대학();
             Country country = countryFixture.미국();
             Region region = regionFixture.영미권();
+            stubUniversityImageUpload();
 
             AdminHostUniversityCreateRequest request = new AdminHostUniversityCreateRequest(
                     "신규 대학",
                     existing.getEnglishName(),
                     "표시명",
                     null, null, null,
-                    "https://logo.com/image.png",
-                    "https://background.com/image.png",
                     null,
                     country.getCode(),
                     region.getCode()
             );
 
             // when
-            AdminHostUniversityDetailResponse response = adminHostUniversityService.createHostUniversity(request);
+            AdminHostUniversityDetailResponse response = adminHostUniversityService.createHostUniversity(
+                    request,
+                    createImageFile("logo.png"),
+                    createImageFile("background.png")
+            );
 
             // then
             assertThat(response.koreanName()).isEqualTo(request.koreanName());
             assertThat(response.englishName()).isEqualTo(existing.getEnglishName());
+        }
+
+        @Test
+        void 배경_이미지_업로드가_실패하면_이미_업로드된_로고_이미지를_삭제한다() {
+            // given
+            Country country = countryFixture.미국();
+            Region region = regionFixture.영미권();
+            UploadedFileUrlResponse logoImage = stubLogoUploadAndBackgroundUploadFailure();
+
+            AdminHostUniversityCreateRequest request = new AdminHostUniversityCreateRequest(
+                    "테스트 대학",
+                    "Test University",
+                    "테스트 대학",
+                    null, null, null,
+                    null,
+                    country.getCode(),
+                    region.getCode()
+            );
+
+            // when & then
+            assertThatCode(() -> adminHostUniversityService.createHostUniversity(
+                    request,
+                    createImageFile("logo.png"),
+                    createImageFile("background.png")
+            ))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessage("background upload failed");
+            then(s3Service).should().deleteUploadedFile(logoImage);
+        }
+
+        @Test
+        void 보상_삭제가_실패해도_원래_예외를_반환한다() {
+            // given
+            Country country = countryFixture.미국();
+            Region region = regionFixture.영미권();
+            UploadedFileUrlResponse logoImage = stubLogoUploadAndBackgroundUploadFailure();
+            willThrow(new RuntimeException("delete failed"))
+                    .given(s3Service)
+                    .deleteUploadedFile(logoImage);
+
+            AdminHostUniversityCreateRequest request = new AdminHostUniversityCreateRequest(
+                    "테스트 대학",
+                    "Test University",
+                    "테스트 대학",
+                    null, null, null,
+                    null,
+                    country.getCode(),
+                    region.getCode()
+            );
+
+            // when & then
+            assertThatCode(() -> adminHostUniversityService.createHostUniversity(
+                    request,
+                    createImageFile("logo.png"),
+                    createImageFile("background.png")
+            ))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessage("background upload failed");
         }
     }
 
@@ -292,6 +393,8 @@ class AdminHostUniversityServiceTest {
         void 유효한_정보로_대학을_수정하면_성공한다() {
             // given
             HostUniversity university = universityFixture.괌_대학();
+            String originLogoImageUrl = university.getLogoImageUrl();
+            String originBackgroundImageUrl = university.getBackgroundImageUrl();
             Country country = countryFixture.일본();
             Region region = regionFixture.아시아();
 
@@ -301,8 +404,6 @@ class AdminHostUniversityServiceTest {
                     "수정된 표시명",
                     "https://new-homepage.com",
                     null, null,
-                    "https://new-logo.com/image.png",
-                    "https://new-background.com/image.png",
                     "수정된 상세 정보",
                     country.getCode(),
                     region.getCode()
@@ -310,7 +411,11 @@ class AdminHostUniversityServiceTest {
 
             // when
             AdminHostUniversityDetailResponse response = adminHostUniversityService.updateHostUniversity(
-                    university.getId(), request);
+                    university.getId(),
+                    request,
+                    null,
+                    null
+            );
 
             // then
             assertThat(response.koreanName()).isEqualTo(request.koreanName());
@@ -318,6 +423,66 @@ class AdminHostUniversityServiceTest {
 
             HostUniversity updatedUniversity = hostUniversityRepository.findById(university.getId()).orElseThrow();
             assertThat(updatedUniversity.getKoreanName()).isEqualTo(request.koreanName());
+            assertThat(updatedUniversity.getLogoImageUrl()).isEqualTo(originLogoImageUrl);
+            assertThat(updatedUniversity.getBackgroundImageUrl()).isEqualTo(originBackgroundImageUrl);
+        }
+
+        @Test
+        void 이미지_파일을_함께_전달하면_업로드된_이미지_URL로_수정한다() {
+            // given
+            HostUniversity university = universityFixture.괌_대학();
+            stubUniversityImageUpload();
+
+            AdminHostUniversityUpdateRequest request = new AdminHostUniversityUpdateRequest(
+                    university.getKoreanName(),
+                    university.getEnglishName(),
+                    "수정된 표시명",
+                    null, null, null,
+                    null,
+                    university.getCountry().getCode(),
+                    university.getRegion().getCode()
+            );
+
+            // when
+            adminHostUniversityService.updateHostUniversity(
+                    university.getId(),
+                    request,
+                    createImageFile("new-logo.png"),
+                    createImageFile("new-background.png")
+            );
+
+            // then
+            HostUniversity updatedUniversity = hostUniversityRepository.findById(university.getId()).orElseThrow();
+            assertThat(updatedUniversity.getLogoImageUrl()).isEqualTo("admin/logo/test/logo.png");
+            assertThat(updatedUniversity.getBackgroundImageUrl()).isEqualTo("admin/background/test/background.png");
+        }
+
+        @Test
+        void 배경_이미지_업로드가_실패하면_이미_업로드된_로고_이미지를_삭제한다() {
+            // given
+            HostUniversity university = universityFixture.괌_대학();
+            UploadedFileUrlResponse logoImage = stubLogoUploadAndBackgroundUploadFailure();
+
+            AdminHostUniversityUpdateRequest request = new AdminHostUniversityUpdateRequest(
+                    university.getKoreanName(),
+                    university.getEnglishName(),
+                    "수정된 표시명",
+                    null, null, null,
+                    null,
+                    university.getCountry().getCode(),
+                    university.getRegion().getCode()
+            );
+
+            // when & then
+            assertThatCode(() -> adminHostUniversityService.updateHostUniversity(
+                    university.getId(),
+                    request,
+                    createImageFile("new-logo.png"),
+                    createImageFile("new-background.png")
+            ))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessage("background upload failed");
+            then(s3Service).should().deleteUploadedFile(logoImage);
         }
 
         @Test
@@ -331,15 +496,13 @@ class AdminHostUniversityServiceTest {
                     "Updated University",
                     "수정된 표시명",
                     null, null, null,
-                    "https://logo.com/image.png",
-                    "https://background.com/image.png",
                     null,
                     country.getCode(),
                     region.getCode()
             );
 
             // when & then
-            assertThatCode(() -> adminHostUniversityService.updateHostUniversity(999L, request))
+            assertThatCode(() -> adminHostUniversityService.updateHostUniversity(999L, request, null, null))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(ErrorCode.UNIVERSITY_NOT_FOUND.getMessage());
         }
@@ -355,15 +518,13 @@ class AdminHostUniversityServiceTest {
                     "Updated University",
                     "수정된 표시명",
                     null, null, null,
-                    "https://logo.com/image.png",
-                    "https://background.com/image.png",
                     null,
                     university1.getCountry().getCode(),
                     university1.getRegion().getCode()
             );
 
             // when & then
-            assertThatCode(() -> adminHostUniversityService.updateHostUniversity(university1.getId(), request))
+            assertThatCode(() -> adminHostUniversityService.updateHostUniversity(university1.getId(), request, null, null))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(ErrorCode.HOST_UNIVERSITY_ALREADY_EXISTS.getMessage());
         }
@@ -379,8 +540,6 @@ class AdminHostUniversityServiceTest {
                     university2.getEnglishName(),
                     "수정된 표시명",
                     null, null, null,
-                    "https://logo.com/image.png",
-                    "https://background.com/image.png",
                     null,
                     university1.getCountry().getCode(),
                     university1.getRegion().getCode()
@@ -388,7 +547,11 @@ class AdminHostUniversityServiceTest {
 
             // when
             AdminHostUniversityDetailResponse response = adminHostUniversityService.updateHostUniversity(
-                    university1.getId(), request);
+                    university1.getId(),
+                    request,
+                    null,
+                    null
+            );
 
             // then
             assertThat(response.koreanName()).isEqualTo(university1.getKoreanName());
@@ -405,8 +568,6 @@ class AdminHostUniversityServiceTest {
                     "Updated English Name",
                     "수정된 표시명",
                     null, null, null,
-                    "https://logo.com/image.png",
-                    "https://background.com/image.png",
                     null,
                     university.getCountry().getCode(),
                     university.getRegion().getCode()
@@ -414,7 +575,11 @@ class AdminHostUniversityServiceTest {
 
             // when
             AdminHostUniversityDetailResponse response = adminHostUniversityService.updateHostUniversity(
-                    university.getId(), request);
+                    university.getId(),
+                    request,
+                    null,
+                    null
+            );
 
             // then
             assertThat(response.koreanName()).isEqualTo(university.getKoreanName());
@@ -477,15 +642,18 @@ class AdminHostUniversityServiceTest {
                     "캐시 테스트 대학",
                     "https://homepage.com",
                     null, null,
-                    "https://logo.com/image.png",
-                    "https://background.com/image.png",
                     null,
                     country.getCode(),
                     region.getCode()
             );
+            stubUniversityImageUpload();
 
             // when
-            adminHostUniversityService.createHostUniversity(request);
+            adminHostUniversityService.createHostUniversity(
+                    request,
+                    createImageFile("logo.png"),
+                    createImageFile("background.png")
+            );
 
             // then
             then(cacheManager).should(times(1)).evictUsingPrefix("univApplyInfoTextSearch");
@@ -510,15 +678,13 @@ class AdminHostUniversityServiceTest {
                     "Updated University",
                     "수정된 표시명",
                     null, null, null,
-                    "https://logo.com/image.png",
-                    "https://background.com/image.png",
                     null,
                     country.getCode(),
                     region.getCode()
             );
 
             // when
-            adminHostUniversityService.updateHostUniversity(university.getId(), request);
+            adminHostUniversityService.updateHostUniversity(university.getId(), request, null, null);
 
             // then
             then(cacheManager).should(times(1)).evictUsingPrefix("univApplyInfoTextSearch");

--- a/src/test/java/com/example/solidconnection/s3/domain/UploadDirectoryNameTest.java
+++ b/src/test/java/com/example/solidconnection/s3/domain/UploadDirectoryNameTest.java
@@ -18,9 +18,10 @@ class UploadDirectoryNameTest {
         void 대학_영문명의_공백을_언더스코어로_변환한다() {
             // given
             String englishName = "University of Tokyo";
+            String koreanName = "도쿄대학교";
 
             // when
-            String directoryName = UploadDirectoryName.fromUniversityEnglishName(englishName);
+            String directoryName = UploadDirectoryName.fromUniversityNames(englishName, koreanName);
 
             // then
             assertThat(directoryName)
@@ -32,9 +33,10 @@ class UploadDirectoryNameTest {
         void 특수문자를_제거하고_앰퍼샌드는_and로_변환한다() {
             // given
             String englishName = "Texas A&M University, Austin";
+            String koreanName = "텍사스 A&M 대학교 오스틴";
 
             // when
-            String directoryName = UploadDirectoryName.fromUniversityEnglishName(englishName);
+            String directoryName = UploadDirectoryName.fromUniversityNames(englishName, koreanName);
 
             // then
             assertThat(directoryName)
@@ -43,17 +45,25 @@ class UploadDirectoryNameTest {
         }
 
         @Test
-        void 같은_slug로_변환되는_서로_다른_영문명은_다른_디렉토리명을_반환한다() {
+        void 같은_영문명이어도_한글명이_다르면_다른_디렉토리명을_반환한다() {
             // given
-            String englishName = "Texas A&M University";
-            String normalizedCollisionName = "Texas A and M University";
+            String englishName = "University of California";
+            String koreanName = "캘리포니아대학교";
+            String duplicateEnglishKoreanName = "캘리포니아대학";
 
             // when
-            String directoryName = UploadDirectoryName.fromUniversityEnglishName(englishName);
-            String collisionDirectoryName = UploadDirectoryName.fromUniversityEnglishName(normalizedCollisionName);
+            String directoryName = UploadDirectoryName.fromUniversityNames(englishName, koreanName);
+            String duplicateEnglishDirectoryName = UploadDirectoryName.fromUniversityNames(
+                    englishName,
+                    duplicateEnglishKoreanName
+            );
 
             // then
-            assertThat(directoryName).isNotEqualTo(collisionDirectoryName);
+            assertThat(directoryName)
+                    .startsWith("university_of_california_")
+                    .isNotEqualTo(duplicateEnglishDirectoryName);
+            assertThat(duplicateEnglishDirectoryName)
+                    .startsWith("university_of_california_");
         }
 
         @Test
@@ -62,7 +72,17 @@ class UploadDirectoryNameTest {
             String blankName = " ";
 
             // when & then
-            assertThatThrownBy(() -> UploadDirectoryName.fromUniversityEnglishName(blankName))
+            assertThatThrownBy(() -> UploadDirectoryName.fromUniversityNames(blankName, "한글명"))
+                    .isInstanceOf(CustomException.class);
+        }
+
+        @Test
+        void 한글명이_공백_문자열이면_예외가_발생한다() {
+            // given
+            String blankKoreanName = " ";
+
+            // when & then
+            assertThatThrownBy(() -> UploadDirectoryName.fromUniversityNames("University of Tokyo", blankKoreanName))
                     .isInstanceOf(CustomException.class);
         }
     }

--- a/src/test/java/com/example/solidconnection/s3/service/S3ServiceTest.java
+++ b/src/test/java/com/example/solidconnection/s3/service/S3ServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.BDDMockito.then;
 
 import com.example.solidconnection.common.exception.CustomException;
 import com.example.solidconnection.s3.domain.UploadPath;
@@ -12,10 +13,13 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockMultipartFile;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 
 @DisplayName("S3 서비스 테스트")
 @ExtendWith(MockitoExtension.class)
@@ -24,6 +28,8 @@ public class S3ServiceTest {
     private static final long MAX_FILE_SIZE_MB = 1024 * 1024 * 5;
     @InjectMocks
     private S3Service s3Service;
+    @Mock
+    private S3Client s3Client;
     @Mock
     private FileUploadService fileUploadService;
 
@@ -149,6 +155,27 @@ public class S3ServiceTest {
                     () -> assertThatCode(() -> s3Service.uploadFile(languageTestPdfFile, UploadPath.LANGUAGE_TEST))
                             .doesNotThrowAnyException()
             );
+        }
+    }
+
+    @Nested
+    class 파일_삭제 {
+
+        @Test
+        void 업로드된_파일을_삭제할_때_삭제용_key를_사용한다() {
+            // given
+            UploadedFileUrlResponse uploadedFile = new UploadedFileUrlResponse(
+                    "resize/profile/test.webp",
+                    "original/profile/test.jpg"
+            );
+
+            // when
+            s3Service.deleteUploadedFile(uploadedFile);
+
+            // then
+            ArgumentCaptor<DeleteObjectRequest> requestCaptor = ArgumentCaptor.forClass(DeleteObjectRequest.class);
+            then(s3Client).should().deleteObject(requestCaptor.capture());
+            assertThat(requestCaptor.getValue().key()).isEqualTo("original/profile/test.jpg");
         }
     }
 }


### PR DESCRIPTION
## 관련 이슈

- resolves: #774

## 작업 내용

### 관리자 대학 이미지 업로드를 대학 생성/수정 API에 통합

- 관리자 대학 생성 API가 `multipart/form-data`로 대학 정보 JSON(`request`)과 로고/배경 이미지 파일을 함께 받도록 변경했습니다.
- 관리자 대학 수정 API도 `multipart/form-data`로 변경하고, 로고/배경 이미지 파일은 선택 입력으로 처리했습니다.
- 기존 분리형 관리자 대학 이미지 업로드 API(`/file/admin/university/logo`, `/file/admin/university/background`)는 제거했습니다.

**이유**

- 이미지 업로드 API와 대학 CRUD API가 분리되어 있으면 프론트에서 호출 순서를 관리해야 하고, 업로드 성공 후 대학 생성/수정 실패 시 S3 파일이 남을 수 있습니다.
- 대학 이미지 업로드는 대학 생성/수정 유스케이스에 종속된 작업이므로, 서버에서 하나의 작업 흐름으로 관리하는 편이 실패 처리와 데이터 정합성 측면에서 안전합니다.

### 이미지 URL 요청 필드 제거

- `AdminHostUniversityCreateRequest`, `AdminHostUniversityUpdateRequest`에서 `logoImageUrl`, `backgroundImageUrl`을 제거했습니다.
- 서버가 S3 업로드 결과로 받은 URL을 `HostUniversity` 이미지 필드에 저장하도록 변경했습니다.

**이유**

- 클라이언트가 임의 URL을 전달하는 구조에서는 업로드 실패, 비이미지 파일 URL 저장, 잘못된 경로 저장을 서버가 충분히 제어하기 어렵습니다.
- 이미지 파일 검증과 URL 생성 책임을 서버로 모아 관리자 대학 이미지 필드의 무결성을 높였습니다.

### 대학별 S3 경로 식별자 개선

- `UploadDirectoryName.fromUniversityNames(englishName, koreanName)`을 추가했습니다.
- 디렉토리 prefix는 영문명을 slug로 변환하고, suffix hash는 unique 제약이 있는 한글명 기준으로 생성하도록 변경했습니다.

**이유**

- `HostUniversity.englishName`은 unique 제약이 없어 서로 다른 대학이 같은 영문명을 가질 수 있습니다.
- 영문명 정규화는 공백/특수문자 제거 등 손실적 변환이 포함되어 같은 slug로 충돌할 수 있습니다.
- 한글명은 unique 제약이 있으므로, 같은 영문명이어도 한글명이 다르면 서로 다른 S3 경로를 만들 수 있습니다.

### 업로드 실패 보상 삭제 처리

- 대학 생성/수정 중 S3 업로드 또는 DB 저장이 실패하면, 이미 업로드된 새 이미지를 삭제하도록 보상 로직을 추가했습니다.
- 로고 업로드 성공 후 배경 업로드가 실패하는 경우에도 로고 파일이 남지 않도록 업로드 단계 전체를 보상 삭제 범위에 포함했습니다.
- 보상 삭제 자체가 실패해도 원래 실패 원인이 덮이지 않도록 `warn` 로그만 남기고 원래 예외를 유지했습니다.

**이유**

- S3는 DB 트랜잭션에 포함되지 않기 때문에 DB rollback만으로 업로드된 파일을 되돌릴 수 없습니다.
- 중간 실패 시 orphan 파일이 남지 않도록 서버에서 보상 삭제를 수행해야 합니다.
- 보상 삭제 실패가 원래 예외를 덮으면 실제 원인 파악이 어려워지므로 원래 예외를 보존했습니다.

### S3 삭제 API 캡슐화

- `S3Service.deleteFile(String)`은 내부 구현으로 유지하고, 외부에서는 `deleteUploadedFile(UploadedFileUrlResponse)`를 사용하도록 변경했습니다.
- `UploadedFileUrlResponse`에 내부 삭제용 `deletionKey`를 추가하고, API 응답에는 노출되지 않도록 `@JsonIgnore`를 적용했습니다.

**이유**

- 리사이즈 대상 이미지는 클라이언트/DB에 저장되는 반환 URL과 실제 업로드 key가 다를 수 있습니다.
- 삭제 호출부가 S3 key 정책을 직접 알지 않도록 삭제 책임을 `S3Service` 내부로 캡슐화했습니다.

### 테스트 보강

- 관리자 대학 생성/수정 시 이미지 업로드 URL 저장 동작을 검증했습니다.
- 수정 시 이미지 파일을 전달하지 않으면 기존 이미지 URL을 유지하는지 검증했습니다.
- 같은 영문명이어도 한글명이 다르면 서로 다른 S3 경로가 생성되는지 검증했습니다.
- 배경 이미지 업로드 실패 시 이미 업로드된 로고 이미지가 보상 삭제되는지 검증했습니다.
- 보상 삭제가 실패해도 원래 예외가 유지되는지 검증했습니다.
- `deleteUploadedFile`이 `fileUrl`이 아니라 `deletionKey`로 삭제 요청을 보내는지 검증했습니다.

**이유**

- 이번 변경은 API 요청 형식, S3 경로 생성, 실패 보상 로직이 함께 바뀌므로 정상 흐름뿐 아니라 중간 실패 흐름까지 회귀 테스트가 필요합니다.

## 특이 사항

- 관리자 대학 생성/수정 API 요청 형식이 JSON body에서 `multipart/form-data`로 변경됩니다.
- 생성 요청은 `request`, `logoFile`, `backgroundFile` part가 필요합니다.
- 수정 요청은 `request` part가 필요하고, `logoFile`, `backgroundFile` part는 선택입니다.
- 이미지 파일 없이 대학명 등 텍스트 정보만 수정하는 요청은 허용하며, 이 경우 기존 이미지 URL을 유지합니다.
- S3 경로는 현재 대학명을 항상 반영하는 값이 아니라 이미지 업로드 시점의 저장 경로로 취급합니다. 따라서 이름만 변경하면 기존 이미지 경로가 이전 이름 기반 디렉터리를 가리킬 수 있습니다.
- 이름 변경에 맞춰 기존 S3 객체를 자동 이동하지 않습니다. S3 rename은 copy/delete 작업이 필요하고 DB 커밋 이후 처리되어야 하므로, 필요 시 별도 마이그레이션/정리 작업 또는 이미지 재업로드 정책으로 다룹니다.
- 기존 이미지 교체 성공 후 old image 삭제는 이번 PR 범위에 포함하지 않았습니다. 커밋 성공 이후 삭제되어야 하며, 프로필/뉴스/게시글 등 기존 이미지 삭제 정책도 함께 정리해야 하므로 별도 후속 작업으로 다루는 것이 안전합니다.
- S3 업로드가 비동기로 처리되는 구조상, 실제 S3 반영 실패까지 DB 트랜잭션과 완전히 묶는 문제는 별도 개선 포인트로 남아 있습니다.

## 리뷰 요구사항 (선택)

- `AdminHostUniversityService`가 S3 업로드까지 담당하도록 변경한 결합도가 현재 유스케이스 기준에서 적절한지 확인 부탁드립니다.
- 한글명 unique 제약을 기반으로 S3 경로 hash suffix를 만드는 방향이 도메인 정책과 맞는지 확인 부탁드립니다.
- 업로드 실패 보상 삭제 범위와 예외 보존 방식이 충분한지 확인 부탁드립니다.
