### PR TITLE
refactor: 검수 결과 표시를 이모지에서 텍스트로 변경

### DIFF
--- a/src/main/java/com/example/solidconnection/common/discord/DiscordReviewMarker.java
+++ b/src/main/java/com/example/solidconnection/common/discord/DiscordReviewMarker.java
@@ -5,8 +5,8 @@ import lombok.Getter;
 @Getter
 public enum DiscordReviewMarker {
 
-    APPROVED("✅"),
-    REJECTED("❌"),
+    APPROVED("(승인되었습니다.)"),
+    REJECTED("(반려되었습니다.)"),
     ;
 
     private final String value;

--- a/src/test/java/com/example/solidconnection/common/discord/DiscordNotifierTest.java
+++ b/src/test/java/com/example/solidconnection/common/discord/DiscordNotifierTest.java
@@ -76,7 +76,7 @@ class DiscordNotifierTest {
             then(discordWebhookSender).should()
                     .editMessage(eq(WEBHOOK_URL), eq(MESSAGE_ID), contentCaptor.capture());
             String content = contentCaptor.getValue();
-            assertThat(content).startsWith("✅ ").contains("홍길동").contains("[개발 서버 알림입니다]");
+            assertThat(content).startsWith("(승인되었습니다.) ").contains("홍길동").contains("[개발 서버 알림입니다]");
         }
 
         @Test
@@ -92,8 +92,8 @@ class DiscordNotifierTest {
             then(discordWebhookSender).should()
                     .editMessage(anyString(), anyString(), contentCaptor.capture());
             String content = contentCaptor.getValue();
-            assertThat(content).startsWith("❌ ");
-            assertThat(content).doesNotContain("✅");
+            assertThat(content).startsWith("(반려되었습니다.) ");
+            assertThat(content).doesNotContain("승인되었습니다");
         }
     }
 


### PR DESCRIPTION
## 관련 이슈

- 관련: #840, #841

## 작업 내용

검수 결과 표시를 이모지에서 문구로 바꿉니다.

봇을 초대하지 않아 반응(reaction)을 쓸 수 없어 알림 본문에 결과를 표시하고 있는데,
이모지보다 문구가 결과를 분명하게 전달합니다.

```
(승인되었습니다.) [개발 서버 알림입니다]
어학 성적 검수 요청이 등록되었습니다.
신청자: hihi
관리자 페이지: https://www.admins.solid-connection.com
```

## 특이 사항

`DiscordReviewMarker` 의 값만 바뀌었고 로직 변경은 없습니다.