### PR TITLE
feat: 지원 현황 미리보기 API 추가

### DIFF
--- a/src/main/java/com/example/solidconnection/application/controller/ApplicationController.java
+++ b/src/main/java/com/example/solidconnection/application/controller/ApplicationController.java
@@ -1,5 +1,6 @@
 package com.example.solidconnection.application.controller;
 
+import com.example.solidconnection.application.dto.ApplicationPreviewResponse;
 import com.example.solidconnection.application.dto.ApplicationSubmissionResponse;
 import com.example.solidconnection.application.dto.ApplicationsResponse;
 import com.example.solidconnection.application.dto.ApplyRequest;
@@ -35,6 +36,14 @@ public class ApplicationController {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(applicationSubmissionResponse);
+    }
+
+    @GetMapping("/preview")
+    public ResponseEntity<ApplicationPreviewResponse> getApplicationPreview(
+            @AuthorizedUser long siteUserId
+    ) {
+        ApplicationPreviewResponse result = applicationQueryService.getApplicantUniversityPreviews(siteUserId);
+        return ResponseEntity.ok(result);
     }
 
     // @RequireRoleAccess(roles = {Role.ADMIN}) // todo : 추후 어드민 페이지에서 권한 변경 기능 추가 필요

--- a/src/main/java/com/example/solidconnection/application/dto/ApplicationPreviewResponse.java
+++ b/src/main/java/com/example/solidconnection/application/dto/ApplicationPreviewResponse.java
@@ -1,0 +1,8 @@
+package com.example.solidconnection.application.dto;
+
+import java.util.List;
+
+public record ApplicationPreviewResponse(
+        long totalUniversityCount,
+        List<ApplicationUniversityPreviewResponse> universities) {
+}

--- a/src/main/java/com/example/solidconnection/application/dto/ApplicationUniversityPreviewResponse.java
+++ b/src/main/java/com/example/solidconnection/application/dto/ApplicationUniversityPreviewResponse.java
@@ -1,0 +1,25 @@
+package com.example.solidconnection.application.dto;
+
+import com.example.solidconnection.university.domain.UnivApplyInfo;
+
+public record ApplicationUniversityPreviewResponse(
+        long id,
+        String koreanName,
+        Integer studentCapacity,
+        String region,
+        String country,
+        String logoImageUrl,
+        String backgroundImageUrl) {
+
+    public static ApplicationUniversityPreviewResponse from(UnivApplyInfo univApplyInfo) {
+        return new ApplicationUniversityPreviewResponse(
+                univApplyInfo.getId(),
+                univApplyInfo.getKoreanName(),
+                univApplyInfo.getStudentCapacity(),
+                univApplyInfo.getUniversity().getRegion().getKoreanName(),
+                univApplyInfo.getUniversity().getCountry().getKoreanName(),
+                univApplyInfo.getUniversity().getLogoImageUrl(),
+                univApplyInfo.getUniversity().getBackgroundImageUrl()
+        );
+    }
+}

--- a/src/main/java/com/example/solidconnection/application/repository/ApplicationRepository.java
+++ b/src/main/java/com/example/solidconnection/application/repository/ApplicationRepository.java
@@ -50,11 +50,13 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
                AND application.termId = :termId
                AND application.isDelete = false
                AND uai.termId = :termId
