### PR TITLE
fix: 학교 이메일 중복 인증을 차단한다

### DIFF
--- a/src/main/java/com/example/solidconnection/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/solidconnection/common/exception/ErrorCode.java
@@ -83,6 +83,7 @@ public enum ErrorCode {
 
     // school email verification
     SCHOOL_EMAIL_ALREADY_VERIFIED(HttpStatus.BAD_REQUEST.value(), "이미 학교 이메일 인증이 완료되었습니다."),
+    SCHOOL_EMAIL_ALREADY_USED(HttpStatus.CONFLICT.value(), "이미 인증에 사용된 학교 이메일입니다."),
     SCHOOL_EMAIL_DOMAIN_NOT_SUPPORTED(HttpStatus.BAD_REQUEST.value(), "지원하지 않는 학교 이메일 도메인입니다."),
     SCHOOL_EMAIL_CONFIRM_REQUEST_NOT_FOUND(HttpStatus.BAD_REQUEST.value(), "학교 이메일 인증 요청을 찾을 수 없습니다. 인증 코드 발송을 다시 요청해주세요."),
     SCHOOL_EMAIL_CONFIRM_CODE_DIFFERENT(HttpStatus.BAD_REQUEST.value(), "인증 코드가 일치하지 않습니다."),

--- a/src/main/java/com/example/solidconnection/community/post/service/UpdateViewCountService.java
+++ b/src/main/java/com/example/solidconnection/community/post/service/UpdateViewCountService.java
@@ -22,6 +22,9 @@ public class UpdateViewCountService {
     public void updateViewCount(String key) {
         Long postId = postRedisManager.getPostIdFromPostViewCountRedisKey(key);
         Long viewCount = postRedisManager.getAndDeleteViewCount(key);
+        if (viewCount == null) {
+            return;
+        }
         postRepository.increaseViewCount(postId, viewCount);
     }
 }

--- a/src/main/java/com/example/solidconnection/siteuser/domain/SiteUser.java
+++ b/src/main/java/com/example/solidconnection/siteuser/domain/SiteUser.java
@@ -30,6 +30,10 @@ import lombok.Setter;
         @UniqueConstraint(
                 name = "uk_site_user_nickname",
                 columnNames = {"nickname"}
+        ),
+        @UniqueConstraint(
+                name = "uk_site_user_verified_school_email",
+                columnNames = {"verified_school_email"}
         )
 })
 public class SiteUser extends BaseEntity {
@@ -53,6 +57,9 @@ public class SiteUser extends BaseEntity {
     @Setter
     @Column(name = "home_university_id", nullable = true)
     private Long homeUniversityId;
+
+    @Column(name = "verified_school_email", nullable = true, length = 100)
+    private String verifiedSchoolEmail;
 
     @Setter
     @Column(name = "profile_image_url", length = 500)
@@ -159,8 +166,9 @@ public class SiteUser extends BaseEntity {
         this.userStatus = status;
     }
 
-    public void verifySchool(Long homeUniversityId) {
+    public void verifySchool(Long homeUniversityId, String verifiedSchoolEmail) {
         this.homeUniversityId = homeUniversityId;
+        this.verifiedSchoolEmail = verifiedSchoolEmail;
     }
 
     public void becomeMentor() {

--- a/src/main/java/com/example/solidconnection/siteuser/dto/SchoolEmailRequest.java
+++ b/src/main/java/com/example/solidconnection/siteuser/dto/SchoolEmailRequest.java
@@ -2,10 +2,12 @@ package com.example.solidconnection.siteuser.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 public record SchoolEmailRequest(
         @NotBlank(message = "학교 이메일은 필수입니다")
         @Email(message = "올바른 이메일 형식이 아닙니다")
+        @Size(max = 100, message = "학교 이메일은 100자 이하여야 합니다")
         String schoolEmail
 ) {
 

--- a/src/main/java/com/example/solidconnection/siteuser/repository/SiteUserRepository.java
+++ b/src/main/java/com/example/solidconnection/siteuser/repository/SiteUserRepository.java
@@ -20,6 +20,8 @@ public interface SiteUserRepository extends JpaRepository<SiteUser, Long>, SiteU
 
     boolean existsByNickname(String nickname);
 
+    boolean existsByVerifiedSchoolEmail(String verifiedSchoolEmail);
+
     @Query("SELECT u FROM SiteUser u WHERE u.quitedAt <= :cutoffDate")
     List<SiteUser> findUsersToBeRemoved(@Param("cutoffDate") LocalDate cutoffDate);
 

--- a/src/main/java/com/example/solidconnection/siteuser/service/SchoolEmailService.java
+++ b/src/main/java/com/example/solidconnection/siteuser/service/SchoolEmailService.java
@@ -1,6 +1,7 @@
 package com.example.solidconnection.siteuser.service;
 
 import static com.example.solidconnection.common.exception.ErrorCode.SCHOOL_EMAIL_ALREADY_VERIFIED;
+import static com.example.solidconnection.common.exception.ErrorCode.SCHOOL_EMAIL_ALREADY_USED;
 import static com.example.solidconnection.common.exception.ErrorCode.SCHOOL_EMAIL_CONFIRM_CODE_DIFFERENT;
 import static com.example.solidconnection.common.exception.ErrorCode.SCHOOL_EMAIL_CONFIRM_REQUEST_NOT_FOUND;
 import static com.example.solidconnection.common.exception.ErrorCode.SCHOOL_EMAIL_DOMAIN_NOT_SUPPORTED;
@@ -17,9 +18,11 @@ import com.example.solidconnection.university.domain.HomeUniversity;
 import com.example.solidconnection.university.repository.HomeUniversityRepository;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Locale;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -46,15 +49,17 @@ public class SchoolEmailService {
             throw new CustomException(SCHOOL_EMAIL_ALREADY_VERIFIED);
         }
 
-        String domain = extractEmailDomain(schoolEmail);
+        String normalizedSchoolEmail = normalizeSchoolEmail(schoolEmail);
+        String domain = extractEmailDomain(normalizedSchoolEmail);
         HomeUniversity homeUniversity = homeUniversityRepository.findByEmailDomain(domain)
                 .orElseThrow(() -> new CustomException(SCHOOL_EMAIL_DOMAIN_NOT_SUPPORTED));
+        validateVerifiedSchoolEmailNotDuplicated(normalizedSchoolEmail);
 
         String code = generateVerificationCode();
-        saveVerificationInfo(siteUserId, new SchoolVerificationInfo(schoolEmail, homeUniversity.getId(), code));
+        saveVerificationInfo(siteUserId, new SchoolVerificationInfo(normalizedSchoolEmail, homeUniversity.getId(), code));
 
         try {
-            mailService.sendVerificationEmail(schoolEmail, code);
+            mailService.sendVerificationEmail(normalizedSchoolEmail, code);
         } catch (Exception e) {
             redisTemplate.delete(KEY_PREFIX + siteUserId);
             throw e;
@@ -72,8 +77,19 @@ public class SchoolEmailService {
             throw new CustomException(SCHOOL_EMAIL_CONFIRM_CODE_DIFFERENT);
         }
 
-        siteUser.verifySchool(info.getHomeUniversityId());
+        String verifiedSchoolEmail = normalizeSchoolEmail(info.getSchoolEmail());
+        validateVerifiedSchoolEmailNotDuplicated(verifiedSchoolEmail);
+        siteUser.verifySchool(info.getHomeUniversityId(), verifiedSchoolEmail);
+        flushVerifiedSchoolEmail();
         redisTemplate.delete(KEY_PREFIX + siteUserId);
+    }
+
+    private void flushVerifiedSchoolEmail() {
+        try {
+            siteUserRepository.flush();
+        } catch (DataIntegrityViolationException e) {
+            throw new CustomException(SCHOOL_EMAIL_ALREADY_USED);
+        }
     }
 
     private void saveVerificationInfo(long siteUserId, SchoolVerificationInfo info) {
@@ -95,15 +111,57 @@ public class SchoolEmailService {
             throw new CustomException(SCHOOL_EMAIL_CONFIRM_REQUEST_NOT_FOUND);
         }
         try {
-            return objectMapper.readValue(jsonInfo, SchoolVerificationInfo.class);
+            SchoolVerificationInfo info = objectMapper.readValue(jsonInfo, SchoolVerificationInfo.class);
+            validateVerificationInfo(siteUserId, info);
+            return info;
         } catch (JsonProcessingException e) {
-            redisTemplate.delete(KEY_PREFIX + siteUserId);
-            throw new CustomException(SCHOOL_EMAIL_VERIFICATION_INFO_CORRUPTED);
+            throw corruptedVerificationInfoException(siteUserId);
         }
     }
 
+    private void validateVerificationInfo(long siteUserId, SchoolVerificationInfo info) {
+        if (info == null
+                || isBlank(info.getSchoolEmail())
+                || !hasEmailDomain(info.getSchoolEmail())
+                || info.getHomeUniversityId() == null
+                || isBlank(info.getCode())
+                || !homeUniversityRepository.existsById(info.getHomeUniversityId())) {
+            throw corruptedVerificationInfoException(siteUserId);
+        }
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+
+    private CustomException corruptedVerificationInfoException(long siteUserId) {
+        redisTemplate.delete(KEY_PREFIX + siteUserId);
+        return new CustomException(SCHOOL_EMAIL_VERIFICATION_INFO_CORRUPTED);
+    }
+
+    private void validateVerifiedSchoolEmailNotDuplicated(String verifiedSchoolEmail) {
+        if (siteUserRepository.existsByVerifiedSchoolEmail(verifiedSchoolEmail)) {
+            throw new CustomException(SCHOOL_EMAIL_ALREADY_USED);
+        }
+    }
+
+    private String normalizeSchoolEmail(String schoolEmail) {
+        return schoolEmail.trim().toLowerCase(Locale.ROOT);
+    }
+
     private String extractEmailDomain(String email) {
-        return email.substring(email.indexOf('@') + 1).toLowerCase();
+        if (!hasEmailDomain(email)) {
+            throw new CustomException(SCHOOL_EMAIL_DOMAIN_NOT_SUPPORTED);
+        }
+        return email.substring(email.indexOf('@') + 1);
+    }
+
+    private boolean hasEmailDomain(String email) {
+        if (email == null) {
+            return false;
+        }
+        int atIndex = email.indexOf('@');
+        return atIndex > 0 && atIndex < email.length() - 1;
     }
 
     private String generateVerificationCode() {

--- a/src/main/resources/db/migration/V57__add_verified_school_email_to_site_user.sql
+++ b/src/main/resources/db/migration/V57__add_verified_school_email_to_site_user.sql
@@ -1,0 +1,3 @@
+ALTER TABLE site_user
+    ADD COLUMN verified_school_email VARCHAR(100) NULL,
+    ADD CONSTRAINT uk_site_user_verified_school_email UNIQUE (verified_school_email);

--- a/src/test/java/com/example/solidconnection/community/post/service/UpdateViewCountServiceTest.java
+++ b/src/test/java/com/example/solidconnection/community/post/service/UpdateViewCountServiceTest.java
@@ -1,0 +1,54 @@
+package com.example.solidconnection.community.post.service;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import com.example.solidconnection.community.post.repository.PostRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@DisplayName("조회수 업데이트 서비스 테스트")
+@ExtendWith(MockitoExtension.class)
+class UpdateViewCountServiceTest {
+
+    @InjectMocks
+    private UpdateViewCountService updateViewCountService;
+
+    @Mock
+    private PostRepository postRepository;
+
+    @Mock
+    private PostRedisManager postRedisManager;
+
+    @Test
+    void Redis_조회수_키가_이미_소비되었으면_DB_업데이트를_하지_않는다() {
+        // given
+        String key = "post:view:1";
+        given(postRedisManager.getPostIdFromPostViewCountRedisKey(key)).willReturn(1L);
+        given(postRedisManager.getAndDeleteViewCount(key)).willReturn(null);
+
+        // when
+        updateViewCountService.updateViewCount(key);
+
+        // then
+        then(postRepository).shouldHaveNoInteractions();
+    }
+
+    @Test
+    void Redis_조회수가_있으면_DB_조회수를_증가시킨다() {
+        // given
+        String key = "post:view:1";
+        given(postRedisManager.getPostIdFromPostViewCountRedisKey(key)).willReturn(1L);
+        given(postRedisManager.getAndDeleteViewCount(key)).willReturn(2L);
+
+        // when
+        updateViewCountService.updateViewCount(key);
+
+        // then
+        then(postRepository).should().increaseViewCount(1L, 2L);
+    }
+}

--- a/src/test/java/com/example/solidconnection/siteuser/dto/SchoolEmailRequestTest.java
+++ b/src/test/java/com/example/solidconnection/siteuser/dto/SchoolEmailRequestTest.java
@@ -1,0 +1,66 @@
+package com.example.solidconnection.siteuser.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("학교 이메일 인증 요청 유효성 검사 테스트")
+class SchoolEmailRequestTest {
+
+    private static final String MESSAGE = "message";
+    private static final String SCHOOL_EMAIL_MAX_LENGTH_MESSAGE = "학교 이메일은 100자 이하여야 합니다";
+
+    private Validator validator;
+
+    @BeforeEach
+    void setUp() {
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    @Nested
+    class 학교_이메일_길이_검증 {
+
+        @Test
+        void 학교_이메일이_100자이면_검증을_통과한다() {
+            // given
+            SchoolEmailRequest request = new SchoolEmailRequest(emailWithLength(100));
+
+            // when
+            Set<ConstraintViolation<SchoolEmailRequest>> violations = validator.validate(request);
+
+            // then
+            assertThat(violations).isEmpty();
+        }
+
+        @Test
+        void 학교_이메일이_100자를_초과하면_검증에_실패한다() {
+            // given
+            SchoolEmailRequest request = new SchoolEmailRequest(emailWithLength(101));
+
+            // when
+            Set<ConstraintViolation<SchoolEmailRequest>> violations = validator.validate(request);
+
+            // then
+            assertThat(violations)
+                    .extracting(MESSAGE)
+                    .contains(SCHOOL_EMAIL_MAX_LENGTH_MESSAGE);
+        }
+    }
+
+    private String emailWithLength(int length) {
+        String prefix = "a@";
+        String domainPrefix = "b".repeat(63) + ".";
+        String suffix = ".edu";
+        String domain = domainPrefix + "c".repeat(length - prefix.length() - domainPrefix.length() - suffix.length());
+        return prefix + domain + suffix;
+    }
+}

--- a/src/test/java/com/example/solidconnection/siteuser/repository/SiteUserRepositoryTest.java
+++ b/src/test/java/com/example/solidconnection/siteuser/repository/SiteUserRepositoryTest.java
@@ -88,4 +88,22 @@ class SiteUserRepositoryTest {
                     .isInstanceOf(DataIntegrityViolationException.class);
         }
     }
+
+    @Nested
+    class 인증된_학교_이메일은_중복될_수_없다 {
+
+        @Test
+        void 인증된_학교_이메일이_동일한_사용자를_저장하면_예외가_발생한다() {
+            // given
+            SiteUser user1 = createSiteUser("email1", "nickname1", AuthType.KAKAO);
+            SiteUser user2 = createSiteUser("email2", "nickname2", AuthType.KAKAO);
+            user1.verifySchool(1L, "test@inha.edu");
+            user2.verifySchool(1L, "test@inha.edu");
+            siteUserRepository.save(user1);
+
+            // when, then
+            assertThatCode(() -> siteUserRepository.saveAndFlush(user2))
+                    .isInstanceOf(DataIntegrityViolationException.class);
+        }
+    }
 }

--- a/src/test/java/com/example/solidconnection/siteuser/service/SchoolEmailServiceTest.java
+++ b/src/test/java/com/example/solidconnection/siteuser/service/SchoolEmailServiceTest.java
@@ -1,14 +1,17 @@
 package com.example.solidconnection.siteuser.service;
 
 import static com.example.solidconnection.common.exception.ErrorCode.SCHOOL_EMAIL_ALREADY_VERIFIED;
+import static com.example.solidconnection.common.exception.ErrorCode.SCHOOL_EMAIL_ALREADY_USED;
 import static com.example.solidconnection.common.exception.ErrorCode.SCHOOL_EMAIL_CONFIRM_CODE_DIFFERENT;
 import static com.example.solidconnection.common.exception.ErrorCode.SCHOOL_EMAIL_CONFIRM_REQUEST_NOT_FOUND;
 import static com.example.solidconnection.common.exception.ErrorCode.SCHOOL_EMAIL_DOMAIN_NOT_SUPPORTED;
+import static com.example.solidconnection.common.exception.ErrorCode.SCHOOL_EMAIL_VERIFICATION_INFO_CORRUPTED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
 
 import com.example.solidconnection.common.exception.CustomException;
 import com.example.solidconnection.common.mail.MailService;
@@ -18,11 +21,13 @@ import com.example.solidconnection.siteuser.repository.SiteUserRepository;
 import com.example.solidconnection.support.TestContainerSpringBootTest;
 import com.example.solidconnection.university.domain.HomeUniversity;
 import com.example.solidconnection.university.fixture.HomeUniversityFixture;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @TestContainerSpringBootTest
@@ -44,6 +49,9 @@ class SchoolEmailServiceTest {
     @Autowired
     private SiteUserRepository siteUserRepository;
 
+    @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+
     @Nested
     @DisplayName("학교 이메일 인증 요청")
     class 학교_이메일_인증_요청 {
@@ -55,7 +63,7 @@ class SchoolEmailServiceTest {
             SiteUser siteUser = siteUserFixture.사용자();
 
             // when & then
-            schoolEmailService.requestSchoolEmailVerification(siteUser.getId(), "test@inha.edu");
+            schoolEmailService.requestSchoolEmailVerification(siteUser.getId(), " Test@INHA.EDU ");
             then(mailService).should().sendVerificationEmail(eq("test@inha.edu"), any());
         }
 
@@ -70,6 +78,25 @@ class SchoolEmailServiceTest {
                     schoolEmailService.requestSchoolEmailVerification(siteUser.getId(), "test@inha.edu"))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(SCHOOL_EMAIL_ALREADY_VERIFIED.getMessage());
+        }
+
+        @Test
+        void 이미_인증에_사용된_학교_이메일이면_예외가_발생한다() {
+            // given
+            homeUniversityFixture.인하대학교();
+            SiteUser verifiedUser = siteUserFixture.사용자(1, "인증사용자");
+            SiteUser anotherUser = siteUserFixture.사용자(2, "다른사용자");
+            schoolEmailService.requestSchoolEmailVerification(verifiedUser.getId(), "test@inha.edu");
+
+            ArgumentCaptor<String> codeCaptor = ArgumentCaptor.forClass(String.class);
+            then(mailService).should().sendVerificationEmail(eq("test@inha.edu"), codeCaptor.capture());
+            schoolEmailService.confirmSchoolEmail(verifiedUser.getId(), codeCaptor.getValue());
+
+            // when & then
+            assertThatThrownBy(() ->
+                    schoolEmailService.requestSchoolEmailVerification(anotherUser.getId(), "test@inha.edu"))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(SCHOOL_EMAIL_ALREADY_USED.getMessage());
         }
 
         @Test
@@ -94,7 +121,7 @@ class SchoolEmailServiceTest {
             // given
             HomeUniversity homeUniversity = homeUniversityFixture.인하대학교();
             SiteUser siteUser = siteUserFixture.사용자();
-            schoolEmailService.requestSchoolEmailVerification(siteUser.getId(), "test@inha.edu");
+            schoolEmailService.requestSchoolEmailVerification(siteUser.getId(), " Test@INHA.EDU ");
 
             ArgumentCaptor<String> codeCaptor = ArgumentCaptor.forClass(String.class);
             then(mailService).should().sendVerificationEmail(any(), codeCaptor.capture());
@@ -106,6 +133,7 @@ class SchoolEmailServiceTest {
             // Then
             SiteUser updated = siteUserRepository.findById(siteUser.getId()).orElseThrow();
             assertThat(updated.getHomeUniversityId()).isEqualTo(homeUniversity.getId());
+            assertThat(updated.getVerifiedSchoolEmail()).isEqualTo("test@inha.edu");
         }
 
         @Test
@@ -132,6 +160,46 @@ class SchoolEmailServiceTest {
                     schoolEmailService.confirmSchoolEmail(siteUser.getId(), "000000"))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(SCHOOL_EMAIL_CONFIRM_CODE_DIFFERENT.getMessage());
+        }
+
+        @Test
+        void 인증_정보가_손상되면_예외가_발생하고_인증_정보가_삭제된다() {
+            // given
+            HomeUniversity homeUniversity = homeUniversityFixture.인하대학교();
+            SiteUser siteUser = siteUserFixture.사용자();
+            String key = "school-email:" + siteUser.getId();
+            redisTemplate.opsForValue().set(
+                    key,
+                    "{\"homeUniversityId\":" + homeUniversity.getId() + ",\"code\":\"123456\"}"
+            );
+
+            // when & then
+            assertThatThrownBy(() ->
+                    schoolEmailService.confirmSchoolEmail(siteUser.getId(), "123456"))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(SCHOOL_EMAIL_VERIFICATION_INFO_CORRUPTED.getMessage());
+            assertThat(redisTemplate.opsForValue().get(key)).isNull();
+        }
+
+        @Test
+        void 같은_학교_이메일로_인증_코드를_받았더라도_먼저_인증한_사용자가_있으면_나중_인증은_예외가_발생한다() {
+            // given
+            homeUniversityFixture.인하대학교();
+            SiteUser firstUser = siteUserFixture.사용자(1, "첫번째사용자");
+            SiteUser secondUser = siteUserFixture.사용자(2, "두번째사용자");
+            schoolEmailService.requestSchoolEmailVerification(firstUser.getId(), "test@inha.edu");
+            schoolEmailService.requestSchoolEmailVerification(secondUser.getId(), "test@inha.edu");
+
+            ArgumentCaptor<String> codeCaptor = ArgumentCaptor.forClass(String.class);
+            then(mailService).should(times(2)).sendVerificationEmail(eq("test@inha.edu"), codeCaptor.capture());
+            List<String> codes = codeCaptor.getAllValues();
+            schoolEmailService.confirmSchoolEmail(firstUser.getId(), codes.get(0));
+
+            // when & then
+            assertThatThrownBy(() ->
+                    schoolEmailService.confirmSchoolEmail(secondUser.getId(), codes.get(1)))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(SCHOOL_EMAIL_ALREADY_USED.getMessage());
         }
     }
 }


### PR DESCRIPTION
## 관련 이슈

- resolves: #807

## 작업 내용

- 학교 이메일 인증 완료 시 인증에 사용한 이메일을 `verified_school_email`로 저장하도록 사용자 도메인과 DB 마이그레이션을 추가했습니다.
- 이미 인증 완료된 학교 이메일은 다른 계정에서 재사용할 수 없도록 요청 단계와 인증 확인 단계에서 중복 검증을 추가했습니다.
- 동시 요청 등 애플리케이션 검증만으로 막기 어려운 케이스를 대비해 `verified_school_email` unique 제약과 저장 직후 flush 기반 예외 변환을 추가했습니다.
- Redis 인증 정보가 손상된 경우 인증을 진행하지 않고 임시 인증 정보를 삭제하도록 검증 로직을 보강했습니다.
- 학교 이메일 정규화, 인증 이메일 저장, 중복 인증 차단, unique 제약 검증 테스트를 추가했습니다.
- 전체 테스트 실행 중 여러 테스트 컨텍스트의 조회수 스케줄러가 같은 Redis 키를 동시에 소비할 수 있는 경합을 확인해, 이미 소비된 조회수 Redis 키는 DB 업데이트를 건너뛰도록 방어 로직과 테스트를 추가했습니다.

## 특이 사항

- `site_user.verified_school_email`은 nullable unique 컬럼입니다. 미인증 사용자는 `NULL` 상태로 유지되고, 인증 완료된 이메일만 중복 차단 대상이 됩니다.
- 학교 이메일은 저장/검증 전에 `trim + lowerCase`로 정규화합니다.
- `bash gradlew test` 전체 테스트 통과를 확인했습니다.

## 리뷰 요구사항 (선택)

- `verified_school_email` unique 제약과 서비스 중복 검증이 함께 필요한 구조인지 확인 부탁드립니다.
- 인증 요청과 인증 확인 양쪽에서 중복 검증하는 흐름, 그리고 DB unique 충돌을 `SCHOOL_EMAIL_ALREADY_USED`로 변환하는 방식이 적절한지 봐주세요.
- 조회수 업데이트 스케줄러가 같은 Redis 키를 중복 처리하는 경우 `null` 카운트를 무시하는 방어 방식이 적절한지 확인 부탁드립니다.
