### PR TITLE
fix: 지원자 목록을 모교 기준으로 조회하도록 수정

### DIFF
--- a/src/main/java/com/example/solidconnection/application/service/ApplicationQueryService.java
+++ b/src/main/java/com/example/solidconnection/application/service/ApplicationQueryService.java
@@ -68,13 +68,19 @@ public class ApplicationQueryService {
     public ApplicationsResponse getApplicants(long siteUserId, String regionCode, String keyword) {
         SiteUser siteUser = siteUserRepository.findById(siteUserId)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        if (siteUser.getHomeUniversityId() == null) {
+            throw new CustomException(SCHOOL_EMAIL_NOT_VERIFIED);
+        }
+
         List<String> keywords = StringUtils.isNotBlank(keyword) ? List.of(keyword) : List.of();
 
         Term term = termRepository.findByIsCurrentTrue()
                 .orElseThrow(() -> new CustomException(CURRENT_TERM_NOT_FOUND));
 
         List<UnivApplyInfo> univApplyInfos = universityFilterRepository
-                .findAllByRegionCodeAndKeywordsAndTermId(regionCode, keywords, term.getId());
+                .findAllByRegionCodeAndKeywordsAndTermIdAndHomeUniversityId(
+                        regionCode, keywords, term.getId(), siteUser.getHomeUniversityId());
         if (univApplyInfos.isEmpty()) {
             return new ApplicationsResponse(List.of());
         }

--- a/src/main/java/com/example/solidconnection/application/service/ApplicationQueryService.java
+++ b/src/main/java/com/example/solidconnection/application/service/ApplicationQueryService.java
@@ -82,7 +82,7 @@ public class ApplicationQueryService {
 
         List<UnivApplyInfo> univApplyInfos = universityFilterRepository
                 .findAllByRegionCodeAndKeywordsAndTermIdAndHomeUniversityId(
-                        regionCode, keywords, term.getId(), siteUser.getHomeUniversityId());
+                        regionCode, keywords, term.getId(), homeUniversityId);
         if (univApplyInfos.isEmpty()) {
             return new ApplicationsResponse(List.of());
         }

--- a/src/main/java/com/example/solidconnection/application/service/ApplicationQueryService.java
+++ b/src/main/java/com/example/solidconnection/application/service/ApplicationQueryService.java
@@ -60,7 +60,8 @@ public class ApplicationQueryService {
                 applicationRepository.findApplicantUniversityPreviews(
                         VerifyStatus.APPROVED,
                         term.getId(),
-                        siteUser.getHomeUniversityId())
+                        siteUser.getHomeUniversityId()
+                )
         );
     }
 