+               AND uai.homeUniversity.id = :homeUniversityId
            ORDER BY uai.koreanName
            """)
     List<ApplicationUniversityPreviewResponse> findApplicantUniversityPreviews(
             @Param("status") VerifyStatus status,
-            @Param("termId") long termId);
+            @Param("termId") long termId,
+            @Param("homeUniversityId") long homeUniversityId);
 
     Optional<Application> findTopBySiteUserIdAndTermIdAndIsDeleteFalseOrderByIdDesc(long siteUserId, long termId);
 

--- a/src/main/java/com/example/solidconnection/application/repository/ApplicationRepository.java
+++ b/src/main/java/com/example/solidconnection/application/repository/ApplicationRepository.java
@@ -3,6 +3,7 @@ package com.example.solidconnection.application.repository;
 import static com.example.solidconnection.common.exception.ErrorCode.APPLICATION_NOT_FOUND;
 
 import com.example.solidconnection.application.domain.Application;
+import com.example.solidconnection.application.dto.ApplicationUniversityPreviewResponse;
 import com.example.solidconnection.common.VerifyStatus;
 import com.example.solidconnection.common.exception.CustomException;
 import java.util.List;
@@ -26,6 +27,32 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
            """)
     List<Application> findAllByUnivApplyInfoIds(
             @Param("univApplyInfoIds") List<Long> univApplyInfoIds,
+            @Param("status") VerifyStatus status,
+            @Param("termId") long termId);
+
+    @Query("""
+           SELECT DISTINCT new com.example.solidconnection.application.dto.ApplicationUniversityPreviewResponse(
+               uai.id,
+               uai.koreanName,
+               uai.studentCapacity,
+               region.koreanName,
+               country.koreanName,
+               university.logoImageUrl,
+               university.backgroundImageUrl
+           )
+           FROM Application application
+           JOIN application.choices choice
+           JOIN UnivApplyInfo uai ON uai.id = choice.univApplyInfoId
+           JOIN uai.university university
+           JOIN university.region region
+           JOIN university.country country
+           WHERE application.verifyStatus = :status
+               AND application.termId = :termId
+               AND application.isDelete = false
+               AND uai.termId = :termId
+           ORDER BY uai.koreanName
+           """)
+    List<ApplicationUniversityPreviewResponse> findApplicantUniversityPreviews(
             @Param("status") VerifyStatus status,
             @Param("termId") long termId);
 

