### PR TITLE
refactor: CustomException은 이중 래핑하지 않고 던지도록

### DIFF
--- a/src/main/java/com/example/solidconnection/cache/ThunderingHerdCachingAspect.java
+++ b/src/main/java/com/example/solidconnection/cache/ThunderingHerdCachingAspect.java
@@ -7,6 +7,7 @@ import static com.example.solidconnection.redis.RedisConstants.REFRESH_LIMIT_PER
 
 import com.example.solidconnection.cache.annotation.ThunderingHerdCaching;
 import com.example.solidconnection.cache.manager.CacheManager;
+import com.example.solidconnection.common.exception.CustomException;
 import com.example.solidconnection.util.RedisUtils;
 import java.time.Duration;
 import java.util.UUID;
@@ -114,6 +115,8 @@ public class ThunderingHerdCachingAspect {
             } else {
                 return onLockFailed.call();
             }
+        } catch (CustomException e) {
+            throw e;
         } catch (Exception e) {
             throw new RuntimeException("Error during executeWithLock", e);
         } finally {
@@ -150,6 +153,8 @@ public class ThunderingHerdCachingAspect {
     private Object proceedJoinPoint(ProceedingJoinPoint joinPoint) {
         try {
             return joinPoint.proceed();
+        } catch (CustomException e) {
+            throw e;
         } catch (Throwable e) {
             throw new RuntimeException("Error during proceedJoinPoint", e);
         }

--- a/src/test/java/com/example/solidconnection/university/service/UnivApplyInfoQueryServiceTest.java
+++ b/src/test/java/com/example/solidconnection/university/service/UnivApplyInfoQueryServiceTest.java
@@ -83,10 +83,8 @@ class UnivApplyInfoQueryServiceTest {
             Long invalidUnivApplyInfoId = 9999L;
 
             // when & then
-            assertThatExceptionOfType(RuntimeException.class)
+            assertThatExceptionOfType(CustomException.class)
                     .isThrownBy(() -> univApplyInfoQueryService.getUnivApplyInfoDetail(invalidUnivApplyInfoId))
-                    .havingRootCause()
-                    .isInstanceOf(CustomException.class)
                     .withMessage(UNIV_APPLY_INFO_NOT_FOUND.getMessage());
         }
     }


### PR DESCRIPTION
## 관련 이슈

- resolves: #790 

## 작업 내용

<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

```java
private Object proceedJoinPoint(ProceedingJoinPoint joinPoint) {
    try {
        return joinPoint.proceed();
    } catch (Throwable e) {
        throw new RuntimeException("Error during proceedJoinPoint", e);
    }
}
```

```java
// executeWithLock 메서드
} catch (Exception e) {
    throw new RuntimeException("Error during executeWithLock", e);
}
```

조인포인트에서 예외가 발생한 경우 런타임 예외를 던지고, 이를 `executeWithLock` 메서드에서 `CustomException`은 별도로 처리하지 않고 `Exception`을 받아 런타임 에러로 던집니다.

즉, `CustomException`이 발생하더라도 결과적으로 500 에러가 발생하게 됩니다.

이에 `CustomException`인 경우 미리 던지도록 수정합니다.

## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
