### PR TITLE
fix: 지원 가능 대학 모집 인원 nullable 응답 처리

### DIFF
--- a/src/main/java/com/example/solidconnection/university/dto/UnivApplyInfoDetailResponse.java
+++ b/src/main/java/com/example/solidconnection/university/dto/UnivApplyInfoDetailResponse.java
@@ -17,7 +17,7 @@ public record UnivApplyInfoDetailResponse(
         String logoImageUrl,
         String backgroundImageUrl,
         String detailsForLocal,
-        int studentCapacity,
+        Integer studentCapacity,
         String semesterAvailableForDispatch,
         List<LanguageRequirementResponse> languageRequirements,
         String detailsForLanguage,

--- a/src/main/java/com/example/solidconnection/university/dto/UnivApplyInfoPreviewResponse.java
+++ b/src/main/java/com/example/solidconnection/university/dto/UnivApplyInfoPreviewResponse.java
@@ -14,7 +14,7 @@ public record UnivApplyInfoPreviewResponse(
         String country,
         String logoImageUrl,
         String backgroundImageUrl,
-        int studentCapacity,
+        Integer studentCapacity,
         List<LanguageRequirementResponse> languageRequirements) {
 
     public static UnivApplyInfoPreviewResponse of(UnivApplyInfo univApplyInfo, String termName) {


### PR DESCRIPTION
## 관련 이슈
- `UnivApplyInfo` 도메인과 admin 생성/수정 요청에서는 `studentCapacity`가 nullable한 `Integer`로 정의되어 있습니다.
- 엔티티에도 `studentCapacity`에 `nullable = false` 제약이 없어 DB 저장 시 null이 허용되는 구조입니다.
- 하지만 public 조회 응답 DTO에서는 primitive `int`로 정의되어 있어, 모집 인원이 없는 데이터 조회 시 언박싱 과정에서 `NullPointerException`이 발생했습니다.
- 모집 인원이 아직 미정인 학교도 우선 데이터를 등록한 뒤 추후 admin에서 수정하는 방식으로 운영할 예정이므로, 응답 DTO도 `Integer`로 타입을 통일하는 것이 적절하다고 판단했습니다.

## 작업 내용
- 지원 가능 대학 응답 DTO의 `studentCapacity` 타입을 `int`에서 `Integer`로 변경했습니다.
- 모집 인원이 `null`인 지원 가능 대학 조회 시 `NullPointerException`이 발생하던 문제를 수정했습니다.