### PR TITLE
feat: 지원 대학 단건 조회 API 추가

### DIFF
--- a/src/main/java/com/example/solidconnection/admin/university/controller/AdminUnivApplyInfoController.java
+++ b/src/main/java/com/example/solidconnection/admin/university/controller/AdminUnivApplyInfoController.java
@@ -38,6 +38,13 @@ public class AdminUnivApplyInfoController {
         return ResponseEntity.ok(adminUnivApplyInfoService.importUnivApplyInfos(request));
     }
 
+    @GetMapping("/{id}")
+    public ResponseEntity<AdminUnivApplyInfoResponse> getUnivApplyInfo(
+            @PathVariable long id
+    ) {
+        return ResponseEntity.ok(adminUnivApplyInfoService.getUnivApplyInfo(id));
+    }
+
     @PostMapping
     public ResponseEntity<AdminUnivApplyInfoResponse> createUnivApplyInfo(
             @Valid @RequestBody AdminUnivApplyInfoCreateRequest request

--- a/src/main/java/com/example/solidconnection/admin/university/service/AdminUnivApplyInfoService.java
+++ b/src/main/java/com/example/solidconnection/admin/university/service/AdminUnivApplyInfoService.java
@@ -141,6 +141,13 @@ public class AdminUnivApplyInfoService {
                 .orElseThrow(() -> new CustomException(UNIVERSITY_NOT_FOUND));
     }
 
+    @Transactional(readOnly = true)
+    public AdminUnivApplyInfoResponse getUnivApplyInfo(long id) {
+        UnivApplyInfo univApplyInfo = univApplyInfoRepository.findById(id)
+                .orElseThrow(() -> new CustomException(UNIV_APPLY_INFO_NOT_FOUND));
+        return AdminUnivApplyInfoResponse.from(univApplyInfo);
+    }
+
     @Transactional
     @DefaultCacheOut(
             key = {"univApplyInfoTextSearch", "university:recommend:general"},

--- a/src/test/java/com/example/solidconnection/admin/university/service/AdminUnivApplyInfoServiceTest.java
+++ b/src/test/java/com/example/solidconnection/admin/university/service/AdminUnivApplyInfoServiceTest.java
@@ -516,6 +516,43 @@ class AdminUnivApplyInfoServiceTest {
     }
 
     @Nested
+    class 지원_정보_단건_조회 {
+
+        @Test
+        void 존재하는_id로_조회하면_상세_정보를_반환한다() {
+            // given
+            UnivApplyInfo univApplyInfo = univApplyInfoFixtureBuilder.univApplyInfo()
+                    .termId(term.getId()).koreanName("괌대학(A형)")
+                    .university(hostUniversity).homeUniversity(homeUniversity).create();
+
+            // when
+            AdminUnivApplyInfoResponse response = adminUnivApplyInfoService.getUnivApplyInfo(univApplyInfo.getId());
+
+            // then
+            assertAll(
+                    () -> assertThat(response.id()).isEqualTo(univApplyInfo.getId()),
+                    () -> assertThat(response.termId()).isEqualTo(term.getId()),
+                    () -> assertThat(response.homeUniversityId()).isEqualTo(homeUniversity.getId()),
+                    () -> assertThat(response.hostUniversityId()).isEqualTo(hostUniversity.getId()),
+                    () -> assertThat(response.studentCapacity()).isEqualTo(univApplyInfo.getStudentCapacity()),
+                    () -> assertThat(response.semesterRequirement()).isEqualTo(univApplyInfo.getSemesterRequirement()),
+                    () -> assertThat(response.detailsForLanguage()).isEqualTo(univApplyInfo.getDetailsForLanguage()),
+                    () -> assertThat(response.gpaRequirement()).isEqualTo(univApplyInfo.getGpaRequirement()),
+                    () -> assertThat(response.gpaRequirementCriteria()).isEqualTo(univApplyInfo.getGpaRequirementCriteria()),
+                    () -> assertThat(response.detailsForAccommodation()).isEqualTo(univApplyInfo.getDetailsForAccommodation())
+            );
+        }
+
+        @Test
+        void 존재하지_않는_id로_조회하면_예외가_발생한다() {
+            // when & then
+            assertThatCode(() -> adminUnivApplyInfoService.getUnivApplyInfo(invalidId))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(ErrorCode.UNIV_APPLY_INFO_NOT_FOUND.getMessage());
+        }
+    }
+
+    @Nested
     class 지원_정보_수정 {
 
         @Test


### PR DESCRIPTION
## 관련 이슈

- resolves: #817 

## 작업 내용

<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

GET /admin/univ-apply-infos/{id}를 추가해 전체 필드를 담은
AdminUnivApplyInfoResponse를 단건으로 조회할 수 있게 구현했습니다

## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