@@ -68,8 +69,9 @@ public class ApplicationQueryService {
     public ApplicationsResponse getApplicants(long siteUserId, String regionCode, String keyword) {
         SiteUser siteUser = siteUserRepository.findById(siteUserId)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+        Long homeUniversityId = siteUser.getHomeUniversityId();
 
-        if (siteUser.getHomeUniversityId() == null) {
+        if (homeUniversityId == null) {
             throw new CustomException(SCHOOL_EMAIL_NOT_VERIFIED);
         }
 

--- a/src/main/java/com/example/solidconnection/university/repository/custom/UnivApplyInfoFilterRepository.java
+++ b/src/main/java/com/example/solidconnection/university/repository/custom/UnivApplyInfoFilterRepository.java
@@ -5,7 +5,11 @@ import java.util.List;
 
 public interface UnivApplyInfoFilterRepository {
 
-    List<UnivApplyInfo> findAllByRegionCodeAndKeywordsAndTermId(String regionCode, List<String> keywords, Long term);
+    List<UnivApplyInfo> findAllByRegionCodeAndKeywordsAndTermIdAndHomeUniversityId(
+            String regionCode,
+            List<String> keywords,
+            Long term,
+            long homeUniversityId);
 
     List<UnivApplyInfo> findAllByText(String text, Long termId, Long homeUniversityId);
 }

--- a/src/main/java/com/example/solidconnection/university/repository/custom/UnivApplyInfoFilterRepositoryImpl.java
+++ b/src/main/java/com/example/solidconnection/university/repository/custom/UnivApplyInfoFilterRepositoryImpl.java
@@ -31,7 +31,12 @@ public class UnivApplyInfoFilterRepositoryImpl implements UnivApplyInfoFilterRep
     }
 
     @Override
-    public List<UnivApplyInfo> findAllByRegionCodeAndKeywordsAndTermId(String regionCode, List<String> keywords, Long termId) {
+    public List<UnivApplyInfo> findAllByRegionCodeAndKeywordsAndTermIdAndHomeUniversityId(
+            String regionCode,
+            List<String> keywords,
+            Long termId,
+            long homeUniversityId
+    ) {
         QUnivApplyInfo univApplyInfo = QUnivApplyInfo.univApplyInfo;
         QHostUniversity university = QHostUniversity.hostUniversity;
         QHomeUniversity homeUniversity = QHomeUniversity.homeUniversity;
@@ -42,12 +47,13 @@ public class UnivApplyInfoFilterRepositoryImpl implements UnivApplyInfoFilterRep
                 .selectFrom(univApplyInfo)
                 .join(univApplyInfo.university, university).fetchJoin()
                 .join(university.country, country).fetchJoin()
-                .leftJoin(univApplyInfo.homeUniversity, homeUniversity).fetchJoin()
+                .join(univApplyInfo.homeUniversity, homeUniversity).fetchJoin()
                 .leftJoin(univApplyInfo.languageRequirements, languageRequirement).fetchJoin()
                 .where(
                         regionCodeEq(country, regionCode)
                                 .and(countryOrUniversityContainsKeyword(country, university, keywords))
                                 .and(univApplyInfo.termId.eq(termId))
+                                .and(homeUniversity.id.eq(homeUniversityId))
                 )
                 .distinct()
                 .fetch();

--- a/src/test/java/com/example/solidconnection/application/service/ApplicationQueryServiceTest.java
+++ b/src/test/java/com/example/solidconnection/application/service/ApplicationQueryServiceTest.java
@@ -24,6 +24,7 @@ import com.example.solidconnection.siteuser.fixture.SiteUserFixture;
 import com.example.solidconnection.support.TestContainerSpringBootTest;
 import com.example.solidconnection.term.domain.Term;
 import com.example.solidconnection.term.fixture.TermFixture;
+import com.example.solidconnection.university.domain.HomeUniversity;
 import com.example.solidconnection.university.domain.UnivApplyInfo;
 import com.example.solidconnection.university.fixture.HomeUniversityFixture;
 import com.example.solidconnection.university.fixture.UnivApplyInfoFixture;
@@ -93,16 +94,17 @@ class ApplicationQueryServiceTest {
     @BeforeEach
     void setUp() {
         term = termFixture.현재_학기("2025-2");
+        HomeUniversity 인하대학교 = homeUniversityFixture.인하대학교();
 
-        user1 = siteUserFixture.사용자(1, "test1");
+        user1 = siteUserFixture.국내_대학_정보_소지_사용자(1, "test1", 인하대학교.getId());
         gpaScore1 = gpaScoreFixture.GPA_점수(VerifyStatus.APPROVED, user1);
         languageTestScore1 = languageTestScoreFixture.어학_점수(VerifyStatus.APPROVED, user1);
 
-        user2 = siteUserFixture.사용자(2, "test2");
+        user2 = siteUserFixture.국내_대학_정보_소지_사용자(2, "test2", 인하대학교.getId());
         gpaScore2 = gpaScoreFixture.GPA_점수(VerifyStatus.APPROVED, user2);
         languageTestScore2 = languageTestScoreFixture.어학_점수(VerifyStatus.APPROVED, user2);
 
-        user3 = siteUserFixture.사용자(3, "test3");
+        user3 = siteUserFixture.국내_대학_정보_소지_사용자(3, "test3", 인하대학교.getId());
         gpaScore3 = gpaScoreFixture.GPA_점수(VerifyStatus.APPROVED, user3);
         languageTestScore3 = languageTestScoreFixture.어학_점수(VerifyStatus.APPROVED, user3);
 
@@ -211,9 +213,13 @@ class ApplicationQueryServiceTest {
 
         @Test
         void 모교가_등록되지_않은_사용자는_미리보기를_조회할_수_없다() {
+            // given
+            SiteUser userWithoutHomeUniversity = siteUserFixture.사용자(4, "test4");
+
             // when
             // then
-            assertThatThrownBy(() -> applicationQueryService.getApplicantUniversityPreviews(user1.getId()))
+            assertThatThrownBy(() -> applicationQueryService.getApplicantUniversityPreviews(
+                    userWithoutHomeUniversity.getId()))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(SCHOOL_EMAIL_NOT_VERIFIED.getMessage());
         }
@@ -361,6 +367,50 @@ class ApplicationQueryServiceTest {
                                .flatMap(univ -> univ.applicants().stream())
                                .filter(ApplicantResponse::isMine))
                     .containsExactly(ApplicantResponse.of(secondApplication, true));
+        }
+
+        @Test
+        void 다른_모교의_지원_대학과_지원자는_조회되지_않는다() {
+            // given
+            UnivApplyInfo 인천대학교_전용_지원_정보 = univApplyInfoFixtureBuilder.univApplyInfo()
+                    .termId(term.getId())
+                    .koreanName("인천대학교 전용 교환 대학")
+                    .university(서던덴마크대학교_지원_정보.getUniversity())
+                    .homeUniversity(homeUniversityFixture.인천대학교())
+                    .create();
+            Application application1 = applicationFixture.지원서(
+                    user1, "nickname1", term.getId(),
+                    gpaScore1.getGpa(), languageTestScore1.getLanguageTest(),
+                    List.of(괌대학_A_지원_정보.getId())
+            );
+            applicationFixture.지원서(
+                    user2, "nickname2", term.getId(),
+                    gpaScore2.getGpa(), languageTestScore2.getLanguageTest(),
+                    List.of(인천대학교_전용_지원_정보.getId())
+            );
+
+            // when
+            ApplicationsResponse response = applicationQueryService.getApplicants(user1.getId(), "", "");
+
+            // then
+            assertThat(response.choices().get(0)).containsExactlyInAnyOrder(
+                    ApplicantsResponse.of(괌대학_A_지원_정보, List.of(application1), user1),
+                    ApplicantsResponse.of(버지니아공과대학_지원_정보, List.of(), user1),
+                    ApplicantsResponse.of(서던덴마크대학교_지원_정보, List.of(), user1)
+            );
+        }
+
+        @Test
+        void 모교가_등록되지_않은_사용자는_지원자_목록을_조회할_수_없다() {
+            // given
+            SiteUser userWithoutHomeUniversity = siteUserFixture.사용자(4, "test4");
+
+            // when
+            // then
+            assertThatThrownBy(() -> applicationQueryService.getApplicants(
+                    userWithoutHomeUniversity.getId(), "", ""))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(SCHOOL_EMAIL_NOT_VERIFIED.getMessage());
         }
     }
 

--- a/src/test/java/com/example/solidconnection/siteuser/fixture/SiteUserFixture.java
+++ b/src/test/java/com/example/solidconnection/siteuser/fixture/SiteUserFixture.java
@@ -74,6 +74,19 @@ public class SiteUserFixture {
                 .create();
     }
 
+    public SiteUser 국내_대학_정보_소지_사용자(int index, String nickname, Long homeUniversityId) {
+        return siteUserFixtureBuilder.siteUser()
+                .email("university" + index + "@example.com")
+                .authType(AuthType.EMAIL)
+                .nickname(nickname)
+                .homeUniversityId(homeUniversityId)
+                .profileImageUrl("profileImageUrl")
+                .role(Role.MENTEE)
+                .password("password123")
+                .userStatus(UserStatus.ACTIVE)
+                .create();
+    }
+
     public SiteUser 멘토(int index, String nickname) {
         return siteUserFixtureBuilder.siteUser()
                 .email("mentor" + index + "@example.com")


### PR DESCRIPTION
## 관련 이슈

- resolves: #

## 작업 내용

지원자 목록 조회(`GET /applications`)에 모교 필터가 없어, 다른 학교의 지원 대학과 지원자까지 함께 조회되던 문제를 수정했습니다.

- `UnivApplyInfoFilterRepository.findAllByRegionCodeAndKeywordsAndTermIdAndHomeUniversityId` — 지원 대학 조회 조건에 모교 아이디를 추가했습니다. 모교는 필수 조건이 되었으므로 `leftJoin`을 `join`으로 변경했습니다.
- `ApplicationQueryService.getApplicants` — 모교가 등록되지 않은 사용자는 지원 현황 미리보기(`/applications/preview`)와 동일하게 `SCHOOL_EMAIL_NOT_VERIFIED` 예외를 반환합니다.

## 특이 사항

한 파견 대학을 여러 모교가 동시에 제공하는 경우(예: A대와 B대가 모두 도쿄대학을 제공), 수정 전에는 A대 사용자에게 B대의 지원 대학과 지원자가 함께 노출되었습니다.

3개 모교에 각각 지원 대학과 지원자를 만들어 로컬에서 수동 검증했습니다.

- 각 모교 사용자에게 자신의 모교 지원 대학만 응답됨 (공유 파견 대학이 있어도 분리됨)
- 지망 배열 길이가 모교별 `max_choice_count`를 따름 (3지망 / 5지망)
- `region` 필터, `APPROVED` 상태 필터, 현재 학기 필터 정상 동작
- 모교 미등록 사용자는 `SCHOOL_EMAIL_NOT_VERIFIED` 반환

## 리뷰 요구사항 (선택)

`leftJoin` → `join` 변경으로 `home_university_id`가 `NULL`인 기존 지원 대학 데이터는 조회 대상에서 제외됩니다. 운영 데이터에 해당 케이스가 있는지 확인이 필요합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
