### PR TITLE
refactor: ThunderingHerdCaching의 만료 임박 캐시 갱신 정책 수정

### DIFF
--- a/src/main/java/com/example/solidconnection/cache/ThunderingHerdCachingAspect.java
+++ b/src/main/java/com/example/solidconnection/cache/ThunderingHerdCachingAspect.java
@@ -90,12 +90,13 @@ public class ThunderingHerdCachingAspect {
 
     private Object refreshCache(ProceedingJoinPoint joinPoint, CacheManager cacheManager, Object cachedValue, Long ttl, String key) {
         return executeWithLock(
-                redisUtils.getRefreshLockKey(key),
+                redisUtils.getCreateLockKey(key),
                 () -> {
                     log.info("갱신락 흭득하였습니다. Key: {}, Thread: {}", key, Thread.currentThread().getName());
                     try {
                         Object result = proceedJoinPoint(joinPoint);
                         cacheManager.put(key, result, ttl);
+                        redisTemplate.convertAndSend(CREATE_CHANNEL.getValue(), key);
                         log.info("캐시 갱신을 마쳤습니다. Key: {}, Thread: {}", key, Thread.currentThread().getName());
                         return result;
                     } catch (CustomException e) {

--- a/src/main/java/com/example/solidconnection/cache/ThunderingHerdCachingAspect.java
+++ b/src/main/java/com/example/solidconnection/cache/ThunderingHerdCachingAspect.java
@@ -63,7 +63,7 @@ public class ThunderingHerdCachingAspect {
 
         if (redisUtils.isCacheExpiringSoon(key, ttl, Double.valueOf(REFRESH_LIMIT_PERCENT.getValue()))) {
             log.info("Cache hit, but TTL is expiring soon. Key: {}, Thread: {}", key, Thread.currentThread().getName());
-            return refreshCache(cachedValue, ttl, key);
+            return refreshCache(joinPoint, cacheManager, cachedValue, ttl, key);
         }
 
         log.info("Cache hit. Key: {}, Thread: {}", key, Thread.currentThread().getName());
@@ -88,14 +88,23 @@ public class ThunderingHerdCachingAspect {
         );
     }
 
-    private Object refreshCache(Object cachedValue, Long ttl, String key) {
+    private Object refreshCache(ProceedingJoinPoint joinPoint, CacheManager cacheManager, Object cachedValue, Long ttl, String key) {
         return executeWithLock(
                 redisUtils.getRefreshLockKey(key),
                 () -> {
                     log.info("갱신락 흭득하였습니다. Key: {}, Thread: {}", key, Thread.currentThread().getName());
-                    redisTemplate.opsForValue().getAndExpire(key, Duration.ofSeconds(ttl));
-                    log.info("TTL 갱신을 마쳤습니다. Key: {}, Thread: {}", key, Thread.currentThread().getName());
-                    return cachedValue;
+                    try {
+                        Object result = proceedJoinPoint(joinPoint);
+                        cacheManager.put(key, result, ttl);
+                        log.info("캐시 갱신을 마쳤습니다. Key: {}, Thread: {}", key, Thread.currentThread().getName());
+                        return result;
+                    } catch (CustomException e) {
+                        throw e;
+                    } catch (RuntimeException e) {
+                        log.warn("캐시 갱신 중 오류가 발생하여 기존 캐시값을 반환합니다. Key: {}, Thread: {}",
+                                key, Thread.currentThread().getName(), e);
+                        return cachedValue;
+                    }
                 },
                 () -> {
                     log.info("갱신락 흭득에 실패하였습니다. 캐시의 값을 바로 반환합니다. Key: {}, Thread: {}", key, Thread.currentThread().getName());

--- a/src/main/java/com/example/solidconnection/util/RedisUtils.java
+++ b/src/main/java/com/example/solidconnection/util/RedisUtils.java
@@ -58,6 +58,9 @@ public class RedisUtils {
 
     public boolean isCacheExpiringSoon(String key, Long defaultTtl, Double percent) {
         Long leftTtl = redisTemplate.getExpire(key);
-        return defaultTtl != null && ((double) leftTtl / defaultTtl) * 100 < percent;
+        if (defaultTtl == null || defaultTtl <= 0 || leftTtl == null || leftTtl < 0 || percent == null) {
+            return false;
+        }
+        return ((double) leftTtl / defaultTtl) * 100 < percent;
     }
 }

--- a/src/main/java/com/example/solidconnection/util/RedisUtils.java
+++ b/src/main/java/com/example/solidconnection/util/RedisUtils.java
@@ -58,7 +58,9 @@ public class RedisUtils {
 
     public boolean isCacheExpiringSoon(String key, Long defaultTtl, Double percent) {
         Long leftTtl = redisTemplate.getExpire(key);
-        if (defaultTtl == null || defaultTtl <= 0 || leftTtl == null || leftTtl < 0 || percent == null) {
+        if (defaultTtl == null || defaultTtl <= 0
+                || leftTtl == null || leftTtl < 0
+                || percent == null || percent <= 0 || percent > 100) {
             return false;
         }
         return ((double) leftTtl / defaultTtl) * 100 < percent;

--- a/src/test/java/com/example/solidconnection/cache/ThunderingHerdCachingAspectTest.java
+++ b/src/test/java/com/example/solidconnection/cache/ThunderingHerdCachingAspectTest.java
@@ -1,0 +1,185 @@
+package com.example.solidconnection.cache;
+
+import static com.example.solidconnection.redis.RedisConstants.REFRESH_LOCK_PREFIX;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.example.solidconnection.cache.annotation.ThunderingHerdCaching;
+import com.example.solidconnection.common.exception.CustomException;
+import com.example.solidconnection.common.exception.ErrorCode;
+import com.example.solidconnection.support.TestContainerSpringBootTest;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@TestContainerSpringBootTest
+@DisplayName("ThunderingHerdCaching Aspect 테스트")
+class ThunderingHerdCachingAspectTest {
+
+    private static final String CACHE_KEY_PREFIX = "test:thundering:";
+    private static final long TEST_CACHE_TTL_SEC = 20L;
+
+    @Autowired
+    private TestCacheService testCacheService;
+
+    @Autowired
+    private RedisTemplate<String, Object> redisTemplate;
+
+    @BeforeEach
+    void setUp() {
+        testCacheService.reset();
+    }
+
+    @Test
+    void 캐시가_만료_임박하면_갱신락을_획득한_요청이_값을_다시_계산한다() {
+        // given
+        String firstValue = testCacheService.getValue("refresh");
+        redisTemplate.expire(cacheKey("refresh"), Duration.ofSeconds(1));
+
+        // when
+        String secondValue = testCacheService.getValue("refresh");
+
+        // then
+        assertAll(
+                () -> assertThat(firstValue).isEqualTo("value-1"),
+                () -> assertThat(secondValue).isEqualTo("value-2"),
+                () -> assertThat(redisTemplate.opsForValue().get(cacheKey("refresh"))).isEqualTo("value-2"),
+                () -> assertThat(testCacheService.getCallCount()).isEqualTo(2)
+        );
+    }
+
+    @Test
+    void 캐시가_만료_임박했지만_갱신락_획득에_실패하면_기존_캐시값을_반환한다() {
+        // given
+        String firstValue = testCacheService.getValue("locked");
+        redisTemplate.expire(cacheKey("locked"), Duration.ofSeconds(1));
+        redisTemplate.opsForValue().set(refreshLockKey("locked"), "lock", Duration.ofSeconds(5));
+
+        // when
+        String secondValue = testCacheService.getValue("locked");
+
+        // then
+        assertAll(
+                () -> assertThat(secondValue).isEqualTo(firstValue),
+                () -> assertThat(redisTemplate.opsForValue().get(cacheKey("locked"))).isEqualTo(firstValue),
+                () -> assertThat(testCacheService.getCallCount()).isEqualTo(1)
+        );
+    }
+
+    @Test
+    void 캐시_갱신_중_오류가_발생하면_기존_캐시값을_반환하고_TTL을_연장하지_않는다() {
+        // given
+        String firstValue = testCacheService.getValue("failed");
+        redisTemplate.expire(cacheKey("failed"), Duration.ofSeconds(1));
+        testCacheService.failWithRuntimeException();
+
+        // when
+        String secondValue = testCacheService.getValue("failed");
+
+        // then
+        Long ttlMillis = redisTemplate.getExpire(cacheKey("failed"), TimeUnit.MILLISECONDS);
+        assertAll(
+                () -> assertThat(secondValue).isEqualTo(firstValue),
+                () -> assertThat(redisTemplate.opsForValue().get(cacheKey("failed"))).isEqualTo(firstValue),
+                () -> assertThat(testCacheService.getCallCount()).isEqualTo(1),
+                () -> assertThat(ttlMillis).isLessThan(TEST_CACHE_TTL_SEC * 1000)
+        );
+    }
+
+    @Test
+    void 캐시_갱신_중_CustomException이_발생하면_기존_캐시값으로_fallback하지_않고_예외를_전파한다() {
+        // given
+        testCacheService.getValue("custom-exception");
+        redisTemplate.expire(cacheKey("custom-exception"), Duration.ofSeconds(1));
+        testCacheService.failWithCustomException();
+
+        // when & then
+        assertAll(
+                () -> assertThatThrownBy(() -> testCacheService.getValue("custom-exception"))
+                        .isInstanceOf(CustomException.class),
+                () -> assertThat(testCacheService.getCallCount()).isEqualTo(1)
+        );
+    }
+
+    @Test
+    void 만료_시간이_없는_캐시는_만료_임박으로_판단하지_않고_기존_캐시값을_반환한다() {
+        // given
+        String firstValue = testCacheService.getValue("no-expire");
+        redisTemplate.persist(cacheKey("no-expire"));
+
+        // when
+        String secondValue = testCacheService.getValue("no-expire");
+
+        // then
+        assertAll(
+                () -> assertThat(secondValue).isEqualTo(firstValue),
+                () -> assertThat(testCacheService.getCallCount()).isEqualTo(1),
+                () -> assertThat(redisTemplate.getExpire(cacheKey("no-expire"))).isEqualTo(-1)
+        );
+    }
+
+    private String cacheKey(String key) {
+        return CACHE_KEY_PREFIX + key;
+    }
+
+    private String refreshLockKey(String key) {
+        return REFRESH_LOCK_PREFIX.getValue() + cacheKey(key);
+    }
+
+    @TestConfiguration
+    static class TestCacheConfig {
+
+        @Bean
+        TestCacheService testCacheService() {
+            return new TestCacheService();
+        }
+    }
+
+    static class TestCacheService {
+
+        private final AtomicInteger callCount = new AtomicInteger();
+        private boolean failWithRuntimeException;
+        private boolean failWithCustomException;
+
+        @ThunderingHerdCaching(
+                key = CACHE_KEY_PREFIX + "{0}",
+                cacheManager = "customCacheManager",
+                ttlSec = TEST_CACHE_TTL_SEC
+        )
+        public String getValue(String key) {
+            if (failWithCustomException) {
+                throw new CustomException(ErrorCode.INVALID_INPUT);
+            }
+            if (failWithRuntimeException) {
+                throw new IllegalStateException("refresh failed");
+            }
+            return "value-" + callCount.incrementAndGet();
+        }
+
+        void reset() {
+            callCount.set(0);
+            failWithRuntimeException = false;
+            failWithCustomException = false;
+        }
+
+        int getCallCount() {
+            return callCount.get();
+        }
+
+        void failWithRuntimeException() {
+            failWithRuntimeException = true;
+        }
+
+        void failWithCustomException() {
+            failWithCustomException = true;
+        }
+    }
+}

--- a/src/test/java/com/example/solidconnection/cache/ThunderingHerdCachingAspectTest.java
+++ b/src/test/java/com/example/solidconnection/cache/ThunderingHerdCachingAspectTest.java
@@ -1,15 +1,21 @@
 package com.example.solidconnection.cache;
 
-import static com.example.solidconnection.redis.RedisConstants.REFRESH_LOCK_PREFIX;
+import static com.example.solidconnection.redis.RedisConstants.CREATE_LOCK_PREFIX;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.example.solidconnection.cache.annotation.ThunderingHerdCaching;
 import com.example.solidconnection.common.exception.CustomException;
 import com.example.solidconnection.common.exception.ErrorCode;
 import com.example.solidconnection.support.TestContainerSpringBootTest;
+import com.example.solidconnection.util.RedisUtils;
 import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,6 +38,9 @@ class ThunderingHerdCachingAspectTest {
 
     @Autowired
     private RedisTemplate<String, Object> redisTemplate;
+
+    @Autowired
+    private RedisUtils redisUtils;
 
     @BeforeEach
     void setUp() {
@@ -61,7 +70,7 @@ class ThunderingHerdCachingAspectTest {
         // given
         String firstValue = testCacheService.getValue("locked");
         redisTemplate.expire(cacheKey("locked"), Duration.ofSeconds(1));
-        redisTemplate.opsForValue().set(refreshLockKey("locked"), "lock", Duration.ofSeconds(5));
+        redisTemplate.opsForValue().set(createLockKey("locked"), "lock", Duration.ofSeconds(5));
 
         // when
         String secondValue = testCacheService.getValue("locked");
@@ -70,7 +79,8 @@ class ThunderingHerdCachingAspectTest {
         assertAll(
                 () -> assertThat(secondValue).isEqualTo(firstValue),
                 () -> assertThat(redisTemplate.opsForValue().get(cacheKey("locked"))).isEqualTo(firstValue),
-                () -> assertThat(testCacheService.getCallCount()).isEqualTo(1)
+                () -> assertThat(testCacheService.getCallCount()).isEqualTo(1),
+                () -> assertThat(testCacheService.getInvocationCount()).isEqualTo(1)
         );
     }
 
@@ -90,6 +100,7 @@ class ThunderingHerdCachingAspectTest {
                 () -> assertThat(secondValue).isEqualTo(firstValue),
                 () -> assertThat(redisTemplate.opsForValue().get(cacheKey("failed"))).isEqualTo(firstValue),
                 () -> assertThat(testCacheService.getCallCount()).isEqualTo(1),
+                () -> assertThat(testCacheService.getInvocationCount()).isEqualTo(2),
                 () -> assertThat(ttlMillis).isLessThan(TEST_CACHE_TTL_SEC * 1000)
         );
     }
@@ -105,7 +116,8 @@ class ThunderingHerdCachingAspectTest {
         assertAll(
                 () -> assertThatThrownBy(() -> testCacheService.getValue("custom-exception"))
                         .isInstanceOf(CustomException.class),
-                () -> assertThat(testCacheService.getCallCount()).isEqualTo(1)
+                () -> assertThat(testCacheService.getCallCount()).isEqualTo(1),
+                () -> assertThat(testCacheService.getInvocationCount()).isEqualTo(2)
         );
     }
 
@@ -122,16 +134,70 @@ class ThunderingHerdCachingAspectTest {
         assertAll(
                 () -> assertThat(secondValue).isEqualTo(firstValue),
                 () -> assertThat(testCacheService.getCallCount()).isEqualTo(1),
+                () -> assertThat(testCacheService.getInvocationCount()).isEqualTo(1),
                 () -> assertThat(redisTemplate.getExpire(cacheKey("no-expire"))).isEqualTo(-1)
         );
+    }
+
+    @Test
+    void 만료_임박_비율이_유효하지_않으면_만료_임박으로_판단하지_않는다() {
+        // given
+        String key = cacheKey("invalid-percent");
+        redisTemplate.opsForValue().set(key, "value", Duration.ofSeconds(1));
+
+        // when & then
+        assertAll(
+                () -> assertThat(redisUtils.isCacheExpiringSoon(key, TEST_CACHE_TTL_SEC, 0.0)).isFalse(),
+                () -> assertThat(redisUtils.isCacheExpiringSoon(key, TEST_CACHE_TTL_SEC, -1.0)).isFalse(),
+                () -> assertThat(redisUtils.isCacheExpiringSoon(key, TEST_CACHE_TTL_SEC, 101.0)).isFalse()
+        );
+    }
+
+    @Test
+    void 캐시_갱신_중_기존_캐시가_만료되어도_생성락으로_중복_계산을_막는다() throws Exception {
+        // given
+        String firstValue = testCacheService.getValue("expired-during-refresh");
+        redisTemplate.expire(cacheKey("expired-during-refresh"), Duration.ofSeconds(1));
+        testCacheService.blockNextInvocation();
+
+        ExecutorService refreshExecutor = Executors.newSingleThreadExecutor();
+        ExecutorService waitingExecutor = Executors.newSingleThreadExecutor();
+
+        try {
+            Future<String> refreshResult = refreshExecutor.submit(() -> testCacheService.getValue("expired-during-refresh"));
+            testCacheService.awaitBlockedInvocation();
+            await().atMost(Duration.ofSeconds(3))
+                    .untilAsserted(() -> assertThat(redisTemplate.hasKey(cacheKey("expired-during-refresh"))).isFalse());
+
+            // when
+            Future<String> waitingResult = waitingExecutor.submit(() -> testCacheService.getValue("expired-during-refresh"));
+            await().during(Duration.ofMillis(200))
+                    .atMost(Duration.ofSeconds(1))
+                    .untilAsserted(() -> assertThat(waitingResult.isDone()).isFalse());
+            testCacheService.releaseBlockedInvocation();
+
+            // then
+            assertAll(
+                    () -> assertThat(firstValue).isEqualTo("value-1"),
+                    () -> assertThat(refreshResult.get(3, TimeUnit.SECONDS)).isEqualTo("value-2"),
+                    () -> assertThat(waitingResult.get(3, TimeUnit.SECONDS)).isEqualTo("value-2"),
+                    () -> assertThat(redisTemplate.opsForValue().get(cacheKey("expired-during-refresh"))).isEqualTo("value-2"),
+                    () -> assertThat(testCacheService.getCallCount()).isEqualTo(2),
+                    () -> assertThat(testCacheService.getInvocationCount()).isEqualTo(2)
+            );
+        } finally {
+            testCacheService.releaseBlockedInvocation();
+            refreshExecutor.shutdownNow();
+            waitingExecutor.shutdownNow();
+        }
     }
 
     private String cacheKey(String key) {
         return CACHE_KEY_PREFIX + key;
     }
 
-    private String refreshLockKey(String key) {
-        return REFRESH_LOCK_PREFIX.getValue() + cacheKey(key);
+    private String createLockKey(String key) {
+        return CREATE_LOCK_PREFIX.getValue() + cacheKey(key);
     }
 
     @TestConfiguration
@@ -146,8 +212,12 @@ class ThunderingHerdCachingAspectTest {
     static class TestCacheService {
 
         private final AtomicInteger callCount = new AtomicInteger();
-        private boolean failWithRuntimeException;
-        private boolean failWithCustomException;
+        private final AtomicInteger invocationCount = new AtomicInteger();
+        private volatile boolean failWithRuntimeException;
+        private volatile boolean failWithCustomException;
+        private volatile boolean blockNextInvocation;
+        private volatile CountDownLatch blockedInvocationStarted;
+        private volatile CountDownLatch blockedInvocationRelease;
 
         @ThunderingHerdCaching(
                 key = CACHE_KEY_PREFIX + "{0}",
@@ -155,6 +225,8 @@ class ThunderingHerdCachingAspectTest {
                 ttlSec = TEST_CACHE_TTL_SEC
         )
         public String getValue(String key) {
+            invocationCount.incrementAndGet();
+            awaitIfBlocked();
             if (failWithCustomException) {
                 throw new CustomException(ErrorCode.INVALID_INPUT);
             }
@@ -166,12 +238,20 @@ class ThunderingHerdCachingAspectTest {
 
         void reset() {
             callCount.set(0);
+            invocationCount.set(0);
             failWithRuntimeException = false;
             failWithCustomException = false;
+            blockNextInvocation = false;
+            blockedInvocationStarted = null;
+            blockedInvocationRelease = null;
         }
 
         int getCallCount() {
             return callCount.get();
+        }
+
+        int getInvocationCount() {
+            return invocationCount.get();
         }
 
         void failWithRuntimeException() {
@@ -180,6 +260,36 @@ class ThunderingHerdCachingAspectTest {
 
         void failWithCustomException() {
             failWithCustomException = true;
+        }
+
+        void blockNextInvocation() {
+            blockedInvocationStarted = new CountDownLatch(1);
+            blockedInvocationRelease = new CountDownLatch(1);
+            blockNextInvocation = true;
+        }
+
+        void awaitBlockedInvocation() throws InterruptedException {
+            assertThat(blockedInvocationStarted.await(3, TimeUnit.SECONDS)).isTrue();
+        }
+
+        void releaseBlockedInvocation() {
+            if (blockedInvocationRelease != null) {
+                blockedInvocationRelease.countDown();
+            }
+        }
+
+        private void awaitIfBlocked() {
+            if (!blockNextInvocation) {
+                return;
+            }
+            blockNextInvocation = false;
+            blockedInvocationStarted.countDown();
+            try {
+                blockedInvocationRelease.await(3, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
         }
     }
 }


### PR DESCRIPTION
## 관련 이슈

- resolves: #801

## 작업 내용

- `ThunderingHerdCaching`의 만료 임박 캐시 갱신 정책을 수정했습니다.
  - 기존에는 갱신락을 획득해도 Redis TTL만 연장하고 기존 캐시값을 그대로 반환했습니다.
  - 변경 후에는 갱신을 맡은 요청이 실제 메서드를 다시 실행해 최신 값을 계산하고 Redis 캐시에 저장합니다.
  - 다른 요청은 기존 캐시값을 반환하거나, refresh 중 캐시가 만료된 경우 생성락 대기 흐름을 통해 갱신된 값을 읽습니다.

- refresh 중 캐시 key가 만료되어도 중복 계산이 발생하지 않도록 보강했습니다.
  - Codex 리뷰 반영: refresh와 create가 같은 생성락을 공유하도록 변경했습니다.
  - refresh 완료 후 `CREATE_CHANNEL`로 publish해, 캐시 miss로 진입해 대기 중인 요청이 갱신된 캐시값을 읽도록 했습니다.

- 갱신 실패 시 fallback 기준을 정리했습니다.
  - 일반 `RuntimeException`이 발생하면 기존 캐시값을 반환하되 TTL은 연장하지 않도록 했습니다.
  - `CustomException`은 기존 캐시값으로 fallback하지 않고 그대로 전파하도록 분리했습니다.

- Redis TTL 경계값 처리를 보강했습니다.
  - `getExpire()` 결과가 `null`, `-1`, `-2`이거나 기본 TTL/percent 값이 비정상인 경우 만료 임박으로 판단하지 않도록 방어 로직을 추가했습니다.
  - CodeRabbit 리뷰 반영: `percent <= 0` 또는 `percent > 100`인 경우도 비정상 값으로 처리합니다.

- `ThunderingHerdCachingAspectTest`를 추가 및 보강했습니다.
  - 만료 임박 캐시 갱신 시 값 재계산
  - 갱신락 획득 실패 시 기존 캐시값 반환
  - 갱신 중 일반 예외 발생 시 기존 캐시값 반환 및 TTL 미연장
  - 갱신 중 `CustomException` 발생 시 예외 전파
  - 만료 시간이 없는 캐시는 만료 임박으로 판단하지 않는 케이스
  - 유효하지 않은 refresh percent는 만료 임박으로 판단하지 않는 케이스
  - refresh 중 기존 캐시가 만료되어도 생성락으로 중복 계산을 막는 케이스
  - CodeRabbit 리뷰 반영: 성공 계산 횟수와 실제 메서드 진입 횟수를 분리해 실패 경로의 refresh 시도를 검증합니다.

## 특이 사항

- `@ThunderingHerdCaching` Annotation의 입력 인터페이스는 변경하지 않았습니다.
- 기존 호출부 변경 없이 Aspect 내부 정책만 수정했습니다.
- 전체 테스트 종료 시 기존 비동기 스케줄러가 Redis 커넥션 종료 중 접근하는 로그가 출력될 수 있으나, 테스트 결과는 성공했습니다.

## 리뷰 요구사항 (선택)

- 만료 임박 캐시에서 한 요청만 최신 값을 재계산하고, 나머지 요청은 기존 캐시값을 반환하거나 생성락 대기 흐름을 타는 정책이 적절한지 확인 부탁드립니다.
- refresh와 create가 생성락을 공유하는 방식이 Thundering Herd 방어 흐름에 적절한지 확인 부탁드립니다.
- `CustomException`을 fallback 대상에서 제외하고 도메인 예외로 전파하는 방식이 기존 예외 처리 흐름과 잘 맞는지 확인 부탁드립니다.
- Redis TTL이 없거나 key가 사라진 경계 상황, 또는 percent 설정값이 비정상인 상황을 만료 임박으로 보지 않는 방어 로직이 충분한지 확인 부탁드립니다.

검증:

- `bash ./gradlew test --tests com.example.solidconnection.cache.ThunderingHerdCachingAspectTest`
- `bash ./gradlew test --tests com.example.solidconnection.cache.ThunderingHerdCachingAspectTest --tests com.example.solidconnection.concurrency.ThunderingHerdTest --tests com.example.solidconnection.university.service.GeneralUnivApplyInfoRecommendServiceTest --tests com.example.solidconnection.university.service.UnivApplyInfoRecommendServiceTest --tests com.example.solidconnection.university.service.UnivApplyInfoQueryServiceTest`
- `bash ./gradlew test`
