### PR TITLE
fix: GPA 상태 조회에 모학교명 반환

### DIFF
--- a/src/main/java/com/example/solidconnection/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/solidconnection/common/exception/ErrorCode.java
@@ -88,6 +88,7 @@ public enum ErrorCode {
     SCHOOL_EMAIL_CONFIRM_CODE_DIFFERENT(HttpStatus.BAD_REQUEST.value(), "인증 코드가 일치하지 않습니다."),
     SCHOOL_EMAIL_VERIFICATION_INFO_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR.value(), "학교 이메일 인증 정보 저장에 실패했습니다."),
     SCHOOL_EMAIL_VERIFICATION_INFO_CORRUPTED(HttpStatus.INTERNAL_SERVER_ERROR.value(), "학교 이메일 인증 정보가 손상되었습니다. 인증 코드 발송을 다시 요청해주세요."),
+    SCHOOL_EMAIL_NOT_VERIFIED(HttpStatus.BAD_REQUEST.value(), "학교 이메일 인증이 필요합니다."),
 
     // s3
     S3_SERVICE_EXCEPTION(HttpStatus.BAD_REQUEST.value(), "S3 서비스 에러 발생"),

--- a/src/main/java/com/example/solidconnection/score/dto/GpaScoreStatusesResponse.java
+++ b/src/main/java/com/example/solidconnection/score/dto/GpaScoreStatusesResponse.java
@@ -3,10 +3,14 @@ package com.example.solidconnection.score.dto;
 import java.util.List;
 
 public record GpaScoreStatusesResponse(
+        String homeUniversityName,
         List<GpaScoreStatusResponse> gpaScoreStatusResponseList
 ) {
 
-    public static GpaScoreStatusesResponse from(List<GpaScoreStatusResponse> gpaScoreStatusResponseList) {
-        return new GpaScoreStatusesResponse(gpaScoreStatusResponseList);
+    public static GpaScoreStatusesResponse of(
+            String homeUniversityName,
+            List<GpaScoreStatusResponse> gpaScoreStatusResponseList
+    ) {
+        return new GpaScoreStatusesResponse(homeUniversityName, gpaScoreStatusResponseList);
     }
 }

--- a/src/main/java/com/example/solidconnection/score/service/ScoreService.java
+++ b/src/main/java/com/example/solidconnection/score/service/ScoreService.java
@@ -1,6 +1,5 @@
 package com.example.solidconnection.score.service;
 
-import static com.example.solidconnection.common.exception.ErrorCode.UNIVERSITY_NOT_FOUND;
 import static com.example.solidconnection.common.exception.ErrorCode.USER_NOT_FOUND;
 
 import com.example.solidconnection.application.domain.Gpa;
@@ -21,8 +20,7 @@ import com.example.solidconnection.score.repository.GpaScoreRepository;
 import com.example.solidconnection.score.repository.LanguageTestScoreRepository;
 import com.example.solidconnection.siteuser.domain.SiteUser;
 import com.example.solidconnection.siteuser.repository.SiteUserRepository;
-import com.example.solidconnection.university.domain.HomeUniversity;
-import com.example.solidconnection.university.repository.HomeUniversityRepository;
+import com.example.solidconnection.university.service.HomeUniversityQueryService;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -38,7 +36,7 @@ public class ScoreService {
     private final S3Service s3Service;
     private final LanguageTestScoreRepository languageTestScoreRepository;
     private final SiteUserRepository siteUserRepository;
-    private final HomeUniversityRepository homeUniversityRepository;
+    private final HomeUniversityQueryService homeUniversityQueryService;
 
     @Transactional
     public Long submitGpaScore(long siteUserId, GpaScoreRequest gpaScoreRequest, MultipartFile file) {
@@ -67,7 +65,7 @@ public class ScoreService {
     public GpaScoreStatusesResponse getGpaScoreStatus(long siteUserId) {
         SiteUser siteUser = siteUserRepository.findById(siteUserId)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
-        String homeUniversityName = findHomeUniversityName(siteUser);
+        String homeUniversityName = homeUniversityQueryService.findNameByRequiredId(siteUser.getHomeUniversityId());
         List<GpaScoreStatusResponse> gpaScoreStatusResponseList =
                 gpaScoreRepository.findBySiteUserId(siteUser.getId())
                         .stream()
@@ -75,17 +73,6 @@ public class ScoreService {
                         .toList();
 
         return GpaScoreStatusesResponse.of(homeUniversityName, gpaScoreStatusResponseList);
-    }
-
-    private String findHomeUniversityName(SiteUser siteUser) {
-        Long homeUniversityId = siteUser.getHomeUniversityId();
-        if (homeUniversityId == null) {
-            return null;
-        }
-
-        HomeUniversity homeUniversity = homeUniversityRepository.findById(homeUniversityId)
-                .orElseThrow(() -> new CustomException(UNIVERSITY_NOT_FOUND));
-        return homeUniversity.getName();
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/example/solidconnection/score/service/ScoreService.java
+++ b/src/main/java/com/example/solidconnection/score/service/ScoreService.java
@@ -1,5 +1,6 @@
 package com.example.solidconnection.score.service;
 
+import static com.example.solidconnection.common.exception.ErrorCode.UNIVERSITY_NOT_FOUND;
 import static com.example.solidconnection.common.exception.ErrorCode.USER_NOT_FOUND;
 
 import com.example.solidconnection.application.domain.Gpa;
@@ -20,6 +21,8 @@ import com.example.solidconnection.score.repository.GpaScoreRepository;
 import com.example.solidconnection.score.repository.LanguageTestScoreRepository;
 import com.example.solidconnection.siteuser.domain.SiteUser;
 import com.example.solidconnection.siteuser.repository.SiteUserRepository;
+import com.example.solidconnection.university.domain.HomeUniversity;
+import com.example.solidconnection.university.repository.HomeUniversityRepository;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -35,6 +38,7 @@ public class ScoreService {
     private final S3Service s3Service;
     private final LanguageTestScoreRepository languageTestScoreRepository;
     private final SiteUserRepository siteUserRepository;
+    private final HomeUniversityRepository homeUniversityRepository;
 
     @Transactional
     public Long submitGpaScore(long siteUserId, GpaScoreRequest gpaScoreRequest, MultipartFile file) {
@@ -63,13 +67,25 @@ public class ScoreService {
     public GpaScoreStatusesResponse getGpaScoreStatus(long siteUserId) {
         SiteUser siteUser = siteUserRepository.findById(siteUserId)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+        String homeUniversityName = findHomeUniversityName(siteUser);
         List<GpaScoreStatusResponse> gpaScoreStatusResponseList =
                 gpaScoreRepository.findBySiteUserId(siteUser.getId())
                         .stream()
                         .map(GpaScoreStatusResponse::from)
                         .toList();
 
-        return GpaScoreStatusesResponse.from(gpaScoreStatusResponseList);
+        return GpaScoreStatusesResponse.of(homeUniversityName, gpaScoreStatusResponseList);
+    }
+
+    private String findHomeUniversityName(SiteUser siteUser) {
+        Long homeUniversityId = siteUser.getHomeUniversityId();
+        if (homeUniversityId == null) {
+            return null;
+        }
+
+        HomeUniversity homeUniversity = homeUniversityRepository.findById(homeUniversityId)
+                .orElseThrow(() -> new CustomException(UNIVERSITY_NOT_FOUND));
+        return homeUniversity.getName();
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/example/solidconnection/siteuser/service/MyPageService.java
+++ b/src/main/java/com/example/solidconnection/siteuser/service/MyPageService.java
@@ -25,10 +25,9 @@ import com.example.solidconnection.siteuser.dto.MyPageResponse;
 import com.example.solidconnection.siteuser.dto.PasswordUpdateRequest;
 import com.example.solidconnection.siteuser.repository.SiteUserRepository;
 import com.example.solidconnection.university.domain.HostUniversity;
-import com.example.solidconnection.university.domain.HomeUniversity;
 import com.example.solidconnection.university.repository.HostUniversityRepository;
-import com.example.solidconnection.university.repository.HomeUniversityRepository;
 import com.example.solidconnection.university.repository.LikedUnivApplyInfoRepository;
+import com.example.solidconnection.university.service.HomeUniversityQueryService;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
@@ -51,7 +50,7 @@ public class MyPageService {
     private final CountryRepository countryRepository;
     private final MentorRepository mentorRepository;
     private final HostUniversityRepository hostUniversityRepository;
-    private final HomeUniversityRepository homeUniversityRepository;
+    private final HomeUniversityQueryService homeUniversityQueryService;
     private final S3Service s3Service;
     private final InterestedCountryService interestedCountryService;
     private final InterestedRegionService interestedRegionService;
@@ -67,7 +66,7 @@ public class MyPageService {
 
         List<String> interestedCountries = null;
         String universityKoreanName = null;
-        String homeUniversityName = findHomeUniversityName(siteUser);
+        String homeUniversityName = homeUniversityQueryService.findNameByNullableId(siteUser.getHomeUniversityId());
         if (siteUser.getRole() == Role.MENTEE) {
             interestedCountries = countryRepository.findKoreanNamesBySiteUserId(siteUser.getId());
         } else if (siteUser.getRole() == Role.MENTOR) {
@@ -84,17 +83,6 @@ public class MyPageService {
                 universityKoreanName,
                 homeUniversityName
         );
-    }
-
-    private String findHomeUniversityName(SiteUser siteUser) {
-        Long homeUniversityId = siteUser.getHomeUniversityId();
-        if (homeUniversityId == null) {
-            return null;
-        }
-
-        HomeUniversity homeUniversity = homeUniversityRepository.findById(homeUniversityId)
-                .orElseThrow(() -> new CustomException(UNIVERSITY_NOT_FOUND));
-        return homeUniversity.getName();
     }
 
     /*

--- a/src/main/java/com/example/solidconnection/university/service/HomeUniversityQueryService.java
+++ b/src/main/java/com/example/solidconnection/university/service/HomeUniversityQueryService.java
@@ -1,0 +1,42 @@
+package com.example.solidconnection.university.service;
+
+import static com.example.solidconnection.common.exception.ErrorCode.SCHOOL_EMAIL_NOT_VERIFIED;
+import static com.example.solidconnection.common.exception.ErrorCode.UNIVERSITY_NOT_FOUND;
+
+import com.example.solidconnection.common.exception.CustomException;
+import com.example.solidconnection.university.domain.HomeUniversity;
+import com.example.solidconnection.university.repository.HomeUniversityRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class HomeUniversityQueryService {
+
+    private final HomeUniversityRepository homeUniversityRepository;
+
+    @Transactional(readOnly = true)
+    public String findNameByNullableId(Long homeUniversityId) {
+        if (homeUniversityId == null) {
+            return null;
+        }
+
+        return findNameById(homeUniversityId);
+    }
+
+    @Transactional(readOnly = true)
+    public String findNameByRequiredId(Long homeUniversityId) {
+        if (homeUniversityId == null) {
+            throw new CustomException(SCHOOL_EMAIL_NOT_VERIFIED);
+        }
+
+        return findNameById(homeUniversityId);
+    }
+
+    private String findNameById(Long homeUniversityId) {
+        HomeUniversity homeUniversity = homeUniversityRepository.findById(homeUniversityId)
+                .orElseThrow(() -> new CustomException(UNIVERSITY_NOT_FOUND));
+        return homeUniversity.getName();
+    }
+}

--- a/src/test/java/com/example/solidconnection/score/service/ScoreServiceTest.java
+++ b/src/test/java/com/example/solidconnection/score/service/ScoreServiceTest.java
@@ -20,7 +20,9 @@ import com.example.solidconnection.score.repository.LanguageTestScoreRepository;
 import com.example.solidconnection.siteuser.domain.SiteUser;
 import com.example.solidconnection.siteuser.fixture.SiteUserFixture;
 import com.example.solidconnection.support.TestContainerSpringBootTest;
+import com.example.solidconnection.university.domain.HomeUniversity;
 import com.example.solidconnection.university.domain.LanguageTestType;
+import com.example.solidconnection.university.fixture.HomeUniversityFixture;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -54,6 +56,9 @@ class ScoreServiceTest {
     @Autowired
     private LanguageTestScoreFixture languageTestScoreFixture;
 
+    @Autowired
+    private HomeUniversityFixture homeUniversityFixture;
+
     private SiteUser user;
 
     @BeforeEach
@@ -77,12 +82,34 @@ class ScoreServiceTest {
     }
 
     @Test
+    void GPA_점수_상태를_조회할_때_사용자의_모학교명을_반환한다() {
+        // given
+        HomeUniversity homeUniversity = homeUniversityFixture.인하대학교();
+        user = siteUserFixture.국내_대학_정보_소지_사용자(homeUniversity.getId());
+
+        // when
+        GpaScoreStatusesResponse response = scoreService.getGpaScoreStatus(user.getId());
+
+        // then
+        assertThat(response.homeUniversityName()).isEqualTo(homeUniversity.getName());
+    }
+
+    @Test
     void GPA_점수가_없는_경우_빈_리스트를_반환한다() {
         // when
         GpaScoreStatusesResponse response = scoreService.getGpaScoreStatus(user.getId());
 
         // then
         assertThat(response.gpaScoreStatusResponseList()).isEmpty();
+    }
+
+    @Test
+    void 모학교가_없는_사용자의_GPA_점수_상태를_조회하면_모학교명은_null이다() {
+        // when
+        GpaScoreStatusesResponse response = scoreService.getGpaScoreStatus(user.getId());
+
+        // then
+        assertThat(response.homeUniversityName()).isNull();
     }
 
     @Test

--- a/src/test/java/com/example/solidconnection/score/service/ScoreServiceTest.java
+++ b/src/test/java/com/example/solidconnection/score/service/ScoreServiceTest.java
@@ -1,9 +1,11 @@
 package com.example.solidconnection.score.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 
 import com.example.solidconnection.common.VerifyStatus;
+import com.example.solidconnection.common.exception.ErrorCode;
 import com.example.solidconnection.s3.domain.UploadPath;
 import com.example.solidconnection.s3.dto.UploadedFileUrlResponse;
 import com.example.solidconnection.s3.service.S3Service;
@@ -59,11 +61,13 @@ class ScoreServiceTest {
     @Autowired
     private HomeUniversityFixture homeUniversityFixture;
 
+    private HomeUniversity homeUniversity;
     private SiteUser user;
 
     @BeforeEach
     void setUp() {
-        user = siteUserFixture.사용자();
+        homeUniversity = homeUniversityFixture.인하대학교();
+        user = siteUserFixture.국내_대학_정보_소지_사용자(homeUniversity.getId());
     }
 
     @Test
@@ -83,10 +87,6 @@ class ScoreServiceTest {
 
     @Test
     void GPA_점수_상태를_조회할_때_사용자의_모학교명을_반환한다() {
-        // given
-        HomeUniversity homeUniversity = homeUniversityFixture.인하대학교();
-        user = siteUserFixture.국내_대학_정보_소지_사용자(homeUniversity.getId());
-
         // when
         GpaScoreStatusesResponse response = scoreService.getGpaScoreStatus(user.getId());
 
@@ -104,12 +104,14 @@ class ScoreServiceTest {
     }
 
     @Test
-    void 모학교가_없는_사용자의_GPA_점수_상태를_조회하면_모학교명은_null이다() {
-        // when
-        GpaScoreStatusesResponse response = scoreService.getGpaScoreStatus(user.getId());
+    void 모학교가_없는_사용자의_GPA_점수_상태를_조회하면_예외가_발생한다() {
+        // given
+        user = siteUserFixture.사용자();
 
+        // when
         // then
-        assertThat(response.homeUniversityName()).isNull();
+        assertThatThrownBy(() -> scoreService.getGpaScoreStatus(user.getId()))
+                .hasMessage(ErrorCode.SCHOOL_EMAIL_NOT_VERIFIED.getMessage());
     }
 
     @Test


### PR DESCRIPTION
﻿## 관련 이슈

- resolves: #797

## 작업 내용

- GPA 점수 상태 조회 응답에 사용자의 모학교명(`homeUniversityName`)을 추가했습니다.
- 사용자의 `homeUniversityId`가 존재하는 경우 `HomeUniversity`를 조회해 모학교명을 응답에 포함하도록 수정했습니다.
- 사용자의 모학교 정보가 없는 경우 기존 GPA 상태 조회는 유지하면서 `homeUniversityName`을 `null`로 반환하도록 처리했습니다.
- GPA 상태 조회 테스트를 검증 목적별로 분리했습니다.
  - GPA 점수 상태 목록 조회 검증
  - 모학교명이 응답에 포함되는지 검증
  - 모학교가 없는 사용자는 모학교명이 `null`인지 검증

## 특이 사항

- 기존 GPA 점수 상태 목록 응답 구조에 `homeUniversityName` 필드가 추가되므로, 프론트엔드에서 해당 필드를 사용할 수 있습니다.
- `homeUniversityId`가 저장되어 있는데 실제 모학교 데이터가 존재하지 않는 경우에는 기존 예외 정책에 맞춰 `UNIVERSITY_NOT_FOUND` 예외가 발생합니다.
- 검증 결과
  - `./gradlew compileTestJava` 통과
  - `./gradlew test --tests "com.example.solidconnection.score.service.ScoreServiceTest"`는 Docker/Testcontainers 환경을 찾지 못해 실행 실패

## 리뷰 요구사항 (선택)

- `getGpaScoreStatus`에서 GPA 상태 목록 조회와 모학교명 조회를 함께 수행하는 흐름이 API 응답 요구사항에 적절한지 확인 부탁드립니다.
- 모학교가 없는 사용자의 `homeUniversityName = null` 처리 방식이 프론트엔드 기대값과 맞는지 확인 부탁드립니다.
