### PR TITLE
fix: 공통 추천 목록의 오래된 인메모리 캐시 제거

### DIFF
--- a/src/main/java/com/example/solidconnection/university/service/GeneralUnivApplyInfoRecommendService.java
+++ b/src/main/java/com/example/solidconnection/university/service/GeneralUnivApplyInfoRecommendService.java
@@ -27,7 +27,7 @@ public class GeneralUnivApplyInfoRecommendService {
 
     @Transactional(readOnly = true)
     @ThunderingHerdCaching(
-            key = "university:recommend:general:{0}",
+            key = "university:recommend:general:{0}:{1}",
             cacheManager = "customCacheManager",
             ttlSec = GENERAL_RECOMMEND_CACHE_TTL_SEC
     )

--- a/src/main/java/com/example/solidconnection/university/service/GeneralUnivApplyInfoRecommendService.java
+++ b/src/main/java/com/example/solidconnection/university/service/GeneralUnivApplyInfoRecommendService.java
@@ -2,36 +2,41 @@ package com.example.solidconnection.university.service;
 
 import static com.example.solidconnection.university.service.UnivApplyInfoRecommendService.RECOMMEND_UNIV_APPLY_INFO_NUM;
 
-import com.example.solidconnection.term.repository.TermRepository;
+import com.example.solidconnection.cache.annotation.ThunderingHerdCaching;
 import com.example.solidconnection.university.domain.UnivApplyInfo;
+import com.example.solidconnection.university.dto.UnivApplyInfoPreviewResponse;
+import com.example.solidconnection.university.dto.UnivApplyInfoRecommendsResponse;
 import com.example.solidconnection.university.repository.UnivApplyInfoRepository;
 import java.util.List;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.boot.context.event.ApplicationReadyEvent;
-import org.springframework.context.event.EventListener;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class GeneralUnivApplyInfoRecommendService {
 
+    private static final long GENERAL_RECOMMEND_CACHE_TTL_SEC = 3600;
+
     /*
      * 해당 시기에 열리는 대학교들 중 랜덤으로 선택해서 목록을 구성한다.
      * */
     private final UnivApplyInfoRepository univApplyInfoRepository;
-    private final TermRepository termRepository;
 
-    @Getter
-    private List<UnivApplyInfo> generalRecommends;
+    @Transactional(readOnly = true)
+    @ThunderingHerdCaching(
+            key = "university:recommend:general:{0}",
+            cacheManager = "customCacheManager",
+            ttlSec = GENERAL_RECOMMEND_CACHE_TTL_SEC
+    )
+    public UnivApplyInfoRecommendsResponse getGeneralRecommends(long termId, String termName) {
+        Pageable page = PageRequest.of(0, RECOMMEND_UNIV_APPLY_INFO_NUM);
+        List<UnivApplyInfo> generalRecommends = univApplyInfoRepository.findRandomByTermId(termId, page);
 
-    @EventListener(ApplicationReadyEvent.class)
-    public void init() {
-        termRepository.findByIsCurrentTrue().ifPresent(term -> {
-            Pageable page = PageRequest.of(0, RECOMMEND_UNIV_APPLY_INFO_NUM);
-            generalRecommends = univApplyInfoRepository.findRandomByTermId(term.getId(), page);
-        });
+        return new UnivApplyInfoRecommendsResponse(generalRecommends.stream()
+                                                           .map(univApplyInfo -> UnivApplyInfoPreviewResponse.of(univApplyInfo, termName))
+                                                           .toList());
     }
 }

--- a/src/main/java/com/example/solidconnection/university/service/UnivApplyInfoRecommendService.java
+++ b/src/main/java/com/example/solidconnection/university/service/UnivApplyInfoRecommendService.java
@@ -2,7 +2,6 @@ package com.example.solidconnection.university.service;
 
 import static com.example.solidconnection.common.exception.ErrorCode.CURRENT_TERM_NOT_FOUND;
 
-import com.example.solidconnection.cache.annotation.ThunderingHerdCaching;
 import com.example.solidconnection.common.exception.CustomException;
 import com.example.solidconnection.term.domain.Term;
 import com.example.solidconnection.term.repository.TermRepository;
@@ -47,7 +46,7 @@ public class UnivApplyInfoRecommendService {
 
         // 맞춤 추천 대학교의 수가 6개보다 적다면, 일반 추천 대학교를 부족한 수 만큼 불러온다.
         if (trimmedRecommends.size() < RECOMMEND_UNIV_APPLY_INFO_NUM) {
-            trimmedRecommends.addAll(getGeneralRecommendsExcludingSelected(trimmedRecommends));
+            return new UnivApplyInfoRecommendsResponse(getPersonalRecommendPreviewsWithGeneralFallback(trimmedRecommends, term));
         }
 
         return new UnivApplyInfoRecommendsResponse(trimmedRecommends.stream()
@@ -55,9 +54,29 @@ public class UnivApplyInfoRecommendService {
                                                            .toList());
     }
 
-    private List<UnivApplyInfo> getGeneralRecommendsExcludingSelected(List<UnivApplyInfo> alreadyPicked) {
-        List<UnivApplyInfo> generalRecommend = new ArrayList<>(generalUnivApplyInfoRecommendService.getGeneralRecommends());
-        generalRecommend.removeAll(alreadyPicked);
+    private List<UnivApplyInfoPreviewResponse> getPersonalRecommendPreviewsWithGeneralFallback(
+            List<UnivApplyInfo> personalRecommends,
+            Term term
+    ) {
+        List<UnivApplyInfoPreviewResponse> recommendPreviews = new ArrayList<>(personalRecommends.stream()
+                .map(univApplyInfo -> UnivApplyInfoPreviewResponse.of(univApplyInfo, term.getName()))
+                .toList());
+        recommendPreviews.addAll(getGeneralRecommendsExcludingSelected(personalRecommends, term));
+
+        return recommendPreviews;
+    }
+
+    private List<UnivApplyInfoPreviewResponse> getGeneralRecommendsExcludingSelected(
+            List<UnivApplyInfo> alreadyPicked,
+            Term term
+    ) {
+        List<Long> alreadyPickedIds = alreadyPicked.stream()
+                .map(UnivApplyInfo::getId)
+                .toList();
+        List<UnivApplyInfoPreviewResponse> generalRecommend = new ArrayList<>(generalUnivApplyInfoRecommendService
+                .getGeneralRecommends(term.getId(), term.getName())
+                .recommendedUniversities());
+        generalRecommend.removeIf(univApplyInfo -> alreadyPickedIds.contains(univApplyInfo.id()));
         Collections.shuffle(generalRecommend);
         int needed = RECOMMEND_UNIV_APPLY_INFO_NUM - alreadyPicked.size();
         return generalRecommend.subList(0, Math.min(needed, generalRecommend.size()));
@@ -67,15 +86,10 @@ public class UnivApplyInfoRecommendService {
      * 공통 추천 대학교를 불러온다.
      * */
     @Transactional(readOnly = true)
-    @ThunderingHerdCaching(key = "university:recommend:general", cacheManager = "customCacheManager", ttlSec = 86400)
     public UnivApplyInfoRecommendsResponse getGeneralRecommends() {
         Term term = termRepository.findByIsCurrentTrue()
                 .orElseThrow(() -> new CustomException(CURRENT_TERM_NOT_FOUND));
 
-        List<UnivApplyInfo> generalRecommends = new ArrayList<>(generalUnivApplyInfoRecommendService.getGeneralRecommends());
-
-        return new UnivApplyInfoRecommendsResponse(generalRecommends.stream()
-                                                           .map(univApplyInfo -> UnivApplyInfoPreviewResponse.of(univApplyInfo, term.getName()))
-                                                           .toList());
+        return generalUnivApplyInfoRecommendService.getGeneralRecommends(term.getId(), term.getName());
     }
 }

--- a/src/test/java/com/example/solidconnection/university/service/GeneralUnivApplyInfoRecommendServiceTest.java
+++ b/src/test/java/com/example/solidconnection/university/service/GeneralUnivApplyInfoRecommendServiceTest.java
@@ -44,6 +44,7 @@ class GeneralUnivApplyInfoRecommendServiceTest {
     @BeforeEach
     void setUp() {
         term = termFixture.현재_학기("2025-2");
+        cacheManager.evictUsingPrefix("university:recommend:general:" + term.getId());
 
         currentTermUnivApplyInfos = List.of(
                 univApplyInfoFixture.괌대학_A_지원_정보(term.getId()),
@@ -92,7 +93,7 @@ class GeneralUnivApplyInfoRecommendServiceTest {
                 term.getId(),
                 term.getName()
         );
-        cacheManager.evict("university:recommend:general:" + term.getId());
+        cacheManager.evictUsingPrefix("university:recommend:general:" + term.getId());
         UnivApplyInfoRecommendsResponse responseAfterCacheEvict = generalUnivApplyInfoRecommendService.getGeneralRecommends(
                 term.getId(),
                 term.getName()

--- a/src/test/java/com/example/solidconnection/university/service/GeneralUnivApplyInfoRecommendServiceTest.java
+++ b/src/test/java/com/example/solidconnection/university/service/GeneralUnivApplyInfoRecommendServiceTest.java
@@ -4,11 +4,15 @@ import static com.example.solidconnection.university.service.UnivApplyInfoRecomm
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.example.solidconnection.cache.manager.CustomCacheManager;
 import com.example.solidconnection.support.TestContainerSpringBootTest;
 import com.example.solidconnection.term.domain.Term;
 import com.example.solidconnection.term.fixture.TermFixture;
 import com.example.solidconnection.university.domain.UnivApplyInfo;
+import com.example.solidconnection.university.dto.UnivApplyInfoPreviewResponse;
+import com.example.solidconnection.university.dto.UnivApplyInfoRecommendsResponse;
 import com.example.solidconnection.university.fixture.UnivApplyInfoFixture;
+import com.example.solidconnection.university.repository.UnivApplyInfoRepository;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -26,38 +30,88 @@ class GeneralUnivApplyInfoRecommendServiceTest {
     private UnivApplyInfoFixture univApplyInfoFixture;
 
     @Autowired
+    private UnivApplyInfoRepository univApplyInfoRepository;
+
+    @Autowired
+    private CustomCacheManager cacheManager;
+
+    @Autowired
     private TermFixture termFixture;
 
     private Term term;
+    private List<UnivApplyInfo> currentTermUnivApplyInfos;
 
     @BeforeEach
     void setUp() {
         term = termFixture.현재_학기("2025-2");
 
-        univApplyInfoFixture.괌대학_A_지원_정보(term.getId());
-        univApplyInfoFixture.버지니아공과대학_지원_정보(term.getId());
-        univApplyInfoFixture.네바다주립대학_라스베이거스_지원_정보(term.getId());
-        univApplyInfoFixture.메모리얼대학_세인트존스_A_지원_정보(term.getId());
-        univApplyInfoFixture.서던덴마크대학교_지원_정보(term.getId());
-        univApplyInfoFixture.코펜하겐IT대학_지원_정보(term.getId());
-        univApplyInfoFixture.그라츠대학_지원_정보(term.getId());
-        univApplyInfoFixture.그라츠공과대학_지원_정보(term.getId());
-        univApplyInfoFixture.린츠_카톨릭대학_지원_정보(term.getId());
-        univApplyInfoFixture.메이지대학_지원_정보(term.getId());
-        generalUnivApplyInfoRecommendService.init();
+        currentTermUnivApplyInfos = List.of(
+                univApplyInfoFixture.괌대학_A_지원_정보(term.getId()),
+                univApplyInfoFixture.버지니아공과대학_지원_정보(term.getId()),
+                univApplyInfoFixture.네바다주립대학_라스베이거스_지원_정보(term.getId()),
+                univApplyInfoFixture.메모리얼대학_세인트존스_A_지원_정보(term.getId()),
+                univApplyInfoFixture.서던덴마크대학교_지원_정보(term.getId()),
+                univApplyInfoFixture.코펜하겐IT대학_지원_정보(term.getId())
+        );
     }
 
     @Test
     void 모집_시기의_대학_지원_정보_중에서_랜덤하게_N개를_추천_목록으로_구성한다() {
-        // given
-        List<UnivApplyInfo> universities = generalUnivApplyInfoRecommendService.getGeneralRecommends();
+        // when
+        UnivApplyInfoRecommendsResponse response = generalUnivApplyInfoRecommendService.getGeneralRecommends(
+                term.getId(),
+                term.getName()
+        );
+        List<Long> currentTermUnivApplyInfoIds = currentTermUnivApplyInfos.stream()
+                .map(UnivApplyInfo::getId)
+                .toList();
 
-        // when & then
+        // then
         assertAll(
-                () -> assertThat(universities)
-                        .extracting("termId")
-                        .allMatch(term.getId()::equals),
-                () -> assertThat(universities).hasSize(RECOMMEND_UNIV_APPLY_INFO_NUM)
+                () -> assertThat(response.recommendedUniversities()).hasSize(RECOMMEND_UNIV_APPLY_INFO_NUM),
+                () -> assertThat(response.recommendedUniversities())
+                        .extracting(UnivApplyInfoPreviewResponse::id)
+                        .isSubsetOf(currentTermUnivApplyInfoIds)
+        );
+    }
+
+    @Test
+    void 캐시를_삭제하면_서버_재기동_없이_DB_기준으로_추천_목록을_다시_구성한다() {
+        // given
+        UnivApplyInfo deletedUnivApplyInfo = currentTermUnivApplyInfos.get(0);
+        UnivApplyInfoRecommendsResponse cachedResponse = generalUnivApplyInfoRecommendService.getGeneralRecommends(
+                term.getId(),
+                term.getName()
+        );
+
+        univApplyInfoRepository.delete(deletedUnivApplyInfo);
+        UnivApplyInfo addedUnivApplyInfo = univApplyInfoFixture.그라츠대학_지원_정보(term.getId());
+
+        // when
+        UnivApplyInfoRecommendsResponse responseBeforeCacheEvict = generalUnivApplyInfoRecommendService.getGeneralRecommends(
+                term.getId(),
+                term.getName()
+        );
+        cacheManager.evict("university:recommend:general:" + term.getId());
+        UnivApplyInfoRecommendsResponse responseAfterCacheEvict = generalUnivApplyInfoRecommendService.getGeneralRecommends(
+                term.getId(),
+                term.getName()
+        );
+
+        // then
+        assertAll(
+                () -> assertThat(cachedResponse.recommendedUniversities())
+                        .extracting(UnivApplyInfoPreviewResponse::id)
+                        .contains(deletedUnivApplyInfo.getId()),
+                () -> assertThat(responseBeforeCacheEvict.recommendedUniversities())
+                        .extracting(UnivApplyInfoPreviewResponse::id)
+                        .contains(deletedUnivApplyInfo.getId())
+                        .doesNotContain(addedUnivApplyInfo.getId()),
+                () -> assertThat(responseAfterCacheEvict.recommendedUniversities())
+                        .hasSize(RECOMMEND_UNIV_APPLY_INFO_NUM)
+                        .extracting(UnivApplyInfoPreviewResponse::id)
+                        .contains(addedUnivApplyInfo.getId())
+                        .doesNotContain(deletedUnivApplyInfo.getId())
         );
     }
 }

--- a/src/test/java/com/example/solidconnection/university/service/UnivApplyInfoRecommendServiceTest.java
+++ b/src/test/java/com/example/solidconnection/university/service/UnivApplyInfoRecommendServiceTest.java
@@ -78,7 +78,6 @@ class UnivApplyInfoRecommendServiceTest {
         univApplyInfoFixture.그라츠공과대학_지원_정보(term.getId());
         univApplyInfoFixture.린츠_카톨릭대학_지원_정보(term.getId());
         univApplyInfoFixture.메이지대학_지원_정보(term.getId());
-        generalUnivApplyInfoRecommendService.init();
     }
 
     @Test
@@ -148,9 +147,8 @@ class UnivApplyInfoRecommendServiceTest {
         assertThat(response.recommendedUniversities())
                 .hasSize(RECOMMEND_UNIV_APPLY_INFO_NUM)
                 .containsExactlyInAnyOrderElementsOf(
-                        generalUnivApplyInfoRecommendService.getGeneralRecommends().stream()
-                                .map(univApplyInfo -> UnivApplyInfoPreviewResponse.of(univApplyInfo, term.getName()))
-                                .toList()
+                        generalUnivApplyInfoRecommendService.getGeneralRecommends(term.getId(), term.getName())
+                                .recommendedUniversities()
                 );
     }
 
@@ -163,9 +161,8 @@ class UnivApplyInfoRecommendServiceTest {
         assertThat(response.recommendedUniversities())
                 .hasSize(RECOMMEND_UNIV_APPLY_INFO_NUM)
                 .containsExactlyInAnyOrderElementsOf(
-                        generalUnivApplyInfoRecommendService.getGeneralRecommends().stream()
-                                .map(univApplyInfo -> UnivApplyInfoPreviewResponse.of(univApplyInfo, term.getName()))
-                                .toList()
+                        generalUnivApplyInfoRecommendService.getGeneralRecommends(term.getId(), term.getName())
+                                .recommendedUniversities()
                 );
     }
 }


### PR DESCRIPTION

## 관련 이슈

- resolves: #798

## 작업 내용

- `GeneralUnivApplyInfoRecommendService`에서 서버 기동 시점에 공통 추천 목록을 저장하던 `generalRecommends` 인메모리 캐시를 제거했습니다.
- 공통 추천 목록은 Redis 캐시만 사용하도록 변경했습니다.
  - Redis cache hit: 캐시된 추천 응답 반환
  - Redis cache miss: 현재 DB의 `termId` 기준으로 추천 목록 조회 후 Redis에 저장하고 반환
- 공통 추천 Redis key에 `termId`를 포함했습니다.
  - `university:recommend:general:{termId}`
- 공통 추천 TTL을 `86400초`에서 `3600초`로 낮췄습니다.
- 개인 추천 부족분을 채울 때도 새 공통 추천 캐시 흐름을 사용하도록 수정했습니다.
- Redis 캐시 삭제 후 서버 재시작 없이 DB 기준으로 추천 목록이 재생성되는 회귀 테스트를 추가했습니다.

## 특이 사항

이번 변경 방식을 선택한 이유는 캐시의 출처를 Redis 하나로 단순화하기 위해서입니다.

기존 방식은 서버 기동 시점에 생성한 `generalRecommends` 인메모리 객체와 Redis 캐시를 함께 사용했습니다. 이 구조에서는 잘못된 추천 응답이 Redis에 저장된 경우 `DEL university:recommend:general`로 Redis 값을 삭제해도, 서버 메모리에 남아 있는 오래된 `generalRecommends`가 같은 값을 다시 Redis에 저장했습니다. 그래서 잘못된 캐싱을 운영에서 해소하려면 결국 서버 재시작이 필요하다는 단점이 있었습니다.

이번 변경으로 Redis 캐시가 비워졌을 때 현재 DB 기준으로 추천 목록이 다시 만들어지므로, 데이터 정합성 문제가 생겼을 때 서버 재시작 없이 캐시 삭제만으로 복구할 수 있습니다.

기존 어드민 캐시 무효화는 `university:recommend:general` prefix 기반이라, 새 key인 `university:recommend:general:{termId}`도 함께 무효화됩니다.

테스트:

```bash
bash ./gradlew test --tests GeneralUnivApplyInfoRecommendServiceTest --tests UnivApplyInfoRecommendServiceTest
```

## 리뷰 요구사항 (선택)

- 공통 추천 TTL을 `3600초`로 낮춘 것이 적절한지 확인 부탁드립니다.
  - `ORDER BY RAND()` 비용을 고려하면 너무 짧은 TTL은 부담이 될 수 있습니다.
  - 반대로 기존 `86400초`는 잘못된 추천 데이터가 오래 유지될 수 있어 운영 복구 관점에서 길다고 판단했습니다.
  - 현재는 추천 목록이 완전 실시간일 필요는 없지만, 데이터 import/update 이후 stale cache가 하루 유지되는 것은 피하고자 1시간으로 조정했습니다.
- `termId`를 캐시 key에 포함한 방식이 현재 term 변경 시나리오에 충분한지도 함께 봐주시면 좋겠습니다.