--- a/src/main/java/com/example/solidconnection/application/repository/ApplicationRepository.java
+++ b/src/main/java/com/example/solidconnection/application/repository/ApplicationRepository.java
@@ -31,7 +31,7 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
             @Param("termId") long termId);
 
     @Query("""
-           SELECT DISTINCT new com.example.solidconnection.application.dto.ApplicationUniversityPreviewResponse(
+           SELECT new com.example.solidconnection.application.dto.ApplicationUniversityPreviewResponse(
                uai.id,
                uai.koreanName,
                uai.studentCapacity,
@@ -40,17 +40,21 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
                university.logoImageUrl,
                university.backgroundImageUrl
            )
-           FROM Application application
-           JOIN application.choices choice
-           JOIN UnivApplyInfo uai ON uai.id = choice.univApplyInfoId
+           FROM UnivApplyInfo uai
            JOIN uai.university university
            JOIN university.region region
            JOIN university.country country
-           WHERE application.verifyStatus = :status
-               AND application.termId = :termId
-               AND application.isDelete = false
-               AND uai.termId = :termId
+           WHERE uai.termId = :termId
                AND uai.homeUniversity.id = :homeUniversityId
+               AND EXISTS (
+                   SELECT application.id
+                   FROM Application application
+                   JOIN application.choices choice
+                   WHERE choice.univApplyInfoId = uai.id
+                       AND application.verifyStatus = :status
+                       AND application.termId = :termId
+                       AND application.isDelete = false
+               )
            ORDER BY uai.koreanName
            """)
     List<ApplicationUniversityPreviewResponse> findApplicantUniversityPreviews(

--- a/src/main/java/com/example/solidconnection/application/service/ApplicationQueryService.java
+++ b/src/main/java/com/example/solidconnection/application/service/ApplicationQueryService.java
@@ -7,6 +7,7 @@ import static com.example.solidconnection.common.exception.ErrorCode.USER_NOT_FO
 import com.example.solidconnection.application.domain.Application;
 import com.example.solidconnection.application.domain.ApplicationChoice;
 import com.example.solidconnection.application.dto.ApplicantsResponse;
+import com.example.solidconnection.application.dto.ApplicationPreviewResponse;
 import com.example.solidconnection.application.dto.ApplicationsResponse;
 import com.example.solidconnection.application.repository.ApplicationRepository;
 import com.example.solidconnection.common.VerifyStatus;
@@ -40,6 +41,20 @@ public class ApplicationQueryService {
     private final SiteUserRepository siteUserRepository;
     private final TermRepository termRepository;
     private final HomeUniversityRepository homeUniversityRepository;
+
+    @Transactional(readOnly = true)
+    public ApplicationPreviewResponse getApplicantUniversityPreviews(long siteUserId) {
+        siteUserRepository.findById(siteUserId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        Term term = termRepository.findByIsCurrentTrue()
+                .orElseThrow(() -> new CustomException(CURRENT_TERM_NOT_FOUND));
+
+        return new ApplicationPreviewResponse(
+                univApplyInfoRepository.countByTermId(term.getId()),
+                applicationRepository.findApplicantUniversityPreviews(VerifyStatus.APPROVED, term.getId())
+        );
+    }
 
     @Transactional(readOnly = true)
     public ApplicationsResponse getApplicants(long siteUserId, String regionCode, String keyword) {

--- a/src/main/java/com/example/solidconnection/application/service/ApplicationQueryService.java
+++ b/src/main/java/com/example/solidconnection/application/service/ApplicationQueryService.java
@@ -44,15 +44,22 @@ public class ApplicationQueryService {
 
     @Transactional(readOnly = true)
     public ApplicationPreviewResponse getApplicantUniversityPreviews(long siteUserId) {
-        siteUserRepository.findById(siteUserId)
+        SiteUser siteUser = siteUserRepository.findById(siteUserId)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        if (siteUser.getHomeUniversityId() == null) {
+            return new ApplicationPreviewResponse(0, List.of());
+        }
 
         Term term = termRepository.findByIsCurrentTrue()
                 .orElseThrow(() -> new CustomException(CURRENT_TERM_NOT_FOUND));
 
         return new ApplicationPreviewResponse(
-                univApplyInfoRepository.countByTermId(term.getId()),
-                applicationRepository.findApplicantUniversityPreviews(VerifyStatus.APPROVED, term.getId())
+                univApplyInfoRepository.countByTermIdAndHomeUniversityId(term.getId(), siteUser.getHomeUniversityId()),
+                applicationRepository.findApplicantUniversityPreviews(
+                        VerifyStatus.APPROVED,
+                        term.getId(),
+                        siteUser.getHomeUniversityId())
         );
     }
 

--- a/src/main/java/com/example/solidconnection/application/service/ApplicationQueryService.java
+++ b/src/main/java/com/example/solidconnection/application/service/ApplicationQueryService.java
@@ -2,6 +2,7 @@ package com.example.solidconnection.application.service;
 
 import static com.example.solidconnection.common.exception.ErrorCode.APPLICATION_NOT_APPROVED;
 import static com.example.solidconnection.common.exception.ErrorCode.CURRENT_TERM_NOT_FOUND;
+import static com.example.solidconnection.common.exception.ErrorCode.SCHOOL_EMAIL_NOT_VERIFIED;
 import static com.example.solidconnection.common.exception.ErrorCode.USER_NOT_FOUND;
 
 import com.example.solidconnection.application.domain.Application;
@@ -48,7 +49,7 @@ public class ApplicationQueryService {
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
 
         if (siteUser.getHomeUniversityId() == null) {
-            return new ApplicationPreviewResponse(0, List.of());
+            throw new CustomException(SCHOOL_EMAIL_NOT_VERIFIED);
         }
 
         Term term = termRepository.findByIsCurrentTrue()

--- a/src/main/java/com/example/solidconnection/university/repository/UnivApplyInfoRepository.java
+++ b/src/main/java/com/example/solidconnection/university/repository/UnivApplyInfoRepository.java
@@ -71,6 +71,8 @@ public interface UnivApplyInfoRepository extends JpaRepository<UnivApplyInfo, Lo
 
     boolean existsByHomeUniversityId(Long homeUniversityId);
 
+    long countByTermId(long termId);
+
     @Query("""
            SELECT uai.id
            FROM UnivApplyInfo uai

--- a/src/main/java/com/example/solidconnection/university/repository/UnivApplyInfoRepository.java
+++ b/src/main/java/com/example/solidconnection/university/repository/UnivApplyInfoRepository.java
@@ -71,7 +71,7 @@ public interface UnivApplyInfoRepository extends JpaRepository<UnivApplyInfo, Lo
 
     boolean existsByHomeUniversityId(Long homeUniversityId);
 
-    long countByTermId(long termId);
+    long countByTermIdAndHomeUniversityId(long termId, long homeUniversityId);
 
     @Query("""
            SELECT uai.id

--- a/src/test/java/com/example/solidconnection/application/service/ApplicationQueryServiceTest.java
+++ b/src/test/java/com/example/solidconnection/application/service/ApplicationQueryServiceTest.java
@@ -1,6 +1,8 @@
 package com.example.solidconnection.application.service;
 
+import static com.example.solidconnection.common.exception.ErrorCode.SCHOOL_EMAIL_NOT_VERIFIED;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.example.solidconnection.application.domain.Application;
 import com.example.solidconnection.application.dto.ApplicantResponse;
@@ -11,6 +13,7 @@ import com.example.solidconnection.application.dto.ApplicationsResponse;
 import com.example.solidconnection.application.fixture.ApplicationFixture;
 import com.example.solidconnection.application.repository.ApplicationRepository;
 import com.example.solidconnection.common.VerifyStatus;
+import com.example.solidconnection.common.exception.CustomException;
 import com.example.solidconnection.location.region.fixture.RegionFixture;
 import com.example.solidconnection.score.domain.GpaScore;
 import com.example.solidconnection.score.domain.LanguageTestScore;
@@ -109,6 +112,7 @@ class ApplicationQueryServiceTest {
     }
 
     @Nested
+    @DisplayName("지원 현황 미리보기 조회")
     class 지원_현황_미리보기_조회_테스트 {
 
         @Test
@@ -144,13 +148,39 @@ class ApplicationQueryServiceTest {
             );
             deletedApplication.setIsDeleteTrue();
             applicationRepository.save(deletedApplication);
+            UnivApplyInfo 승인_대기_지원_정보 = univApplyInfoFixtureBuilder.univApplyInfo()
+                    .termId(term.getId())
+                    .koreanName("승인 대기 교환 대학")
+                    .university(서던덴마크대학교_지원_정보.getUniversity())
+                    .homeUniversity(괌대학_A_지원_정보.getHomeUniversity())
+                    .create();
+            Application pendingApplication = applicationFixture.지원서(
+                    user1, "pending-nickname", term.getId(),
+                    gpaScore1.getGpa(), languageTestScore1.getLanguageTest(),
+                    List.of(승인_대기_지원_정보.getId())
+            );
+            pendingApplication.setVerifyStatus(VerifyStatus.PENDING);
+            applicationRepository.save(pendingApplication);
+            UnivApplyInfo 승인_거절_지원_정보 = univApplyInfoFixtureBuilder.univApplyInfo()
+                    .termId(term.getId())
+                    .koreanName("승인 거절 교환 대학")
+                    .university(서던덴마크대학교_지원_정보.getUniversity())
+                    .homeUniversity(괌대학_A_지원_정보.getHomeUniversity())
+                    .create();
+            Application rejectedApplication = applicationFixture.지원서(
+                    user2, "rejected-nickname", term.getId(),
+                    gpaScore2.getGpa(), languageTestScore2.getLanguageTest(),
+                    List.of(승인_거절_지원_정보.getId())
+            );
+            rejectedApplication.setVerifyStatus(VerifyStatus.REJECTED);
+            applicationRepository.save(rejectedApplication);
 
             // when
             ApplicationPreviewResponse response = applicationQueryService.getApplicantUniversityPreviews(
                     inhaUniversityUser.getId());
 
             // then
-            assertThat(response.totalUniversityCount()).isEqualTo(3);
+            assertThat(response.totalUniversityCount()).isEqualTo(5);
             assertThat(response.universities()).containsExactly(
                     ApplicationUniversityPreviewResponse.from(괌대학_A_지원_정보),
                     ApplicationUniversityPreviewResponse.from(버지니아공과대학_지원_정보)
@@ -180,13 +210,12 @@ class ApplicationQueryServiceTest {
         }
 
         @Test
-        void 모교가_등록되지_않은_사용자에게는_빈_미리보기를_반환한다() {
+        void 모교가_등록되지_않은_사용자는_미리보기를_조회할_수_없다() {
             // when
-            ApplicationPreviewResponse response = applicationQueryService.getApplicantUniversityPreviews(user1.getId());
-
             // then
-            assertThat(response.totalUniversityCount()).isZero();
-            assertThat(response.universities()).isEmpty();
+            assertThatThrownBy(() -> applicationQueryService.getApplicantUniversityPreviews(user1.getId()))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(SCHOOL_EMAIL_NOT_VERIFIED.getMessage());
         }
     }
 

--- a/src/test/java/com/example/solidconnection/application/service/ApplicationQueryServiceTest.java
+++ b/src/test/java/com/example/solidconnection/application/service/ApplicationQueryServiceTest.java
@@ -5,6 +5,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.example.solidconnection.application.domain.Application;
 import com.example.solidconnection.application.dto.ApplicantResponse;
 import com.example.solidconnection.application.dto.ApplicantsResponse;
+import com.example.solidconnection.application.dto.ApplicationPreviewResponse;
+import com.example.solidconnection.application.dto.ApplicationUniversityPreviewResponse;
 import com.example.solidconnection.application.dto.ApplicationsResponse;
 import com.example.solidconnection.application.fixture.ApplicationFixture;
 import com.example.solidconnection.application.repository.ApplicationRepository;
@@ -96,6 +98,63 @@ class ApplicationQueryServiceTest {
         괌대학_A_지원_정보 = univApplyInfoFixture.괌대학_A_지원_정보(term.getId());
         버지니아공과대학_지원_정보 = univApplyInfoFixture.버지니아공과대학_지원_정보(term.getId());
         서던덴마크대학교_지원_정보 = univApplyInfoFixture.서던덴마크대학교_지원_정보(term.getId());
+    }
+
+    @Nested
+    class 지원_현황_미리보기_조회_테스트 {
+
+        @Test
+        void 현재_학기에_승인되고_삭제되지_않은_지원서의_대학만_중복_없이_조회한다() {
+            // given
+            applicationFixture.지원서(
+                    user1, "nickname1", term.getId(),
+                    gpaScore1.getGpa(), languageTestScore1.getLanguageTest(),
+                    List.of(괌대학_A_지원_정보.getId(), 버지니아공과대학_지원_정보.getId())
+            );
+            applicationFixture.지원서(
+                    user2, "nickname2", term.getId(),
+                    gpaScore2.getGpa(), languageTestScore2.getLanguageTest(),
+                    List.of(괌대학_A_지원_정보.getId())
+            );
+            Application deletedApplication = applicationFixture.지원서(
+                    user3, "nickname3", term.getId(),
+                    gpaScore3.getGpa(), languageTestScore3.getLanguageTest(),
+                    List.of(서던덴마크대학교_지원_정보.getId())
+            );
+            deletedApplication.setIsDeleteTrue();
+            applicationRepository.save(deletedApplication);
+
+            // when
+            ApplicationPreviewResponse response = applicationQueryService.getApplicantUniversityPreviews(user1.getId());
+
+            // then
+            assertThat(response.totalUniversityCount()).isEqualTo(3);
+            assertThat(response.universities()).containsExactly(
+                    ApplicationUniversityPreviewResponse.from(괌대학_A_지원_정보),
+                    ApplicationUniversityPreviewResponse.from(버지니아공과대학_지원_정보)
+            );
+        }
+
+        @Test
+        void 성적과_지원서를_제출하지_않은_로그인_사용자도_미리보기를_조회할_수_있다() {
+            // given
+            SiteUser signedInUserWithoutScores = siteUserFixture.사용자(4, "signed-in-only");
+            applicationFixture.지원서(
+                    user2, "nickname2", term.getId(),
+                    gpaScore2.getGpa(), languageTestScore2.getLanguageTest(),
+                    List.of(괌대학_A_지원_정보.getId())
+            );
+
+            // when
+            ApplicationPreviewResponse response = applicationQueryService.getApplicantUniversityPreviews(
+                    signedInUserWithoutScores.getId());
+
+            // then
+            assertThat(response.totalUniversityCount()).isEqualTo(3);
+            assertThat(response.universities()).containsExactly(
+                    ApplicationUniversityPreviewResponse.from(괌대학_A_지원_정보)
+            );
+        }
     }
 
     @Nested

--- a/src/test/java/com/example/solidconnection/application/service/ApplicationQueryServiceTest.java
+++ b/src/test/java/com/example/solidconnection/application/service/ApplicationQueryServiceTest.java
@@ -22,7 +22,9 @@ import com.example.solidconnection.support.TestContainerSpringBootTest;
 import com.example.solidconnection.term.domain.Term;
 import com.example.solidconnection.term.fixture.TermFixture;
 import com.example.solidconnection.university.domain.UnivApplyInfo;
+import com.example.solidconnection.university.fixture.HomeUniversityFixture;
 import com.example.solidconnection.university.fixture.UnivApplyInfoFixture;
+import com.example.solidconnection.university.fixture.UnivApplyInfoFixtureBuilder;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -48,6 +50,12 @@ class ApplicationQueryServiceTest {
 
     @Autowired
     private UnivApplyInfoFixture univApplyInfoFixture;
+
+    @Autowired
+    private UnivApplyInfoFixtureBuilder univApplyInfoFixtureBuilder;
+
+    @Autowired
+    private HomeUniversityFixture homeUniversityFixture;
 
     @Autowired
     private GpaScoreFixture gpaScoreFixture;
@@ -104,8 +112,10 @@ class ApplicationQueryServiceTest {
     class 지원_현황_미리보기_조회_테스트 {
 
         @Test
-        void 현재_학기에_승인되고_삭제되지_않은_지원서의_대학만_중복_없이_조회한다() {
+        void 자신의_모교에_속한_지원_대학만_중복_없이_조회한다() {
             // given
+            SiteUser inhaUniversityUser = siteUserFixture.국내_대학_정보_소지_사용자(
+                    괌대학_A_지원_정보.getHomeUniversity().getId());
             applicationFixture.지원서(
                     user1, "nickname1", term.getId(),
                     gpaScore1.getGpa(), languageTestScore1.getLanguageTest(),
@@ -116,6 +126,17 @@ class ApplicationQueryServiceTest {
                     gpaScore2.getGpa(), languageTestScore2.getLanguageTest(),
                     List.of(괌대학_A_지원_정보.getId())
             );
+            UnivApplyInfo 인천대학교_전용_지원_정보 = univApplyInfoFixtureBuilder.univApplyInfo()
+                    .termId(term.getId())
+                    .koreanName("인천대학교 전용 교환 대학")
+                    .university(서던덴마크대학교_지원_정보.getUniversity())
+                    .homeUniversity(homeUniversityFixture.인천대학교())
+                    .create();
+            applicationFixture.지원서(
+                    user3, "nickname3", term.getId(),
+                    gpaScore3.getGpa(), languageTestScore3.getLanguageTest(),
+                    List.of(인천대학교_전용_지원_정보.getId())
+            );
             Application deletedApplication = applicationFixture.지원서(
                     user3, "nickname3", term.getId(),
                     gpaScore3.getGpa(), languageTestScore3.getLanguageTest(),
@@ -125,7 +146,8 @@ class ApplicationQueryServiceTest {
             applicationRepository.save(deletedApplication);
 
             // when
-            ApplicationPreviewResponse response = applicationQueryService.getApplicantUniversityPreviews(user1.getId());
+            ApplicationPreviewResponse response = applicationQueryService.getApplicantUniversityPreviews(
+                    inhaUniversityUser.getId());
 
             // then
             assertThat(response.totalUniversityCount()).isEqualTo(3);
@@ -138,7 +160,8 @@ class ApplicationQueryServiceTest {
         @Test
         void 성적과_지원서를_제출하지_않은_로그인_사용자도_미리보기를_조회할_수_있다() {
             // given
-            SiteUser signedInUserWithoutScores = siteUserFixture.사용자(4, "signed-in-only");
+            SiteUser signedInUserWithoutScores = siteUserFixture.국내_대학_정보_소지_사용자(
+                    괌대학_A_지원_정보.getHomeUniversity().getId());
             applicationFixture.지원서(
                     user2, "nickname2", term.getId(),
                     gpaScore2.getGpa(), languageTestScore2.getLanguageTest(),
@@ -154,6 +177,16 @@ class ApplicationQueryServiceTest {
             assertThat(response.universities()).containsExactly(
                     ApplicationUniversityPreviewResponse.from(괌대학_A_지원_정보)
             );
+        }
+
+        @Test
+        void 모교가_등록되지_않은_사용자에게는_빈_미리보기를_반환한다() {
+            // when
+            ApplicationPreviewResponse response = applicationQueryService.getApplicantUniversityPreviews(user1.getId());
+
+            // then
+            assertThat(response.totalUniversityCount()).isZero();
+            assertThat(response.universities()).isEmpty();
         }
     }
 


### PR DESCRIPTION
## 관련 이슈

- 클라이언트 PR: https://github.com/solid-connection/solid-connect-web/pull/612

## 작업 내용

### 지원 현황 제한 공개 API

인증 사용자가 성적/어학 제출 또는 승인 전에도 자신의 모교 기준 지원 대학을 확인할 수 있도록 GET /applications/preview를 추가했습니다.

- 요청에서 대학 ID를 받지 않습니다.
- 서버가 인증된 사용자의 homeUniversityId를 직접 사용합니다.
- 현재 학기이면서 해당 모교에 연결된 지원 가능 대학 수만 totalUniversityCount로 반환합니다.
- 해당 모교의 승인·미삭제 지원서에 포함된 대학만 중복 없이 반환합니다.
- 모교가 아직 등록되지 않은 사용자는 다른 학교 데이터가 노출되지 않도록 빈 응답을 받습니다.
- 지원자 배열, 지원자 수, 닉네임, 성적은 DTO와 쿼리 projection에서 제외했습니다.
- 기존 GET /applications의 승인 후 전체 조회 정책은 변경하지 않았습니다.

응답 예시는 다음과 같습니다.

~~~json
{
  "totalUniversityCount": 3,
  "universities": [
    {
      "id": 1,
      "koreanName": "괌대학",
      "studentCapacity": 5,
      "region": "미주권",
      "country": "미국",
      "logoImageUrl": "https://...",
      "backgroundImageUrl": "https://..."
    }
  ]
}
~~~

## 특이 사항

클라이언트 호출 분기는 다음과 같습니다.

- 비로그인: 지원 API 호출 없음
- 로그인 + 성적/어학 미제출: GET /applications/preview
- 로그인 + 성적/어학 제출·미승인: GET /applications/preview
- 로그인 + 성적/어학 모두 승인: GET /applications

예를 들어 경희대학교 사용자라면 서버가 토큰의 사용자 정보에서 경희대학교 모교 ID를 확인하고, 경희대학교에 연결된 대학만 반환합니다.

## 리뷰 요구사항 (선택)

- 요청 파라미터 없이 인증 사용자 모교로 범위를 제한하는 방식
- 모교 미등록 사용자에게 명시적 오류를 반환하는 정책
- 전체 대학 수와 지원 대학 목록 모두 같은 모교 범위를 사용하는지
- 응답에서 지원자 관련 데이터가 완전히 배제되었는지

## 검증

- bash gradlew test --tests 'com.example.solidconnection.application.service.ApplicationQueryServiceTest'
- bash gradlew test
- Java 21 환경에서 전체 테스트 통과

